### PR TITLE
Implement manual Codex intake issue generator

### DIFF
--- a/.github/workflows/codex-intake-issue.yml
+++ b/.github/workflows/codex-intake-issue.yml
@@ -1,0 +1,111 @@
+name: Create Codex intake issue
+
+on:
+  workflow_dispatch:
+    inputs:
+      category:
+        description: Codex-ready category from the canonical routing contract
+        required: true
+        type: choice
+        options:
+          - runtime-bug
+          - tests-fixtures
+          - verification-audit
+          - data-schema
+          - documentation-consistency
+          - corpus-tooling
+          - ci-repository-tooling
+          - behavior-preserving-refactor
+          - accepted-specification
+          - repository-pr-audit
+      title:
+        description: Concise issue title
+        required: true
+        type: string
+      outcome:
+        description: One bounded observable outcome
+        required: true
+        type: string
+      acceptance_criteria:
+        description: Required checks and observable acceptance criteria, one per line
+        required: true
+        type: string
+      relevant_context:
+        description: Canonical files, accepted specification, and dependencies
+        required: false
+        type: string
+      protected_state:
+        description: Protected state or files, one per line
+        required: false
+        type: string
+      risk:
+        description: Task risk
+        required: true
+        default: medium
+        type: choice
+        options:
+          - low
+          - medium
+          - high
+      execution_mode:
+        description: Whether Codex may implement changes or only report findings
+        required: true
+        default: implementation
+        type: choice
+        options:
+          - implementation
+          - findings-only
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate input and create intake issue
+        uses: actions/github-script@v8
+        env:
+          INPUT_CATEGORY: ${{ inputs.category }}
+          INPUT_TITLE: ${{ inputs.title }}
+          INPUT_OUTCOME: ${{ inputs.outcome }}
+          INPUT_ACCEPTANCE_CRITERIA: ${{ inputs.acceptance_criteria }}
+          INPUT_RELEVANT_CONTEXT: ${{ inputs.relevant_context }}
+          INPUT_PROTECTED_STATE: ${{ inputs.protected_state }}
+          INPUT_RISK: ${{ inputs.risk }}
+          INPUT_EXECUTION_MODE: ${{ inputs.execution_mode }}
+        with:
+          script: |
+            const {
+              buildIntakeIssue,
+              ensureRoutingLabels,
+              findExactDuplicate,
+              inputFromEnvironment,
+            } = require("./tools/coordination/codex-intake");
+
+            const intake = buildIntakeIssue(inputFromEnvironment(process.env));
+            const openIssues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                per_page: 100,
+              },
+            );
+            const duplicate = findExactDuplicate(openIssues, intake);
+            if (duplicate) {
+              throw new Error(`exact open Codex intake already exists: #${duplicate.number}`);
+            }
+
+            await ensureRoutingLabels(github, context.repo, intake.labels);
+            const response = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: intake.title,
+              body: intake.body,
+              labels: intake.labels.map((label) => label.name),
+            });
+            core.notice(`created Codex intake issue #${response.data.number}: ${response.data.html_url}`);

--- a/docs/current/CODEX-ISSUE-WORKFLOW.md
+++ b/docs/current/CODEX-ISSUE-WORKFLOW.md
@@ -1,7 +1,7 @@
 ---
 title: Canto Span — ChatGPT and Codex Task Routing
 status: current
-implementation_status: routing-active; automated-issue-generator-not-implemented
+implementation_status: routing-active; manual-issue-generator-implemented; automatic-dispatch-not-implemented
 tags: [canto-span/infrastructure, canto-span/agents, canto-span/github]
 related: "[[00-START-HERE]] [[MULTI-AGENT-COORDINATION]] [[USER-MERGE-REVIEW]]"
 ---
@@ -11,11 +11,12 @@ related: "[[00-START-HERE]] [[MULTI-AGENT-COORDINATION]] [[USER-MERGE-REVIEW]]"
 This document is the canonical owner of task routing between ChatGPT and Codex for
 Canto Span repository work.
 
-The routing duties in this document are active now. The planned GitHub issue-generator
-and automatic Codex dispatch adapter are not yet implemented. Until they exist,
-ChatGPT creates eligible intake issues directly through available GitHub tools and
-reports them to the user. Creating an issue alone does not prove that Codex has begun
-work; dispatch status must remain explicit and truthful.
+The routing duties in this document are active now. The manual GitHub issue-generator
+is implemented, while automatic Codex dispatch is not. ChatGPT may create eligible
+intake issues directly through available GitHub tools, and a user may invoke the
+manual workflow. Both paths report `manual-pickup-required`. Creating an issue alone
+does not prove that Codex has begun work; dispatch status remains explicit and
+truthful.
 
 This document supplements, but does not replace:
 
@@ -342,7 +343,7 @@ Recommended labels:
 4. ChatGPT creates each eligible Codex intake issue without requiring a reminder.
 5. ChatGPT informs the user of every created issue and truthful dispatch status.
 
-A user may also manually start the future issue-generator workflow, but manual
+A user may also manually start the implemented issue-generator workflow. Manual
 initiation is an additional entry point, not a prerequisite for ChatGPT delegation.
 
 ### 8.2 Pickup and self-screen
@@ -409,19 +410,24 @@ starting Codex unless a controlled end-to-end test has verified that behavior.
 A dispatch failure must leave the intake issue intact and must be reported to the
 user.
 
-## 12. Future issue-generator workflow
+## 12. Manual issue-generator workflow
 
-The later implementation should add:
+The manually triggered
+[`codex-intake-issue.yml`](../../.github/workflows/codex-intake-issue.yml)
+workflow:
 
-1. a manual and ChatGPT-callable GitHub workflow;
-2. a checked-in schema for `canto-span-codex-task-v1`;
-3. an issue generator and validator;
-4. tests for every category and rejection rule;
-5. label validation or setup;
-6. bounded duplicate and overlap checks;
-7. an isolated optional dispatch adapter;
-8. verification of the canonical bootstrap and user-review stop;
-9. an end-to-end low-risk test issue.
+1. accepts structured category, title, outcome, acceptance-criteria, context,
+   protected-state, risk, and execution-mode inputs;
+2. validates them against
+   [`codex-task.schema.json`](../../schemas/codex-task.schema.json) and the
+   prohibited routing classes in this document;
+3. rejects missing required fields, unsupported categories, unsafe direct
+   authorizations, Markdown-fence injection, and an exact duplicate open intake;
+4. creates the canonical issue body with one metadata block and
+   `dispatch_status: manual-pickup-required`;
+5. idempotently creates or reconciles the routing labels;
+6. uses environment variables rather than inserting untrusted input into executable
+   workflow script text.
 
 For issue creation, expected least-privilege permissions are:
 
@@ -429,15 +435,17 @@ For issue creation, expected least-privilege permissions are:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
 ```
 
-The intake workflow should not need `contents: write`, should not create branches,
-and should never merge.
+The implemented workflow does not need pull-request access or `contents: write`. It
+does not dispatch Codex, create branches, create work claims, open pull requests,
+merge, enable auto-merge, or make linguistic, survey, status, release, or governance
+decisions. Exact duplicate detection does not replace Codex self-screening for
+semantic overlap or hidden dependencies.
 
-## 13. Definition of done for the future workflow
+## 13. Definition of done for the manual workflow
 
-The automated workflow is complete only when:
+The manual workflow remains complete only while:
 
 - every allowlisted category produces the documented issue format;
 - prohibited task classes are rejected or routed to ChatGPT;
@@ -448,6 +456,11 @@ The automated workflow is complete only when:
 - no intake issue is mistaken for a semantic work claim;
 - dispatch status is explicit and truthful;
 - failure does not cause partial repository writes;
+- untrusted input remains data rather than executable workflow text;
+- duplicate detection remains bounded to exact open intake matches;
 - Codex pull requests still stop for independent review and explicit user merge
   approval;
 - documentation and implementation describe the same behavior.
+
+An automatic Codex dispatch adapter remains a separate future design and review
+task. It must not be inferred from the presence of this manual generator.

--- a/schemas/codex-task.schema.json
+++ b/schemas/codex-task.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Vazhi/canto-span/schemas/codex-task.schema.json",
+  "title": "Canto Span Codex intake task",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "category",
+    "risk",
+    "execution_mode",
+    "dependencies",
+    "protected_state",
+    "dispatch_status",
+    "chatgpt_routing_complete",
+    "codex_self_screen_required",
+    "work_claim_required",
+    "user_merge_approval_required"
+  ],
+  "properties": {
+    "schema": { "const": "canto-span-codex-task-v1" },
+    "category": {
+      "enum": [
+        "runtime-bug",
+        "tests-fixtures",
+        "verification-audit",
+        "data-schema",
+        "documentation-consistency",
+        "corpus-tooling",
+        "ci-repository-tooling",
+        "behavior-preserving-refactor",
+        "accepted-specification",
+        "repository-pr-audit"
+      ]
+    },
+    "risk": { "enum": ["low", "medium", "high"] },
+    "execution_mode": { "enum": ["implementation", "findings-only"] },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "integer", "minimum": 1 },
+          { "type": "string", "minLength": 1 }
+        ]
+      },
+      "uniqueItems": true
+    },
+    "protected_state": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "dispatch_status": { "const": "manual-pickup-required" },
+    "chatgpt_routing_complete": { "const": true },
+    "codex_self_screen_required": { "const": true },
+    "work_claim_required": { "const": true },
+    "user_merge_approval_required": { "const": true }
+  }
+}

--- a/tests/tooling/coordination/codex-intake.test.js
+++ b/tests/tooling/coordination/codex-intake.test.js
@@ -1,0 +1,220 @@
+"use strict";
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const test = require("node:test");
+const {
+  ALLOWED_CATEGORIES,
+  CANONICAL_BOOTSTRAP,
+  IntakeValidationError,
+  buildIntakeIssue,
+  ensureRoutingLabels,
+  findExactDuplicate,
+  inputFromEnvironment,
+  validateTaskMetadata,
+} = require("../../../tools/coordination/codex-intake");
+
+function validInput(overrides = {}) {
+  return {
+    category: "verification-audit",
+    title: "Codex: verify bounded state",
+    outcome: "One deterministic verifier reports stale state.",
+    acceptanceCriteria: "Add focused tests\nRun the existing coordination verifier",
+    relevantContext: "Use the accepted specification in issue #40.",
+    protectedState: "main\nruntime_behavior",
+    risk: "low",
+    executionMode: "implementation",
+    ...overrides,
+  };
+}
+
+function metadataFromBody(body) {
+  const matches = [...body.matchAll(/```codex-task\n([\s\S]*?)```/g)];
+  assert.equal(matches.length, 1);
+  return JSON.parse(matches[0][1]);
+}
+
+test("builds one canonical validated Codex intake issue", () => {
+  const result = buildIntakeIssue(validInput());
+  assert.equal(result.title, "Codex: verify bounded state");
+  assert.ok(result.body.startsWith(CANONICAL_BOOTSTRAP));
+  assert.match(result.body, /## Outcome/);
+  assert.match(result.body, /- Add focused tests/);
+  assert.deepEqual(metadataFromBody(result.body), result.metadata);
+  assert.deepEqual(validateTaskMetadata(result.metadata), []);
+  assert.deepEqual(result.metadata.protected_state, ["main", "runtime_behavior"]);
+  assert.deepEqual(result.labels.map((label) => label.name), [
+    "codex-ready",
+    "codex:verification-audit",
+    "risk:low",
+  ]);
+});
+
+test("accepts every canonical Codex-ready category", () => {
+  assert.equal(ALLOWED_CATEGORIES.size, 10);
+  for (const category of ALLOWED_CATEGORIES) {
+    const result = buildIntakeIssue(validInput({ category }));
+    assert.equal(result.metadata.category, category);
+    assert.ok(result.labels.some((label) => label.name === `codex:${category}`));
+  }
+});
+
+test("rejects unsupported category, risk, and execution mode values", () => {
+  for (const overrides of [
+    { category: "governance" },
+    { risk: "critical" },
+    { executionMode: "auto-dispatch" },
+  ]) {
+    assert.throws(
+      () => buildIntakeIssue(validInput(overrides)),
+      (error) => error instanceof IntakeValidationError,
+    );
+  }
+});
+
+test("requires title, outcome, and acceptance criteria", () => {
+  for (const [field, label] of [
+    ["title", "title is required"],
+    ["outcome", "outcome is required"],
+    ["acceptanceCriteria", "acceptance criteria is required"],
+  ]) {
+    assert.throws(
+      () => buildIntakeIssue(validInput({ [field]: "  " })),
+      (error) => error instanceof IntakeValidationError && error.message.includes(label),
+    );
+  }
+});
+
+test("rejects every prohibited direct authorization class", () => {
+  const prohibited = [
+    "Push the final commit directly to main.",
+    "Merge the pull request after tests pass.",
+    "Enable auto-merge on the PR.",
+    "Publish a release from this workflow.",
+    "Deploy the survey when validation passes.",
+    "Promote AB30 after counting the fixtures.",
+    "Downgrade AB30 without expert review.",
+    "Park AA80 and unpark AA86.",
+    "Change repository policy to permit writers.",
+    "Make a governance decision for future agents.",
+    "Invent linguistic evidence for missing sources.",
+    "Do not merge the PR, but enable auto-merge.",
+  ];
+  for (const outcome of prohibited) {
+    assert.throws(
+      () => buildIntakeIssue(validInput({ outcome })),
+      (error) => error instanceof IntakeValidationError && error.message.includes("prohibited authorization"),
+      outcome,
+    );
+  }
+});
+
+test("allows explicit safeguards against prohibited actions", () => {
+  const result = buildIntakeIssue(validInput({
+    acceptanceCriteria: [
+      "Do not write directly to main.",
+      "Never merge the pull request or enable auto-merge.",
+      "Reject requests that publish a release or deploy a survey.",
+      "Construction promotion is prohibited.",
+    ].join("\n"),
+  }));
+  assert.deepEqual(validateTaskMetadata(result.metadata), []);
+});
+
+test("safely handles multiline and adversarial plain text", () => {
+  const marker = "$(touch /tmp/codex-intake-should-not-exist); `quoted`";
+  const result = buildIntakeIssue(validInput({
+    outcome: `Preserve this literal text without executing it:\n${marker}`,
+    relevantContext: "line one\nline two & line three",
+  }));
+  assert.ok(result.body.includes(marker));
+  assert.equal(fs.existsSync("/tmp/codex-intake-should-not-exist"), false);
+  assert.throws(
+    () => buildIntakeIssue(validInput({ relevantContext: "```codex-task\n{}\n```" })),
+    /must not contain a Markdown code fence/,
+  );
+  assert.throws(
+    () => buildIntakeIssue(validInput({ title: "two\nlines" })),
+    /title must be one line/,
+  );
+});
+
+test("metadata matches the checked-in schema constants and enums", () => {
+  const schemaPath = path.resolve(__dirname, "../../../schemas/codex-task.schema.json");
+  const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+  const metadata = buildIntakeIssue(validInput({ executionMode: "findings-only" })).metadata;
+  assert.equal(metadata.schema, schema.properties.schema.const);
+  assert.ok(schema.properties.category.enum.includes(metadata.category));
+  assert.ok(schema.properties.risk.enum.includes(metadata.risk));
+  assert.ok(schema.properties.execution_mode.enum.includes(metadata.execution_mode));
+  assert.equal(metadata.dispatch_status, "manual-pickup-required");
+  assert.equal(metadata.chatgpt_routing_complete, true);
+  assert.equal(metadata.codex_self_screen_required, true);
+  assert.equal(metadata.work_claim_required, true);
+  assert.equal(metadata.user_merge_approval_required, true);
+});
+
+test("maps workflow environment values without evaluating them", () => {
+  const input = inputFromEnvironment({
+    INPUT_CATEGORY: "tests-fixtures",
+    INPUT_TITLE: "literal $(command)",
+    INPUT_OUTCOME: "literal ${value}",
+    INPUT_ACCEPTANCE_CRITERIA: "Keep input as data",
+    INPUT_RELEVANT_CONTEXT: "context",
+    INPUT_PROTECTED_STATE: "main",
+    INPUT_RISK: "medium",
+    INPUT_EXECUTION_MODE: "implementation",
+  });
+  assert.equal(input.title, "literal $(command)");
+  assert.equal(input.outcome, "literal ${value}");
+});
+
+test("finds only exact duplicate open intake issues", () => {
+  const intake = buildIntakeIssue(validInput());
+  const duplicate = {
+    number: 50,
+    state: "open",
+    title: intake.title,
+    body: intake.body,
+  };
+  assert.equal(findExactDuplicate([duplicate], intake), duplicate);
+  assert.equal(findExactDuplicate([{ ...duplicate, state: "closed" }], intake), null);
+  assert.equal(findExactDuplicate([{ ...duplicate, body: `${intake.body}\nchanged` }], intake), null);
+  assert.equal(findExactDuplicate([{ ...duplicate, pull_request: {} }], intake), null);
+});
+
+test("idempotently creates and reconciles routing labels", async () => {
+  const labels = new Map();
+  const calls = { create: 0, update: 0 };
+  const github = {
+    rest: {
+      issues: {
+        async getLabel({ name }) {
+          if (!labels.has(name)) {
+            const error = new Error("not found");
+            error.status = 404;
+            throw error;
+          }
+          return { data: labels.get(name) };
+        },
+        async createLabel(label) {
+          calls.create += 1;
+          labels.set(label.name, { ...label });
+        },
+        async updateLabel(label) {
+          calls.update += 1;
+          labels.set(label.new_name, { ...label, name: label.new_name });
+        },
+      },
+    },
+  };
+  const definitions = buildIntakeIssue(validInput()).labels;
+  await ensureRoutingLabels(github, { owner: "Vazhi", repo: "canto-span" }, definitions);
+  await ensureRoutingLabels(github, { owner: "Vazhi", repo: "canto-span" }, definitions);
+  assert.equal(calls.create, definitions.length);
+  assert.equal(calls.update, 0);
+  labels.get("codex-ready").color = "FFFFFF";
+  await ensureRoutingLabels(github, { owner: "Vazhi", repo: "canto-span" }, definitions);
+  assert.equal(calls.update, 1);
+});

--- a/tools/coordination/codex-intake.js
+++ b/tools/coordination/codex-intake.js
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const TASK_SCHEMA_PATH = path.resolve(__dirname, "../../schemas/codex-task.schema.json");
+const TASK_SCHEMA = JSON.parse(fs.readFileSync(TASK_SCHEMA_PATH, "utf8"));
+const TASK_PROPERTIES = TASK_SCHEMA.properties;
+const ALLOWED_CATEGORIES = new Set(TASK_PROPERTIES.category.enum);
+const ALLOWED_RISKS = new Set(TASK_PROPERTIES.risk.enum);
+const ALLOWED_EXECUTION_MODES = new Set(TASK_PROPERTIES.execution_mode.enum);
+
+const CANONICAL_BOOTSTRAP = [
+  "Read `AGENTS.md`, `docs/current/00-START-HERE.md`, and",
+  "`docs/current/CODEX-ISSUE-WORKFLOW.md` in full. Before creating a claim, branch,",
+  "or edit, self-screen this task against the ChatGPT-first and Codex eligibility",
+  "rules. If it is misrouted or requires an unresolved decision, report",
+  "`needs-chatgpt` and stop without changing the repository. Otherwise inspect",
+  "current `main`, open pull requests, intake issues, and work claims; create the",
+  "required semantic work claim and exact branch; complete the bounded outcome;",
+  "run every applicable check; open one coherent pull request; notify the user when",
+  "it is ready; and stop without merging.",
+].join(" ");
+
+const PROHIBITED_DIRECTIVES = [
+  {
+    name: "direct write to main",
+    pattern: /\b(?:write|commit|push|apply|land)\b.{0,50}\b(?:to|into|on)\s+(?:the\s+)?main\b/i,
+  },
+  {
+    name: "merge or auto-merge authorization",
+    pattern: /\b(?:merge(?:\s+the)?\s+(?:pull request|pr|changes?)|enable\s+auto-?merge|auto-?merge)\b/i,
+  },
+  {
+    name: "release publication",
+    pattern: /\b(?:publish|cut|ship)\b.{0,40}\b(?:a\s+|the\s+)?release\b/i,
+  },
+  {
+    name: "survey deployment",
+    pattern: /\b(?:deploy|launch|publish)\b.{0,40}\b(?:survey|instrument)\b/i,
+  },
+  {
+    name: "construction status decision",
+    pattern: /\b(?:promote|downgrade|park|unpark)\b/i,
+  },
+  {
+    name: "governance decision",
+    pattern: /\b(?:(?:decide|change|set|define|rewrite|override)\b.{0,60}\b(?:governance|project policy|repository policy)|(?:make|take)\b.{0,30}\bgovernance decision)\b/i,
+  },
+  {
+    name: "invented linguistic evidence",
+    pattern: /\b(?:invent|fabricate|manufacture|assume)\b.{0,50}\b(?:linguistic\s+)?evidence\b/i,
+  },
+];
+
+const LABEL_STYLES = {
+  "codex-ready": {
+    color: "1D76DB",
+    description: "Bounded task eligible for Codex self-screening",
+  },
+  category: {
+    color: "5319E7",
+    description: "Codex intake task category",
+  },
+  "risk:low": {
+    color: "0E8A16",
+    description: "Low-risk Codex intake",
+  },
+  "risk:medium": {
+    color: "FBCA04",
+    description: "Medium-risk Codex intake",
+  },
+  "risk:high": {
+    color: "D93F0B",
+    description: "High-risk Codex intake",
+  },
+  "findings-only": {
+    color: "C5DEF5",
+    description: "Task produces findings without repairs",
+  },
+};
+
+class IntakeValidationError extends Error {
+  constructor(errors) {
+    super(`invalid Codex intake:\n- ${errors.join("\n- ")}`);
+    this.name = "IntakeValidationError";
+    this.errors = errors;
+  }
+}
+
+function text(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function validateTextField(name, value, options = {}) {
+  const errors = [];
+  const normalized = text(value);
+  if (options.required && !normalized) errors.push(`${name} is required`);
+  if (normalized.length > (options.maxLength || 12000)) {
+    errors.push(`${name} exceeds ${options.maxLength || 12000} characters`);
+  }
+  if (options.singleLine && /[\r\n]/.test(normalized)) {
+    errors.push(`${name} must be one line`);
+  }
+  if (/```/.test(normalized)) {
+    errors.push(`${name} must not contain a Markdown code fence`);
+  }
+  if (/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/.test(normalized)) {
+    errors.push(`${name} contains unsupported control characters`);
+  }
+  return errors;
+}
+
+function directiveIsGuarded(clause, match) {
+  const before = clause.slice(0, match.index).toLowerCase();
+  const after = clause.slice(match.index + match[0].length).toLowerCase();
+  const guardBefore = /\b(?:do not|must not|never|may not|cannot|can't|should not|without|reject(?:s|ed|ing)?|prevent(?:s|ed|ing)?|block(?:s|ed|ing)?|prohibit(?:s|ed|ing)?|forbid(?:s|den|ding)?)\b(?:\W+\w+){0,7}\W*$/i;
+  const guardAfter = /^\W*(?:is|are|must be|remains?)?\W*(?:not allowed|prohibited|forbidden|blocked|protected)\b/i;
+  return guardBefore.test(before) || guardAfter.test(after);
+}
+
+function findProhibitedDirectives(values) {
+  const hits = [];
+  const clauses = values
+    .map(text)
+    .join("\n")
+    .split(/\r?\n|[.;!?]+|,\s*|\b(?:but|however|then)\b/i)
+    .map((clause) => clause.trim())
+    .filter(Boolean);
+  for (const clause of clauses) {
+    for (const rule of PROHIBITED_DIRECTIVES) {
+      const flags = rule.pattern.flags.includes("g") ? rule.pattern.flags : `${rule.pattern.flags}g`;
+      const pattern = new RegExp(rule.pattern.source, flags);
+      let match = pattern.exec(clause);
+      while (match) {
+        if (!directiveIsGuarded(clause, match)) {
+          hits.push(`${rule.name}: ${clause}`);
+        }
+        match = pattern.exec(clause);
+      }
+    }
+  }
+  return hits;
+}
+
+function parseList(value) {
+  const items = text(value)
+    .split(/\r?\n|,/)
+    .map((item) => item.trim().replace(/^[-*]\s+/, ""))
+    .filter(Boolean);
+  return [...new Set(items)];
+}
+
+function normalizeInput(input) {
+  const normalized = {
+    category: text(input.category),
+    title: text(input.title),
+    outcome: text(input.outcome),
+    acceptanceCriteria: text(input.acceptanceCriteria),
+    relevantContext: text(input.relevantContext),
+    protectedStateText: text(input.protectedState),
+    risk: text(input.risk || "medium"),
+    executionMode: text(input.executionMode || "implementation"),
+  };
+  const errors = [
+    ...validateTextField("title", normalized.title, { required: true, singleLine: true, maxLength: 256 }),
+    ...validateTextField("outcome", normalized.outcome, { required: true, maxLength: 8000 }),
+    ...validateTextField("acceptance criteria", normalized.acceptanceCriteria, { required: true, maxLength: 12000 }),
+    ...validateTextField("relevant context", normalized.relevantContext, { maxLength: 12000 }),
+    ...validateTextField("protected state", normalized.protectedStateText, { maxLength: 8000 }),
+  ];
+  if (!ALLOWED_CATEGORIES.has(normalized.category)) {
+    errors.push(`category must be one of: ${[...ALLOWED_CATEGORIES].join(", ")}`);
+  }
+  if (!ALLOWED_RISKS.has(normalized.risk)) {
+    errors.push(`risk must be one of: ${[...ALLOWED_RISKS].join(", ")}`);
+  }
+  if (!ALLOWED_EXECUTION_MODES.has(normalized.executionMode)) {
+    errors.push(`execution mode must be one of: ${[...ALLOWED_EXECUTION_MODES].join(", ")}`);
+  }
+  for (const hit of findProhibitedDirectives([
+    normalized.title,
+    normalized.outcome,
+    normalized.acceptanceCriteria,
+    normalized.relevantContext,
+    normalized.protectedStateText,
+  ])) {
+    errors.push(`prohibited authorization (${hit})`);
+  }
+  if (errors.length) throw new IntakeValidationError(errors);
+  normalized.protectedState = parseList(normalized.protectedStateText);
+  return normalized;
+}
+
+function buildMetadata(input) {
+  return {
+    schema: TASK_PROPERTIES.schema.const,
+    category: input.category,
+    risk: input.risk,
+    execution_mode: input.executionMode,
+    dependencies: [],
+    protected_state: input.protectedState,
+    dispatch_status: TASK_PROPERTIES.dispatch_status.const,
+    chatgpt_routing_complete: true,
+    codex_self_screen_required: true,
+    work_claim_required: true,
+    user_merge_approval_required: true,
+  };
+}
+
+function validateTaskMetadata(metadata) {
+  const errors = [];
+  const expectedKeys = Object.keys(TASK_PROPERTIES).sort();
+  const actualKeys = metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? Object.keys(metadata).sort()
+    : [];
+  if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
+    errors.push("metadata keys do not match the checked-in schema");
+  }
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return errors;
+  for (const [name, property] of Object.entries(TASK_PROPERTIES)) {
+    const value = metadata[name];
+    if (Object.hasOwn(property, "const") && value !== property.const) {
+      errors.push(`${name} must equal ${JSON.stringify(property.const)}`);
+    }
+    if (property.enum && !property.enum.includes(value)) {
+      errors.push(`${name} must be one of: ${property.enum.join(", ")}`);
+    }
+  }
+  for (const name of ["dependencies", "protected_state"]) {
+    const value = metadata[name];
+    if (!Array.isArray(value)) {
+      errors.push(`${name} must be an array`);
+    } else if (new Set(value.map((item) => JSON.stringify(item))).size !== value.length) {
+      errors.push(`${name} must contain unique items`);
+    }
+  }
+  if (Array.isArray(metadata.protected_state)) {
+    if (metadata.protected_state.some((item) => typeof item !== "string" || !item.trim())) {
+      errors.push("protected_state items must be non-empty strings");
+    }
+  }
+  if (Array.isArray(metadata.dependencies)) {
+    if (metadata.dependencies.some((item) => !((Number.isInteger(item) && item >= 1) || (typeof item === "string" && item.trim())))) {
+      errors.push("dependencies items must be positive integers or non-empty strings");
+    }
+  }
+  return errors;
+}
+
+function markdownList(value) {
+  return text(value)
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/^[-*]\s+/, ""))
+    .filter(Boolean)
+    .map((line) => `- ${line}`)
+    .join("\n");
+}
+
+function labelDefinitions(input) {
+  const names = ["codex-ready", `codex:${input.category}`, `risk:${input.risk}`];
+  if (input.executionMode === "findings-only") names.push("findings-only");
+  return names.map((name) => ({
+    name,
+    ...(name.startsWith("codex:") ? LABEL_STYLES.category : LABEL_STYLES[name]),
+  }));
+}
+
+function buildIntakeIssue(rawInput) {
+  const input = normalizeInput(rawInput);
+  const metadata = buildMetadata(input);
+  const metadataErrors = validateTaskMetadata(metadata);
+  if (metadataErrors.length) throw new IntakeValidationError(metadataErrors);
+  const acceptance = markdownList(input.acceptanceCriteria);
+  const context = input.relevantContext || "No additional context provided.";
+  const protectedState = input.protectedState.length
+    ? input.protectedState.map((item) => `- ${item}`).join("\n")
+    : "No additional protected state declared.";
+  const body = [
+    CANONICAL_BOOTSTRAP,
+    "",
+    "## Outcome",
+    "",
+    input.outcome,
+    "",
+    "## Acceptance criteria",
+    "",
+    acceptance,
+    "",
+    "## Relevant context",
+    "",
+    context,
+    "",
+    "## Protected state",
+    "",
+    protectedState,
+    "",
+    "```codex-task",
+    JSON.stringify(metadata, null, 2),
+    "```",
+  ].join("\n");
+  if (body.length > 60000) throw new IntakeValidationError(["generated issue body exceeds 60000 characters"]);
+  return {
+    title: input.title,
+    body,
+    metadata,
+    labels: labelDefinitions(input),
+  };
+}
+
+function inputFromEnvironment(env) {
+  return {
+    category: env.INPUT_CATEGORY,
+    title: env.INPUT_TITLE,
+    outcome: env.INPUT_OUTCOME,
+    acceptanceCriteria: env.INPUT_ACCEPTANCE_CRITERIA,
+    relevantContext: env.INPUT_RELEVANT_CONTEXT,
+    protectedState: env.INPUT_PROTECTED_STATE,
+    risk: env.INPUT_RISK,
+    executionMode: env.INPUT_EXECUTION_MODE,
+  };
+}
+
+function findExactDuplicate(issues, intake) {
+  return (issues || []).find((issue) => (
+    !issue.pull_request
+    && issue.state === "open"
+    && text(issue.title) === intake.title
+    && text(issue.body) === intake.body
+  )) || null;
+}
+
+async function ensureRoutingLabels(github, repository, labels) {
+  const { owner, repo } = repository;
+  for (const label of labels) {
+    try {
+      const response = await github.rest.issues.getLabel({ owner, repo, name: label.name });
+      const current = response.data;
+      if (
+        String(current.color || "").toUpperCase() !== label.color.toUpperCase()
+        || String(current.description || "") !== label.description
+      ) {
+        await github.rest.issues.updateLabel({
+          owner,
+          repo,
+          name: label.name,
+          new_name: label.name,
+          color: label.color,
+          description: label.description,
+        });
+      }
+    } catch (error) {
+      if (error.status !== 404) throw error;
+      await github.rest.issues.createLabel({
+        owner,
+        repo,
+        name: label.name,
+        color: label.color,
+        description: label.description,
+      });
+    }
+  }
+}
+
+module.exports = {
+  ALLOWED_CATEGORIES,
+  CANONICAL_BOOTSTRAP,
+  IntakeValidationError,
+  buildIntakeIssue,
+  ensureRoutingLabels,
+  findExactDuplicate,
+  inputFromEnvironment,
+  validateTaskMetadata,
+};

--- a/tools/verify-coordination-system.js
+++ b/tools/verify-coordination-system.js
@@ -36,16 +36,20 @@ function forbidText(relativePath, forbidden, label) {
 const requiredFiles = [
   ".github/ISSUE_TEMPLATE/work-claim.yml",
   ".github/pull_request_template.md",
+  ".github/workflows/codex-intake-issue.yml",
   ".github/workflows/coordination-check.yml",
   "changes/pending/README.md",
   "config/coordination-targets.json",
   "docs/current/MULTI-AGENT-COORDINATION.md",
   "docs/current/USER-MERGE-REVIEW.md",
   "schemas/change-set.schema.json",
+  "schemas/codex-task.schema.json",
   "schemas/work-claim.schema.json",
+  "tools/coordination/codex-intake.js",
   "tools/coordination/change-set.js",
   "tools/coordination/check-pr.js",
   "tools/coordination/lib.js",
+  "tests/tooling/coordination/codex-intake.test.js",
   "tests/tooling/coordination/coordination.test.js",
 ];
 for (const file of requiredFiles) read(file);
@@ -53,6 +57,7 @@ for (const file of requiredFiles) read(file);
 for (const file of [
   "config/coordination-targets.json",
   "schemas/change-set.schema.json",
+  "schemas/codex-task.schema.json",
   "schemas/work-claim.schema.json",
 ]) {
   try {
@@ -94,6 +99,57 @@ requireText(".github/workflows/coordination-check.yml", "issues: read", "least-p
 requireText(".github/workflows/coordination-check.yml", "pull-requests: read", "least-privilege PR access");
 requireText(".github/workflows/coordination-check.yml", "contents: read", "least-privilege contents access");
 requireText(".github/workflows/coordination-check.yml", "node tools/coordination/check-pr.js", "online coordination check");
+
+requireText(".github/workflows/codex-intake-issue.yml", "workflow_dispatch:", "manual intake trigger");
+requireText(".github/workflows/codex-intake-issue.yml", "contents: read", "intake least-privilege contents access");
+requireText(".github/workflows/codex-intake-issue.yml", "issues: write", "intake issue write access");
+requireText(".github/workflows/codex-intake-issue.yml", "actions/github-script@v8", "Node 24-compatible issue action");
+requireText(".github/workflows/codex-intake-issue.yml", "inputFromEnvironment(process.env)", "untrusted input environment boundary");
+requireText(".github/workflows/codex-intake-issue.yml", "findExactDuplicate", "bounded exact duplicate check");
+requireText(".github/workflows/codex-intake-issue.yml", "ensureRoutingLabels", "idempotent routing labels");
+forbidText(".github/workflows/codex-intake-issue.yml", "contents: write", "intake content write permission");
+forbidText(".github/workflows/codex-intake-issue.yml", "pull-requests: write", "intake PR write permission");
+forbidText(".github/workflows/codex-intake-issue.yml", "run:", "intake shell execution");
+
+requireText("docs/current/CODEX-ISSUE-WORKFLOW.md", "manual-issue-generator-implemented", "manual generator status");
+requireText("docs/current/CODEX-ISSUE-WORKFLOW.md", "manual-pickup-required", "truthful manual dispatch");
+requireText("docs/current/CODEX-ISSUE-WORKFLOW.md", ".github/workflows/codex-intake-issue.yml", "manual generator path");
+requireText("tools/coordination/codex-intake.js", "schemas/codex-task.schema.json", "checked-in intake schema");
+requireText("tools/coordination/codex-intake.js", "CANONICAL_BOOTSTRAP", "canonical intake bootstrap");
+
+try {
+  const codexTaskSchema = JSON.parse(read("schemas/codex-task.schema.json"));
+  const categories = codexTaskSchema?.properties?.category?.enum;
+  if (codexTaskSchema?.properties?.schema?.const !== "canto-span-codex-task-v1") {
+    errors.push({ type: "invalid_schema", file: "schemas/codex-task.schema.json", detail: "wrong task schema identifier" });
+  }
+  if (!Array.isArray(categories) || categories.length !== 10 || new Set(categories).size !== 10) {
+    errors.push({ type: "invalid_schema", file: "schemas/codex-task.schema.json", detail: "expected ten unique Codex-ready categories" });
+  }
+  const workflow = read(".github/workflows/codex-intake-issue.yml");
+  const categoryBlock = workflow.match(/      category:\n[\s\S]*?        options:\n([\s\S]*?)      title:/);
+  const workflowCategories = categoryBlock
+    ? [...categoryBlock[1].matchAll(/^\s*-\s+([a-z][a-z-]+)\s*$/gm)].map((match) => match[1])
+    : [];
+  if (JSON.stringify(workflowCategories) !== JSON.stringify(categories)) {
+    errors.push({ type: "invalid_workflow", file: ".github/workflows/codex-intake-issue.yml", detail: "category choices must exactly match the checked-in task schema" });
+  }
+  if (codexTaskSchema?.properties?.dispatch_status?.const !== "manual-pickup-required") {
+    errors.push({ type: "invalid_schema", file: "schemas/codex-task.schema.json", detail: "dispatch status must remain manual-pickup-required" });
+  }
+  for (const field of [
+    "chatgpt_routing_complete",
+    "codex_self_screen_required",
+    "work_claim_required",
+    "user_merge_approval_required",
+  ]) {
+    if (codexTaskSchema?.properties?.[field]?.const !== true) {
+      errors.push({ type: "invalid_schema", file: "schemas/codex-task.schema.json", detail: `${field} must remain true` });
+    }
+  }
+} catch (error) {
+  errors.push({ type: "invalid_schema", file: "schemas/codex-task.schema.json", detail: error.message });
+}
 
 requireText("AGENTS.md", "work-claim issue", "agent work claim bootstrap");
 requireText("AGENTS.md", "MULTI-AGENT-COORDINATION.md", "agent coordination pointer");


### PR DESCRIPTION
<!-- coordination-claim: #42 -->

Work claim: #42

Closes #42
Closes #40

## Outcome and scope

Implements the accepted repository-native manual Codex intake issue generator. The workflow validates structured inputs, rejects unsafe or ChatGPT-first directives before writing, creates one schema-valid intake issue with truthful manual pickup status, reconciles routing labels idempotently, and does not dispatch Codex automatically.

Changed semantic targets:

- `.github/workflows/codex-intake-issue.yml`: manual workflow only
- `schemas/codex-task.schema.json`: `canto-span-codex-task-v1`
- `tools/coordination/codex-intake.js`: validation, generation, duplicate detection, and label reconciliation
- `tests/tooling/coordination/codex-intake.test.js`: allowlist, rejection, metadata, multiline/adversarial, duplicate, and label coverage
- `tools/verify-coordination-system.js`: existing verifier-family integration
- `docs/current/CODEX-ISSUE-WORKFLOW.md`: implementation status and manual workflow lifecycle only

## Coordination

- Work ID: `CS-WORK-0042`
- Claim mode: `exclusive`
- Integration role: `worker`
- Semantic regions: the six exact targets listed above
- Dependencies: merged PR #38
- Overlapping physical files with disjoint regions: none
- Pending changesets: none
- Successor intake: #44 is explicitly blocked until this work merges and claim #42 closes

## Canonical inputs and generated outputs

- Canonical inputs: issue #40 accepted specification; `docs/current/CODEX-ISSUE-WORKFLOW.md`; `config/coordination-targets.json`; existing coordination verifier and tests
- Generated outputs: none
- Integration-owned files reconciled by the integrator: none

## Explicitly protected or unchanged

Parser runtime, executable grammar behavior, construction identities, ontology, linguistic status, evidence grades, corpus decisions, native-panel and survey state, promotion thresholds, release state, tags, packages, versions, automatic Codex dispatch, secrets, repository settings, `main`, merge behavior, and user-review requirements remain unchanged.

The workflow has only `contents: read` and `issues: write`; it cannot write repository contents, create branches or work claims, open pull requests, merge, enable auto-merge, deploy surveys, publish releases, or make linguistic/status decisions.

## Validation

Validated exact head `becc795bdd69b6aa631f6ae2714fcb9474a61a5d`:

- `node --test tests/tooling/coordination/codex-intake.test.js` — PASS
- `node --check tools/coordination/codex-intake.js` — PASS
- workflow YAML parse through the installed Node `yaml` parser — PASS
- `npm run verify:coordination` — PASS
- `npm run verify` — PASS, 12/12 core commands
- `npm run verify:research` — PASS, 11/11 research commands
- `git diff --cached --check` — PASS

Verifier byproducts under `validation/current/` were restored and are absent from the PR.

## Human merge review

- Review status: `APPROVED_FOR_MERGE`
- User notified that this exact head is ready: `yes — current handoff`
- Explicit approval for this pull request and exact head: `received from the user in this conversation for PR #45 at becc795bdd69b6aa631f6ae2714fcb9474a61a5d`

Do not merge or enable auto-merge until the user explicitly approves this specific pull request at the unchanged head. Any new commit invalidates the approval and requires a new notice.

## Remaining work

No implementation blocker or pending changeset remains. GitHub-hosted checks must confirm the pushed head. After merge, successor issue #44 may re-evaluate its dependency gate.