### PR TITLE
Enforce native-panel follow-up deployment lock

### DIFF
--- a/config/verification-profiles.json
+++ b/config/verification-profiles.json
@@ -20,6 +20,7 @@
     "research": [
       { "id": "research-provenance-tests", "command": ["node", "tools/test-research-provenance.js"] },
       { "id": "research-provenance", "command": ["node", "tools/verify-research-provenance.js"] },
+      { "id": "active-review-workflow-tests", "command": ["node", "--test", "tests/tooling/native-panel/active-review-workflow.test.js"] },
       { "id": "active-review-workflow", "command": ["node", "tools/verify-active-review-workflow.js"] },
       { "id": "active-panel-snapshot-links-tests", "command": ["node", "--test", "tests/tooling/native-panel/active-panel-snapshot-links.test.js"] },
       { "id": "active-panel-snapshot-links", "command": ["node", "tools/verify-active-panel-snapshot-links.js"] },

--- a/review-packets/native-panel/active-v2/README.md
+++ b/review-packets/native-panel/active-v2/README.md
@@ -34,11 +34,19 @@ identity tuple: `construction_uuid`, `construction_code`, `canonical_name`, and
 grammar-note path and runtime `construction` field; new analysis uses the
 permanent code and canonical name.
 
-The lifecycle block in `panel-review-state.json` is checked against
-`followup-draft-v1-metadata.json`. It records `YUE-JUDGMENT-PILOT-01` as
-`collection_in_progress` and `YUE-JUDGMENT-FOLLOWUP-01-DRAFT` as a
-non-deployable `draft_followup`. Reported live responses that have not been
-exported, screened, and adjudicated are not accepted panel evidence.
+The lifecycle block in `panel-review-state.json` is the canonical owner of pilot
+collection (`active` or `closed`) and item-level audit (`not_started`,
+`in_progress`, or `accepted`) state. `followup-draft-v1-metadata.json` owns the
+follow-up identity, lifecycle (`draft`, `locked`, `generated`, or `deployed`),
+and tracked artifacts. Compatibility-status fields preserve existing note links
+but do not control the deployment gate.
+
+The deterministic lock permits `locked`, `generated`, or `deployed` only when
+pilot collection is `closed` and the item-level audit is `accepted`. It also
+rejects generated or deployable artifacts while the follow-up lifecycle remains
+`draft`. The current state is `active` / `not_started` / `draft`, and all tracked
+artifacts are non-deployable draft sources. Reported live responses that have not
+been exported, screened, and adjudicated are not accepted panel evidence.
 
 The AB30 active note links the accepted decision ledger and its mechanical source
 ledger. Its five reviewed candidates (two genuine and three false positives)

--- a/review-packets/native-panel/active-v2/followup-draft-v1-metadata.json
+++ b/review-packets/native-panel/active-v2/followup-draft-v1-metadata.json
@@ -2,11 +2,13 @@
   "schema": "canto-span-native-panel-followup-draft-v1",
   "instrument_id": "YUE-JUDGMENT-FOLLOWUP-01-DRAFT",
   "instrument_status": "draft_followup",
+  "lifecycle_state": "draft",
   "deployment_allowed": false,
   "created_date": "2026-07-24",
   "current_live_instrument": {
     "instrument_id": "YUE-JUDGMENT-PILOT-01",
     "status": "collection_in_progress",
+    "collection_state": "active",
     "canonical_item_scheme": "G01A01–G05D04, F001–F010, C001–C002",
     "closure_rule": "Do not deploy this follow-up until the live instrument closes and its item audit is incorporated."
   },
@@ -66,6 +68,23 @@
   "item_file": "review-packets/native-panel/active-v2/followup-draft-v1-items.tsv",
   "crosswalk_file": "review-packets/native-panel/active-v2/followup-draft-v1-item-crosswalk.tsv",
   "response_template_file": "review-packets/native-panel/active-v2/followup-draft-v1-response-template.tsv",
+  "tracked_artifacts": [
+    {
+      "path": "review-packets/native-panel/active-v2/followup-draft-v1-items.tsv",
+      "artifact_state": "draft_source",
+      "deployable": false
+    },
+    {
+      "path": "review-packets/native-panel/active-v2/followup-draft-v1-item-crosswalk.tsv",
+      "artifact_state": "draft_source",
+      "deployable": false
+    },
+    {
+      "path": "review-packets/native-panel/active-v2/followup-draft-v1-response-template.tsv",
+      "artifact_state": "draft_source",
+      "deployable": false
+    }
+  ],
   "variants": [
     {
       "variant_id": "A",

--- a/review-packets/native-panel/active-v2/panel-review-state.json
+++ b/review-packets/native-panel/active-v2/panel-review-state.json
@@ -1,7 +1,7 @@
 {
   "schema": "canto-span-native-panel-review-state-v2",
   "protocol_version": "panel-v2",
-  "last_updated": "2026-07-24",
+  "last_updated": "2026-07-25",
   "policy_file": "review-packets/native-panel/active-v2/panel-policy.json",
   "supersedes": "review-packets/native-speaker/active-v1/active-review-state.json",
   "respondent_model": {
@@ -91,14 +91,22 @@
   ],
   "instrument_lifecycle": {
     "metadata_file": "review-packets/native-panel/active-v2/followup-draft-v1-metadata.json",
-    "current_live_instrument": {
-      "instrument_id": "YUE-JUDGMENT-PILOT-01",
-      "status": "collection_in_progress",
-      "closure_rule": "Do not deploy this follow-up until the live instrument closes and its item audit is incorporated."
+    "pilot_collections": [
+      {
+        "instrument_id": "YUE-JUDGMENT-PILOT-01",
+        "collection_state": "active",
+        "compatibility_status": "collection_in_progress",
+        "closure_rule": "Do not deploy this follow-up until the live instrument closes and its item audit is incorporated."
+      }
+    ],
+    "item_level_audit": {
+      "pilot_instrument_id": "YUE-JUDGMENT-PILOT-01",
+      "state": "not_started"
     },
     "followup_instrument": {
       "instrument_id": "YUE-JUDGMENT-FOLLOWUP-01-DRAFT",
-      "status": "draft_followup",
+      "lifecycle_state": "draft",
+      "compatibility_status": "draft_followup",
       "deployment_allowed": false
     }
   }

--- a/tests/tooling/native-panel/active-review-workflow.test.js
+++ b/tests/tooling/native-panel/active-review-workflow.test.js
@@ -90,10 +90,20 @@ function lifecycleFixtures() {
   const metadata = {
     instrument_id: "YUE-JUDGMENT-FOLLOWUP-01-DRAFT",
     instrument_status: "draft_followup",
+    lifecycle_state: "draft",
     deployment_allowed: false,
+    item_file: "items.tsv",
+    crosswalk_file: "crosswalk.tsv",
+    response_template_file: "responses.tsv",
+    tracked_artifacts: [
+      { path: "items.tsv", artifact_state: "draft_source", deployable: false },
+      { path: "crosswalk.tsv", artifact_state: "draft_source", deployable: false },
+      { path: "responses.tsv", artifact_state: "draft_source", deployable: false },
+    ],
     current_live_instrument: {
       instrument_id: "YUE-JUDGMENT-PILOT-01",
       status: "collection_in_progress",
+      collection_state: "active",
       closure_rule: "Do not deploy this follow-up until the live instrument closes and its item audit is incorporated.",
     },
   };
@@ -106,10 +116,20 @@ function lifecycleFixtures() {
     ],
     instrument_lifecycle: {
       metadata_file: FOLLOWUP_METADATA,
-      current_live_instrument: { ...metadata.current_live_instrument },
+      pilot_collections: [{
+        instrument_id: metadata.current_live_instrument.instrument_id,
+        collection_state: metadata.current_live_instrument.collection_state,
+        compatibility_status: metadata.current_live_instrument.status,
+        closure_rule: metadata.current_live_instrument.closure_rule,
+      }],
+      item_level_audit: {
+        pilot_instrument_id: metadata.current_live_instrument.instrument_id,
+        state: "not_started",
+      },
       followup_instrument: {
         instrument_id: metadata.instrument_id,
-        status: metadata.instrument_status,
+        lifecycle_state: metadata.lifecycle_state,
+        compatibility_status: metadata.instrument_status,
         deployment_allowed: metadata.deployment_allowed,
       },
     },
@@ -117,20 +137,110 @@ function lifecycleFixtures() {
   return { metadata, state };
 }
 
-test("lifecycle validation rejects stale current-instrument and follow-up state", () => {
+function setLifecycle(fixture, pilotState, auditState, followupState) {
+  const pilotStatuses = { active: "collection_in_progress", closed: "collection_closed" };
+  const followupStatuses = {
+    draft: "draft_followup",
+    locked: "instrument_locked",
+    generated: "form_generated",
+    deployed: "deployed",
+  };
+  const { metadata, state } = fixture;
+  metadata.current_live_instrument.collection_state = pilotState;
+  metadata.current_live_instrument.status = pilotStatuses[pilotState];
+  metadata.lifecycle_state = followupState;
+  metadata.instrument_status = followupStatuses[followupState];
+  metadata.deployment_allowed = followupState === "deployed";
+  metadata.tracked_artifacts = metadata.tracked_artifacts.map((artifact) => ({
+    ...artifact,
+    artifact_state: "draft_source",
+    deployable: false,
+  }));
+  if (["generated", "deployed"].includes(followupState)) {
+    metadata.tracked_artifacts[0].artifact_state = followupState;
+    metadata.tracked_artifacts[0].deployable = true;
+  }
+  state.instrument_lifecycle.pilot_collections[0].collection_state = pilotState;
+  state.instrument_lifecycle.pilot_collections[0].compatibility_status = pilotStatuses[pilotState];
+  state.instrument_lifecycle.item_level_audit.state = auditState;
+  state.instrument_lifecycle.followup_instrument.lifecycle_state = followupState;
+  state.instrument_lifecycle.followup_instrument.compatibility_status = followupStatuses[followupState];
+  state.instrument_lifecycle.followup_instrument.deployment_allowed = metadata.deployment_allowed;
+}
+
+test("deployment lock covers every pilot, audit, and follow-up state combination", () => {
+  for (const pilotState of ["active", "closed"]) {
+    for (const auditState of ["not_started", "in_progress", "accepted"]) {
+      for (const followupState of ["draft", "locked", "generated", "deployed"]) {
+        const fixture = lifecycleFixtures();
+        setLifecycle(fixture, pilotState, auditState, followupState);
+        const failures = lifecycleFailures(fixture.state, fixture.metadata);
+        const allowed = followupState === "draft" ||
+          (pilotState === "closed" && auditState === "accepted");
+        assert.equal(
+          failures.length === 0,
+          allowed,
+          `${pilotState}/${auditState}/${followupState}: ${JSON.stringify(failures)}`
+        );
+      }
+    }
+  }
+});
+
+test("current active-pilot, pending-audit, draft-follow-up state passes", () => {
   const { metadata, state } = lifecycleFixtures();
   assert.deepEqual(lifecycleFailures(state, metadata), []);
+});
+
+test("missing, duplicate, and contradictory lifecycle declarations fail precisely", () => {
+  for (const field of ["pilot_collections", "item_level_audit", "followup_instrument"]) {
+    const { metadata, state } = lifecycleFixtures();
+    delete state.instrument_lifecycle[field];
+    assert.notDeepEqual(lifecycleFailures(state, metadata), [], `${field} should be required`);
+  }
+  const duplicate = lifecycleFixtures();
+  duplicate.state.instrument_lifecycle.pilot_collections.push(
+    clone(duplicate.state.instrument_lifecycle.pilot_collections[0])
+  );
+  assert.ok(lifecycleFailures(duplicate.state, duplicate.metadata).some(
+    (failure) => failure.invariant === "exactly_one_pilot_declaration"
+  ));
+
+  const contradictory = lifecycleFixtures();
+  contradictory.metadata.tracked_artifacts[0].artifact_state = "generated";
+  contradictory.metadata.tracked_artifacts[0].deployable = true;
+  assert.ok(lifecycleFailures(contradictory.state, contradictory.metadata).some(
+    (failure) => failure.invariant === "draft_has_no_generated_or_deployable_artifact" &&
+      failure.pilot_state === "active" &&
+      failure.audit_state === "not_started" &&
+      failure.followup_state === "draft" &&
+      failure.artifact.path === "items.tsv"
+  ));
+});
+
+test("duplicate artifact declarations and unrelated prose are handled safely", () => {
+  const duplicate = lifecycleFixtures();
+  duplicate.metadata.tracked_artifacts.push(clone(duplicate.metadata.tracked_artifacts[0]));
+  assert.ok(lifecycleFailures(duplicate.state, duplicate.metadata).some(
+    (failure) => failure.invariant === "unique_tracked_artifact_declaration"
+  ));
+
+  const unrelated = lifecycleFixtures();
+  unrelated.state.expert_prose = "Response quality and survey readiness remain human decisions.";
+  unrelated.metadata.notes = "This prose is not a lifecycle declaration.";
+  assert.deepEqual(lifecycleFailures(unrelated.state, unrelated.metadata), []);
+});
+
+test("legacy lifecycle mirrors and stale survey controls cannot contradict canonical state", () => {
   for (const mutate of [
-    (value) => { value.instrument_lifecycle.current_live_instrument.instrument_id = "OLD-PILOT"; },
-    (value) => { value.instrument_lifecycle.current_live_instrument.status = "closed"; },
-    (value) => { value.instrument_lifecycle.followup_instrument.status = "pilot_ready"; },
-    (value) => { value.instrument_lifecycle.followup_instrument.deployment_allowed = true; },
-    (value) => { value.constructions[0].next_action = "await_user_prompt_then_create"; },
-    (value) => { value.survey_creation_control = { user_prompt_required: true }; },
+    (value) => { value.metadata.current_live_instrument.instrument_id = "OLD-PILOT"; },
+    (value) => { value.state.instrument_lifecycle.followup_instrument.compatibility_status = "pilot_ready"; },
+    (value) => { value.state.constructions[0].next_action = "await_user_prompt_then_create"; },
+    (value) => { value.state.survey_creation_control = { user_prompt_required: true }; },
   ]) {
-    const changed = clone(state);
+    const changed = lifecycleFixtures();
     mutate(changed);
-    assert.notDeepEqual(lifecycleFailures(changed, metadata), []);
+    assert.notDeepEqual(lifecycleFailures(changed.state, changed.metadata), []);
   }
 });
 

--- a/tools/verify-active-review-workflow.js
+++ b/tools/verify-active-review-workflow.js
@@ -13,6 +13,21 @@ const FOLLOWUP_METADATA = "review-packets/native-panel/active-v2/followup-draft-
 const AB30_DECISIONS = "review-packets/corpus-review/AB30/review-decisions-r1.json";
 const AB30_LEDGER = "review-packets/corpus-review/AB30/candidate-ledger.json";
 const CURRENT_NEXT_ACTION = "await_live_pilot_closure_and_item_audit_before_followup_revision";
+const PILOT_COLLECTION_STATES = new Set(["active", "closed"]);
+const ITEM_AUDIT_STATES = new Set(["not_started", "in_progress", "accepted"]);
+const FOLLOWUP_LIFECYCLE_STATES = new Set(["draft", "locked", "generated", "deployed"]);
+const RESTRICTED_FOLLOWUP_STATES = new Set(["locked", "generated", "deployed"]);
+const ARTIFACT_STATES = new Set(["draft_source", "generated", "deployed"]);
+const PILOT_COMPATIBILITY_STATUS = {
+  active: "collection_in_progress",
+  closed: "collection_closed",
+};
+const FOLLOWUP_COMPATIBILITY_STATUS = {
+  draft: "draft_followup",
+  locked: "instrument_locked",
+  generated: "form_generated",
+  deployed: "deployed",
+};
 
 function readJson(root, relativePath) {
   return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8"));
@@ -81,35 +96,151 @@ function permanentIdentityFailures(entry, identity, adjudication) {
 function lifecycleFailures(state, metadata) {
   const failures = [];
   const lifecycle = state.instrument_lifecycle;
+  const canonicalFiles = {
+    pilot_and_audit: PANEL_STATE,
+    followup_and_artifacts: FOLLOWUP_METADATA,
+  };
+  function fail(invariant, detail, values = {}, artifact = null) {
+    failures.push({
+      invariant,
+      pilot_state: values.pilot_state ?? null,
+      audit_state: values.audit_state ?? null,
+      followup_state: values.followup_state ?? null,
+      ...(artifact ? { artifact } : {}),
+      canonical_files: canonicalFiles,
+      detail,
+    });
+  }
   if (Object.prototype.hasOwnProperty.call(state, "survey_creation_control")) {
-    failures.push("stale survey_creation_control is forbidden");
+    fail("no_stale_survey_creation_control", "stale survey_creation_control is forbidden");
   }
-  if (!lifecycle) return [...failures, "instrument_lifecycle is missing"];
-  if (lifecycle.metadata_file !== FOLLOWUP_METADATA) failures.push("follow-up metadata path mismatch");
-  const current = lifecycle.current_live_instrument || {};
-  const expectedCurrent = metadata.current_live_instrument || {};
-  for (const field of ["instrument_id", "status", "closure_rule"]) {
-    if (current[field] !== expectedCurrent[field]) failures.push(`current live instrument ${field} mismatch`);
+  if (!lifecycle) {
+    fail("required_lifecycle_fields", "instrument_lifecycle is missing");
+    return failures;
   }
+  if (lifecycle.metadata_file !== FOLLOWUP_METADATA) {
+    fail("canonical_followup_metadata_link", "follow-up metadata path mismatch");
+  }
+
+  const pilots = lifecycle.pilot_collections;
+  if (!Array.isArray(pilots) || pilots.length === 0) {
+    fail("exactly_one_pilot_declaration", "pilot_collections must contain exactly one declaration");
+  } else if (pilots.length !== 1) {
+    fail("exactly_one_pilot_declaration", `found ${pilots.length} pilot declarations`);
+  }
+  const pilot = Array.isArray(pilots) && pilots.length === 1 ? pilots[0] : {};
+  const audit = lifecycle.item_level_audit || {};
   const followup = lifecycle.followup_instrument || {};
+  const values = {
+    pilot_state: pilot.collection_state,
+    audit_state: audit.state,
+    followup_state: followup.lifecycle_state,
+  };
+
+  if (!PILOT_COLLECTION_STATES.has(values.pilot_state)) {
+    fail("controlled_pilot_collection_state", `unsupported pilot state ${JSON.stringify(values.pilot_state)}`, values);
+  }
+  if (!ITEM_AUDIT_STATES.has(values.audit_state)) {
+    fail("controlled_item_audit_state", `unsupported audit state ${JSON.stringify(values.audit_state)}`, values);
+  }
+  if (!FOLLOWUP_LIFECYCLE_STATES.has(values.followup_state)) {
+    fail("controlled_followup_lifecycle_state", `unsupported follow-up state ${JSON.stringify(values.followup_state)}`, values);
+  }
+
+  const expectedCurrent = metadata.current_live_instrument || {};
+  for (const [field, metadataField] of [
+    ["instrument_id", "instrument_id"],
+    ["collection_state", "collection_state"],
+    ["closure_rule", "closure_rule"],
+  ]) {
+    if (pilot[field] !== expectedCurrent[metadataField]) {
+      fail("single_pilot_declaration_consistency", `pilot ${field} mismatches follow-up metadata`, values);
+    }
+  }
+  if (pilot.compatibility_status !== PILOT_COMPATIBILITY_STATUS[values.pilot_state] ||
+      expectedCurrent.status !== pilot.compatibility_status) {
+    fail("pilot_compatibility_status_consistency", "pilot compatibility status does not match collection state", values);
+  }
+  if (!lifecycle.item_level_audit ||
+      audit.pilot_instrument_id !== pilot.instrument_id) {
+    fail("item_audit_targets_current_pilot", "item-level audit is missing or targets a different pilot", values);
+  }
+
   const expectedFollowup = {
     instrument_id: metadata.instrument_id,
-    status: metadata.instrument_status,
+    lifecycle_state: metadata.lifecycle_state,
+    compatibility_status: metadata.instrument_status,
     deployment_allowed: metadata.deployment_allowed,
   };
-  for (const field of ["instrument_id", "status", "deployment_allowed"]) {
-    if (followup[field] !== expectedFollowup[field]) failures.push(`follow-up instrument ${field} mismatch`);
+  for (const field of ["instrument_id", "lifecycle_state", "compatibility_status", "deployment_allowed"]) {
+    if (followup[field] !== expectedFollowup[field]) {
+      fail("followup_declaration_consistency", `follow-up instrument ${field} mismatch`, values);
+    }
   }
-  if (followup.deployment_allowed !== false) failures.push("follow-up must remain non-deployable");
-  if (expectedCurrent.status !== "collection_in_progress") failures.push("current pilot is not in collection");
-  if (metadata.instrument_status !== "draft_followup") failures.push("follow-up metadata is not draft_followup");
+  if (followup.compatibility_status !== FOLLOWUP_COMPATIBILITY_STATUS[values.followup_state]) {
+    fail("followup_compatibility_status_consistency", "follow-up compatibility status does not match lifecycle state", values);
+  }
+
+  if (RESTRICTED_FOLLOWUP_STATES.has(values.followup_state) &&
+      (values.pilot_state !== "closed" || values.audit_state !== "accepted")) {
+    fail(
+      "followup_deployment_lock",
+      "locked, generated, or deployed follow-up requires pilot=closed and audit=accepted",
+      values
+    );
+  }
+  if (values.followup_state === "draft" && followup.deployment_allowed !== false) {
+    fail("draft_is_non_deployable", "draft follow-up must set deployment_allowed=false", values);
+  }
+  if (followup.deployment_allowed === true &&
+      (values.pilot_state !== "closed" || values.audit_state !== "accepted")) {
+    fail("deployment_permission_prerequisites", "deployment_allowed requires pilot=closed and audit=accepted", values);
+  }
+
+  const artifacts = metadata.tracked_artifacts;
+  if (!Array.isArray(artifacts)) {
+    fail("tracked_artifacts_required", "tracked_artifacts must be an array", values);
+  } else {
+    const paths = new Map();
+    for (const artifact of artifacts) {
+      const prior = paths.get(artifact.path) || [];
+      prior.push(artifact);
+      paths.set(artifact.path, prior);
+      if (!artifact.path || !ARTIFACT_STATES.has(artifact.artifact_state) ||
+          typeof artifact.deployable !== "boolean") {
+        fail("valid_tracked_artifact", "artifact requires path, controlled state, and deployable boolean", values, artifact);
+      }
+      if (values.followup_state === "draft" &&
+          (artifact.deployable || ["generated", "deployed"].includes(artifact.artifact_state))) {
+        fail("draft_has_no_generated_or_deployable_artifact", "draft lifecycle contradicts tracked artifact", values, artifact);
+      }
+    }
+    for (const [artifactPath, declarations] of paths) {
+      if (declarations.length !== 1) {
+        fail("unique_tracked_artifact_declaration", `artifact path has ${declarations.length} declarations`, values, { path: artifactPath });
+      }
+    }
+    for (const artifactPath of [metadata.item_file, metadata.crosswalk_file, metadata.response_template_file]) {
+      if (!artifactPath || (paths.get(artifactPath) || []).length !== 1) {
+        fail("all_followup_sources_are_tracked", "follow-up source is missing one artifact declaration", values, { path: artifactPath || null });
+      }
+    }
+    if (["generated", "deployed"].includes(values.followup_state) &&
+        !artifacts.some((artifact) => ["generated", "deployed"].includes(artifact.artifact_state))) {
+      fail("generated_state_has_generated_artifact", "generated or deployed lifecycle has no generated artifact", values);
+    }
+  }
+
   const staleState = JSON.stringify(state);
   if (/user_prompt_required|user_prompt_received|survey_instrument_created_in_current_checkpoint|await_user_prompt_then_create|after_user_prompt_for_mixed_pilot/.test(staleState)) {
-    failures.push("stale survey-creation lifecycle field remains");
+    fail("no_stale_survey_creation_control", "stale survey-creation lifecycle field remains", values);
   }
-  for (const entry of state.constructions || []) {
-    if (entry.next_action !== CURRENT_NEXT_ACTION) {
-      failures.push(`${entry.legacy_runtime_label || "unknown construction"} has stale next_action`);
+  if (values.pilot_state === "active" && values.audit_state === "not_started" &&
+      values.followup_state === "draft") {
+    for (const entry of state.constructions || []) {
+      if (entry.next_action !== CURRENT_NEXT_ACTION) {
+        fail("current_next_action_matches_lifecycle", `${entry.legacy_runtime_label || "unknown construction"} has stale next_action`, values);
+      }
     }
   }
   return failures;
@@ -321,6 +452,9 @@ function runAudit(root = DEFAULT_ROOT, { writeReport = true } = {}) {
   check("public waves batch two to three focal constructions", policy.batching.focal_constructions_per_public_wave_min === 2 && policy.batching.focal_constructions_per_public_wave_max === 3);
   check("historical v1 workflow remains traceable", fs.existsSync(path.join(root, state.supersedes)));
   checkFailures("instrument lifecycle matches current metadata", lifecycleFailures(state, metadata));
+  for (const artifact of metadata.tracked_artifacts || []) {
+    check(`tracked follow-up artifact exists: ${artifact.path}`, fs.existsSync(path.join(root, artifact.path)));
+  }
 
   const stateConstructions = new Set(state.constructions.map((entry) => entry.legacy_runtime_label));
   const activeConstructions = new Set(notes.map((note) => note.frontmatter.construction));
@@ -401,7 +535,7 @@ function runAudit(root = DEFAULT_ROOT, { writeReport = true } = {}) {
   check("consolidated governance exists", fs.existsSync(path.join(root, "docs/current/GOVERNANCE.md")));
 
   const report = {
-    schema: "canto-span-native-panel-workflow-audit-v2",
+    schema: "canto-span-native-panel-workflow-audit-v3",
     protocol_version: state.protocol_version,
     active_constructions: notes.length,
     check_count: checks.length,

--- a/tools/verify-native-followup-draft.js
+++ b/tools/verify-native-followup-draft.js
@@ -2,6 +2,7 @@
 "use strict";
 const fs = require("node:fs");
 const path = require("node:path");
+const { lifecycleFailures } = require("./verify-active-review-workflow");
 const root = path.resolve(__dirname, "..");
 const panel = path.join(root, "review-packets/native-panel/active-v2");
 const corpus = path.join(root, "review-packets/corpus-review/AB30");
@@ -13,13 +14,14 @@ function tsv(file) {
   return lines.filter(Boolean).map(line => Object.fromEntries(headers.map((h,i)=>[h,line.split("\t")[i]||""])));
 }
 const meta = json(path.join(panel, "followup-draft-v1-metadata.json"));
+const state = json(path.join(panel, "panel-review-state.json"));
 const items = tsv(path.join(panel, "followup-draft-v1-items.tsv"));
 const crosswalk = tsv(path.join(panel, "followup-draft-v1-item-crosswalk.tsv"));
 const responses = tsv(path.join(panel, "followup-draft-v1-response-template.tsv"));
 const decisions = json(path.join(corpus, "review-decisions-r1.json"));
 const ledger = json(path.join(corpus, "candidate-ledger.json"));
-check(meta.instrument_status === "draft_followup" && meta.deployment_allowed === false, "follow-up must remain non-deployable draft");
-check(meta.current_live_instrument.status === "collection_in_progress", "live pilot must remain in progress");
+const lifecycleErrors = lifecycleFailures(state, meta);
+check(lifecycleErrors.length === 0, `follow-up lifecycle lock failed: ${JSON.stringify(lifecycleErrors)}`);
 check(meta.primary_focal_constructions.map(x=>x.code).join(",") === "AB53,AB30", "primary codes must be AB53,AB30");
 check(meta.primary_focal_constructions[0].canonical_name === "ResourceInitialJungLaiFunctionClause", "AB53 canonical name mismatch");
 check(meta.primary_focal_constructions[1].canonical_name === "ZoMarkedPerfectiveObjectVP", "AB30 canonical name mismatch");


### PR DESCRIPTION
<!-- coordination-claim: #52 -->

Work claim: #52

Closes #43
Closes #52

## Outcome and scope

Extends the existing native-panel lifecycle records and verifier family so a follow-up instrument cannot be locked, generated, or deployed unless pilot collection is `closed` and its item-level audit is `accepted`. The verifier also rejects missing or duplicate pilot declarations and generated/deployable artifacts while lifecycle remains `draft`.

The current factual state remains unchanged: pilot `active`, audit `not_started`, follow-up `draft`, and all three tracked artifacts are non-deployable draft sources.

## Coordination

- Work ID: `CS-WORK-0052`
- Claim mode: `exclusive`
- Integration role: `worker`
- Semantic regions: native-panel lifecycle metadata; existing active-review and follow-up verifier logic; lifecycle test matrix; research-profile test command; lifecycle README section
- Dependencies: none
- Overlap with draft PR #49 / claim #48: none; Batch 12 owns disjoint identity/adjudication regions
- Pending changesets: none

## Canonical inputs and generated outputs

- Pilot collection and item-level audit owner: `review-packets/native-panel/active-v2/panel-review-state.json`
- Follow-up identity, lifecycle, and artifact owner: `review-packets/native-panel/active-v2/followup-draft-v1-metadata.json`
- Existing verifier family: `tools/verify-active-review-workflow.js` and `tools/verify-native-followup-draft.js`
- Generated outputs: none; `validation/current` byproducts were restored and excluded

## Explicitly protected or unchanged

No participant data was inspected or changed. This PR does not close the pilot, accept an audit, revise survey wording/items/scales/randomization, lock or generate an instrument, create a deployable form, deploy to SoSci, alter credentials, change runtime behavior, change construction identity/status/evidence, change corpus decisions, change promotion thresholds, or authorize merge.

The verifier does not infer survey readiness from response counts, parser output, tests, corpus evidence, or project-state prose.

## Validation

Validated exact head: `2baf6acfe268ec38ff5d56959bc48451509b2ef3`

- `node tests/tooling/native-panel/active-review-workflow.test.js` — PASS, 11/11 tests including all 24 lifecycle combinations
- `node tools/verify-active-review-workflow.js` — PASS, 123/123 checks
- `node tools/verify-native-followup-draft.js` — PASS
- `npm run verify:coordination` — PASS
- `npm run verify:research` — PASS, 12/12 commands
- `npm run verify` — PASS, 14/14 commands
- `git diff --check` and `git diff --cached --check` — PASS
- GitHub Actions — PASS, 5/5 checks on the exact head

Lifecycle facts intentionally left for ChatGPT/human review: whether or when the pilot should close, whether an item-level audit is acceptable, and whether any future follow-up is substantively ready.

## Human merge review

- Review status: `READY_FOR_USER_REVIEW`
- User notified that this exact head is ready: `yes`
- Explicit approval for this pull request and exact head: `not received`

Any new commit invalidates approval and requires a new ready-for-review notice and fresh approval.

## Remaining work

Review this exact head and provide explicit merge approval if acceptable. No files exist under `changes/pending/`.