### PR TITLE
Generalize task intake pickup routing

### DIFF
--- a/.github/workflows/codex-intake-issue.yml
+++ b/.github/workflows/codex-intake-issue.yml
@@ -1,10 +1,26 @@
-name: Create Codex intake issue
+name: Create task intake issue
 
 on:
   workflow_dispatch:
     inputs:
+      created_by:
+        description: Who prepared this intake
+        required: true
+        type: choice
+        options:
+          - chatgpt
+          - codex
+          - human
+      pickup_target:
+        description: One primary pickup target
+        required: true
+        type: choice
+        options:
+          - codex
+          - chatgpt
+          - human
       category:
-        description: Codex-ready category from the canonical routing contract
+        description: Task category or decision type
         required: true
         type: choice
         options:
@@ -18,6 +34,13 @@ on:
           - behavior-preserving-refactor
           - accepted-specification
           - repository-pr-audit
+          - research-synthesis
+          - linguistic-judgment
+          - design-decision
+          - policy-interpretation
+          - survey-interpretation
+          - independent-review
+          - human-action
       title:
         description: Concise issue title
         required: true
@@ -27,11 +50,15 @@ on:
         required: true
         type: string
       acceptance_criteria:
-        description: Required checks and observable acceptance criteria, one per line
+        description: Observable completion criteria, one per line
         required: true
         type: string
       relevant_context:
-        description: Canonical files, accepted specification, and dependencies
+        description: Evidence, canonical files, authorities, and dependencies
+        required: false
+        type: string
+      dependencies:
+        description: Blocking issues or conditions, one per line
         required: false
         type: string
       protected_state:
@@ -48,13 +75,60 @@ on:
           - medium
           - high
       execution_mode:
-        description: Whether Codex may implement changes or only report findings
+        description: Implementation or findings only
         required: true
         default: implementation
         type: choice
         options:
           - implementation
           - findings-only
+      unresolved_question:
+        description: Required for ChatGPT pickup; exact question, decision, or review
+        required: false
+        type: string
+      mechanical_remainder:
+        description: Required for ChatGPT pickup; bounded later mechanical work
+        required: false
+        type: string
+      human_input_required:
+        description: Whether ChatGPT pickup also requires human input
+        required: false
+        default: false
+        type: boolean
+      human_action:
+        description: Required for human pickup; one concrete human action
+        required: false
+        type: string
+      agent_limitation:
+        description: Required for human pickup; why an agent cannot perform it
+        required: false
+        type: string
+      required_artifact:
+        description: Required for human pickup; information or artifact needed
+        required: false
+        type: string
+      blocked_work:
+        description: Required for human pickup; work blocked by the action
+        required: false
+        type: string
+      next_step:
+        description: Required for human pickup; what happens after completion
+        required: false
+        type: string
+      completion_evidence:
+        description: Required for human pickup; safe evidence of completion
+        required: false
+        type: string
+      work_claim_required:
+        description: Whether non-Codex repository work requires a semantic claim
+        required: false
+        default: false
+        type: boolean
+      user_merge_approval_required:
+        description: Whether completion includes a pull request requiring user approval
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -68,14 +142,28 @@ jobs:
       - name: Validate input and create intake issue
         uses: actions/github-script@v8
         env:
+          INPUT_CREATED_BY: ${{ inputs.created_by }}
+          INPUT_PICKUP_TARGET: ${{ inputs.pickup_target }}
           INPUT_CATEGORY: ${{ inputs.category }}
           INPUT_TITLE: ${{ inputs.title }}
           INPUT_OUTCOME: ${{ inputs.outcome }}
           INPUT_ACCEPTANCE_CRITERIA: ${{ inputs.acceptance_criteria }}
           INPUT_RELEVANT_CONTEXT: ${{ inputs.relevant_context }}
+          INPUT_DEPENDENCIES: ${{ inputs.dependencies }}
           INPUT_PROTECTED_STATE: ${{ inputs.protected_state }}
           INPUT_RISK: ${{ inputs.risk }}
           INPUT_EXECUTION_MODE: ${{ inputs.execution_mode }}
+          INPUT_UNRESOLVED_QUESTION: ${{ inputs.unresolved_question }}
+          INPUT_MECHANICAL_REMAINDER: ${{ inputs.mechanical_remainder }}
+          INPUT_HUMAN_INPUT_REQUIRED: ${{ inputs.human_input_required }}
+          INPUT_HUMAN_ACTION: ${{ inputs.human_action }}
+          INPUT_AGENT_LIMITATION: ${{ inputs.agent_limitation }}
+          INPUT_REQUIRED_ARTIFACT: ${{ inputs.required_artifact }}
+          INPUT_BLOCKED_WORK: ${{ inputs.blocked_work }}
+          INPUT_NEXT_STEP: ${{ inputs.next_step }}
+          INPUT_COMPLETION_EVIDENCE: ${{ inputs.completion_evidence }}
+          INPUT_WORK_CLAIM_REQUIRED: ${{ inputs.work_claim_required }}
+          INPUT_USER_MERGE_APPROVAL_REQUIRED: ${{ inputs.user_merge_approval_required }}
         with:
           script: |
             const {
@@ -97,7 +185,7 @@ jobs:
             );
             const duplicate = findExactDuplicate(openIssues, intake);
             if (duplicate) {
-              throw new Error(`exact open Codex intake already exists: #${duplicate.number}`);
+              throw new Error(`exact open task intake already exists: #${duplicate.number}`);
             }
 
             await ensureRoutingLabels(github, context.repo, intake.labels);
@@ -108,4 +196,4 @@ jobs:
               body: intake.body,
               labels: intake.labels.map((label) => label.name),
             });
-            core.notice(`created Codex intake issue #${response.data.number}: ${response.data.html_url}`);
+            core.notice(`created task intake issue #${response.data.number}: ${response.data.html_url}`);

--- a/docs/current/CODEX-ISSUE-WORKFLOW.md
+++ b/docs/current/CODEX-ISSUE-WORKFLOW.md
@@ -1,22 +1,23 @@
 ---
-title: Canto Span — ChatGPT and Codex Task Routing
+title: Canto Span — Task Creator and Pickup Routing
 status: current
 implementation_status: routing-active; manual-issue-generator-implemented; automatic-dispatch-not-implemented
 tags: [canto-span/infrastructure, canto-span/agents, canto-span/github]
 related: "[[00-START-HERE]] [[MULTI-AGENT-COORDINATION]] [[USER-MERGE-REVIEW]]"
 ---
 
-# ChatGPT and Codex task routing
+# Task creator and pickup routing
 
-This document is the canonical owner of task routing between ChatGPT and Codex for
-Canto Span repository work.
+This document is the canonical owner of task routing among ChatGPT, Codex, and human
+pickup for Canto Span repository work.
 
 The routing duties in this document are active now. The manual GitHub issue-generator
-is implemented, while automatic Codex dispatch is not. ChatGPT may create eligible
-intake issues directly through available GitHub tools, and a user may invoke the
-manual workflow. Both paths report `manual-pickup-required`. Creating an issue alone
-does not prove that Codex has begun work; dispatch status remains explicit and
-truthful.
+is implemented for Codex, ChatGPT, and human pickup, while automatic dispatch is not.
+ChatGPT, Codex, or a human may create intake issues directly through available
+GitHub tools, and a user may invoke the manual workflow. Initial pickup status is
+`manual-pickup-required`, `chatgpt-pickup-required`, or
+`human-pickup-required`, according to the one primary pickup target. Creating an
+issue alone does not prove that the target has begun work.
 
 This document supplements, but does not replace:
 
@@ -36,7 +37,9 @@ requested work as exactly one of:
    user interaction, or review must occur before implementation can be specified.
 2. **Codex-ready** — one bounded, repository-centered, testable outcome can begin
    without an unresolved expert or user decision.
-3. **Hybrid** — ChatGPT performs the decision, research, design, or specification
+3. **Human-required** — one concrete action requires human authority, access, a
+   local device, participant contact, credentials, or a subjective user preference.
+4. **Hybrid** — ChatGPT performs the decision, research, design, or specification
    portion and delegates one or more bounded implementation portions to Codex.
 
 The user does not need to ask ChatGPT to perform this routing or remind it to create
@@ -104,7 +107,13 @@ For hybrid work, ChatGPT must:
 ChatGPT must not delegate an unresolved expert decision merely by describing it as
 implementation.
 
-### 2.4 Tool or dispatch limitations
+### 2.4 Human-required work
+
+When the next action requires a person, the creator makes a human-targeted intake
+with the concrete action, agent limitation, required artifact, blocked work, next
+step, and safe completion evidence. Agent work waits without simulating completion.
+
+### 2.5 Tool or dispatch limitations
 
 If ChatGPT cannot create the issue because GitHub access is unavailable, it must say
 so plainly and provide the complete ready-to-create issue body. It must not silently
@@ -262,73 +271,92 @@ An intake issue may be created as `codex-ready` only when every condition is met
 Failure routes the task to ChatGPT. It does not create a misleading Codex-ready
 issue.
 
-## 7. Intake issue format
+## 7. Unified intake issue format
 
-### 7.1 Minimal bootstrap prompt
+Every new intake distinguishes who prepared it from who must act next:
 
-Use this intent:
+- `created_by`: exactly `chatgpt`, `codex`, or `human`;
+- `pickup_target`: exactly one of `codex`, `chatgpt`, or `human`.
 
-```text
-Read AGENTS.md, docs/current/00-START-HERE.md, and
- docs/current/CODEX-ISSUE-WORKFLOW.md in full. Before creating a claim, branch, or
-edit, self-screen this task against the ChatGPT-first and Codex eligibility rules. If
-it is misrouted or requires an unresolved decision, report needs-chatgpt and stop
-without changing the repository. Otherwise inspect current main, open PRs, and work
-claims; create the required semantic work claim and exact branch; complete the
-bounded outcome; run every applicable check; open a coherent PR; notify the user when
-it is ready; and stop without merging.
-```
+Both ChatGPT and Codex may create any of the three target types. A creator is not the
+active pickup owner unless it is also the selected target. Reassignment requires an
+explicit record of the previous target, new target, active owner, and reason.
 
-The issue should not duplicate the full repository contract.
+### 7.1 Codex pickup
 
-### 7.2 Human-readable body
+A Codex-targeted issue includes the mandatory contract bootstrap and an explicit
+`BEGIN NOW` / `WAIT FOR CHATGPT` self-screen. Codex may begin only when the
+specification is accepted, no protected decision is unresolved, and live overlap
+checks pass. Before repository edits it creates the semantic work claim and exact
+branch. It opens one coherent pull request, notifies the user, and stops without
+merging.
 
-```markdown
-## Outcome
+Initial status is `manual-pickup-required`. A label or issue does not prove dispatch.
 
-<One concrete result>
+### 7.2 ChatGPT pickup
 
-## Acceptance criteria
+A ChatGPT-targeted issue must state:
 
-- <Observable requirement>
-- <Required test or verifier>
-- <Behavior that must remain unchanged>
+- the exact question, decision, research synthesis, or review outcome;
+- relevant evidence, repository context, and conflicting authorities;
+- the bounded mechanical remainder that may later become Codex-ready;
+- whether human input is also required;
+- observable completion criteria.
 
-## Relevant context
+Initial status is `chatgpt-pickup-required`. Until the decision is resolved, the
+issue must not direct Codex to create a claim, branch, or speculative implementation.
 
-<Files, issue, error, construction code, accepted specification, or source packet>
+### 7.3 Human pickup
 
-## Protected state
+A human-targeted issue must state:
 
-<State dimensions or files that must remain unchanged>
-```
+- one concrete human action;
+- why an agent cannot perform it;
+- the exact information or artifact required;
+- the blocked work;
+- what happens after completion;
+- safe completion evidence that exposes no secrets or participant data.
 
-### 7.3 Machine-readable metadata
+Initial status is `human-pickup-required`. Agents must not simulate completion of the
+human action.
 
-```codex-task
+### 7.4 Machine-readable metadata
+
+```task-intake
 {
-  "schema": "canto-span-codex-task-v1",
+  "schema": "canto-span-task-intake-v1",
+  "created_by": "chatgpt",
+  "pickup_target": "codex",
+  "pickup_status": "manual-pickup-required",
   "category": "verification-audit",
   "risk": "low",
   "execution_mode": "implementation",
   "dependencies": [],
   "protected_state": [],
-  "dispatch_status": "manual-pickup-required",
-  "chatgpt_routing_complete": true,
-  "codex_self_screen_required": true,
+  "active_pickup_owner": "codex",
   "work_claim_required": true,
-  "user_merge_approval_required": true
+  "user_merge_approval_required": true,
+  "codex_self_screen_required": true
 }
 ```
 
-The intake metadata is not a semantic work claim and must not fabricate claim targets.
+The checked-in
+[`task-intake.schema.json`](../../schemas/task-intake.schema.json) is the unified
+format. Existing `canto-span-codex-task-v1` blocks remain valid legacy records under
+[`codex-task.schema.json`](../../schemas/codex-task.schema.json); tools validate them
+without silently rewriting them. Intake metadata is not a semantic work claim.
+Codex pickup always requires a claim and user merge approval. For ChatGPT or human
+pickup, the two booleans truthfully record whether that scoped issue also includes
+claimed repository work or a pull request; they do not grant either action.
 
-### 7.4 Labels
+### 7.5 Labels
 
 Recommended labels:
 
-- `codex-ready`;
-- `codex:<category>`;
+- the target status: `codex-ready`, `chatgpt-pickup-required`, or
+  `human-pickup-required`;
+- `pickup:codex`, `pickup:chatgpt`, or `pickup:human`;
+- `task:<category>`;
 - `risk:low`, `risk:medium`, or `risk:high`;
 - `findings-only` where applicable;
 - `needs-chatgpt` when Codex refuses a misrouted issue.
@@ -337,11 +365,11 @@ Recommended labels:
 
 ### 8.1 Routing and intake
 
-1. ChatGPT receives a Canto Span request.
-2. ChatGPT consults this document and classifies the work.
-3. ChatGPT handles ChatGPT-first decisions and decomposes hybrid work.
-4. ChatGPT creates each eligible Codex intake issue without requiring a reminder.
-5. ChatGPT informs the user of every created issue and truthful dispatch status.
+1. The creator consults this document and classifies the work.
+2. ChatGPT handles ChatGPT-first decisions and decomposes hybrid work.
+3. The creator records `created_by` separately from one `pickup_target`.
+4. The generator validates the target-specific fields, owner, status, and labels.
+5. The creator informs the user of every created issue and truthful pickup status.
 
 A user may also manually start the implemented issue-generator workflow. Manual
 initiation is an additional entry point, not a prerequisite for ChatGPT delegation.
@@ -354,7 +382,23 @@ initiation is an additional entry point, not a prerequisite for ChatGPT delegati
 4. Misrouted work returns to ChatGPT with `needs-chatgpt` and no repository change.
 5. Eligible work proceeds to a separate semantic work claim and branch.
 
-### 8.3 Execution and review
+### 8.3 ChatGPT intervention in Codex-targeted work
+
+ChatGPT may intervene only when the user directs it or the issue blocks active work.
+Before intervening, inspect the issue, pull requests, active claims, and branches.
+
+For `resolve-blocker`, record the permitted reason, precise resolved decision,
+bounded remaining Codex work, and `pickup target after intervention: codex`. Codex
+resumes only after the decision is recorded and overlap checks pass.
+
+For `takeover`, record the permitted reason, previous Codex target, active ChatGPT
+owner, bounded scope, and handoff status. If Codex has an overlapping claim, branch,
+or pull request, ChatGPT must first record a handoff, have the claim released or
+narrowed, or remain in a disjoint decision/review region. A comment or review alone
+does not imply takeover. Once takeover is recorded, Codex treats the issue as
+unavailable until explicit reassignment.
+
+### 8.4 Execution and review
 
 1. Codex keeps work inside the claim and updates it before expanding scope.
 2. Codex follows all applicable evidence, identity, runtime, corpus, survey,
@@ -396,13 +440,16 @@ Neither an intake issue nor a Codex-ready label silently authorizes Codex to:
 
 Issue generation and Codex dispatch are separate responsibilities.
 
-A created issue must record one truthful dispatch state:
+A created issue must record one truthful pickup state. Codex pickup may later use:
 
 - `not-configured`;
 - `queued`;
 - `accepted`;
 - `failed`;
 - `manual-pickup-required`.
+
+ChatGPT and human pickup begin as `chatgpt-pickup-required` and
+`human-pickup-required`, respectively.
 
 Assignment, labels, mentions, or an `issues: opened` event must not be described as
 starting Codex unless a controlled end-to-end test has verified that behavior.
@@ -416,18 +463,26 @@ The manually triggered
 [`codex-intake-issue.yml`](../../.github/workflows/codex-intake-issue.yml)
 workflow:
 
-1. accepts structured category, title, outcome, acceptance-criteria, context,
-   protected-state, risk, and execution-mode inputs;
+1. accepts structured creator, one pickup target, category or decision type, title,
+   outcome, acceptance criteria, context, dependencies, protected state, risk,
+   execution mode, and target-specific inputs;
 2. validates them against
-   [`codex-task.schema.json`](../../schemas/codex-task.schema.json) and the
-   prohibited routing classes in this document;
-3. rejects missing required fields, unsupported categories, unsafe direct
-   authorizations, Markdown-fence injection, and an exact duplicate open intake;
-4. creates the canonical issue body with one metadata block and
-   `dispatch_status: manual-pickup-required`;
+   [`task-intake.schema.json`](../../schemas/task-intake.schema.json), while retaining
+   explicit validation compatibility for legacy
+   [`codex-task.schema.json`](../../schemas/codex-task.schema.json) records;
+3. rejects missing common or target-specific fields, multiple or unsupported pickup
+   targets, invalid status/owner combinations, unsafe direct authorizations,
+   Markdown-fence injection, and an exact duplicate open intake;
+4. creates one canonical issue body and metadata block with target-specific
+   instructions, status, owner, and labels;
 5. idempotently creates or reconciles the routing labels;
 6. uses environment variables rather than inserting untrusted input into executable
    workflow script text.
+
+The same coordination implementation validates ChatGPT `resolve-blocker` and
+`takeover` records plus explicit pickup reassignment. Takeover validation rejects
+parallel edits against an active overlapping Codex claim unless a release,
+narrowing, or disjoint handoff is recorded.
 
 For issue creation, expected least-privilege permissions are:
 
@@ -447,11 +502,15 @@ semantic overlap or hidden dependencies.
 
 The manual workflow remains complete only while:
 
-- every allowlisted category produces the documented issue format;
+- every creator and pickup-target combination produces the documented unified
+  format;
+- target-specific required fields, status, owner, and labels remain enforced;
+- legacy `canto-span-codex-task-v1` records remain valid without rewriting;
+- intervention and reassignment records enforce the overlap and handoff rules;
 - prohibited task classes are rejected or routed to ChatGPT;
 - ChatGPT can invoke issue creation without requiring the user to restate the task;
 - the user receives a notice for every created issue;
-- Codex self-screening is included in every generated prompt;
+- Codex self-screening is included in every Codex-targeted prompt;
 - metadata validates against a checked-in schema;
 - no intake issue is mistaken for a semantic work claim;
 - dispatch status is explicit and truthful;

--- a/schemas/task-intake.schema.json
+++ b/schemas/task-intake.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Vazhi/canto-span/schemas/task-intake.schema.json",
+  "title": "Canto Span unified task intake",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "created_by",
+    "pickup_target",
+    "pickup_status",
+    "category",
+    "risk",
+    "execution_mode",
+    "dependencies",
+    "protected_state",
+    "active_pickup_owner",
+    "work_claim_required",
+    "user_merge_approval_required",
+    "codex_self_screen_required"
+  ],
+  "properties": {
+    "schema": { "const": "canto-span-task-intake-v1" },
+    "created_by": { "enum": ["chatgpt", "codex", "human"] },
+    "pickup_target": { "enum": ["codex", "chatgpt", "human"] },
+    "pickup_status": {
+      "enum": [
+        "manual-pickup-required",
+        "chatgpt-pickup-required",
+        "human-pickup-required"
+      ]
+    },
+    "category": {
+      "enum": [
+        "runtime-bug",
+        "tests-fixtures",
+        "verification-audit",
+        "data-schema",
+        "documentation-consistency",
+        "corpus-tooling",
+        "ci-repository-tooling",
+        "behavior-preserving-refactor",
+        "accepted-specification",
+        "repository-pr-audit",
+        "research-synthesis",
+        "linguistic-judgment",
+        "design-decision",
+        "policy-interpretation",
+        "survey-interpretation",
+        "independent-review",
+        "human-action"
+      ]
+    },
+    "risk": { "enum": ["low", "medium", "high"] },
+    "execution_mode": { "enum": ["implementation", "findings-only"] },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "integer", "minimum": 1 },
+          { "type": "string", "minLength": 1 }
+        ]
+      },
+      "uniqueItems": true
+    },
+    "protected_state": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "active_pickup_owner": { "enum": ["codex", "chatgpt", "human"] },
+    "work_claim_required": { "type": "boolean" },
+    "user_merge_approval_required": { "type": "boolean" },
+    "codex_self_screen_required": { "type": "boolean" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "pickup_target": { "const": "codex" } } },
+      "then": {
+        "properties": {
+          "pickup_status": { "const": "manual-pickup-required" },
+          "active_pickup_owner": { "const": "codex" },
+          "work_claim_required": { "const": true },
+          "user_merge_approval_required": { "const": true },
+          "codex_self_screen_required": { "const": true }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "pickup_target": { "const": "chatgpt" } } },
+      "then": {
+        "properties": {
+          "pickup_status": { "const": "chatgpt-pickup-required" },
+          "active_pickup_owner": { "const": "chatgpt" },
+          "codex_self_screen_required": { "const": false }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "pickup_target": { "const": "human" } } },
+      "then": {
+        "properties": {
+          "pickup_status": { "const": "human-pickup-required" },
+          "active_pickup_owner": { "const": "human" },
+          "codex_self_screen_required": { "const": false }
+        }
+      }
+    }
+  ]
+}

--- a/tests/tooling/coordination/codex-intake.test.js
+++ b/tests/tooling/coordination/codex-intake.test.js
@@ -6,120 +6,269 @@ const path = require("path");
 const test = require("node:test");
 const {
   ALLOWED_CATEGORIES,
+  ALLOWED_CREATORS,
+  ALLOWED_PICKUP_TARGETS,
   CANONICAL_BOOTSTRAP,
   IntakeValidationError,
   buildIntakeIssue,
   ensureRoutingLabels,
   findExactDuplicate,
   inputFromEnvironment,
+  validateInterventionRecord,
+  validateReassignmentRecord,
   validateTaskMetadata,
 } = require("../../../tools/coordination/codex-intake");
 
 function validInput(overrides = {}) {
   return {
+    createdBy: "chatgpt",
+    pickupTarget: "codex",
     category: "verification-audit",
-    title: "Codex: verify bounded state",
+    title: "Verify bounded state",
     outcome: "One deterministic verifier reports stale state.",
     acceptanceCriteria: "Add focused tests\nRun the existing coordination verifier",
-    relevantContext: "Use the accepted specification in issue #40.",
+    relevantContext: "Use the accepted specification in issue #44.",
+    dependencies: "Issue #44\nclaim #54",
     protectedState: "main\nruntime_behavior",
     risk: "low",
     executionMode: "implementation",
+    unresolvedQuestion: "",
+    mechanicalRemainder: "",
+    humanInputRequired: false,
+    humanAction: "",
+    agentLimitation: "",
+    requiredArtifact: "",
+    blockedWork: "",
+    nextStep: "",
+    completionEvidence: "",
+    workClaimRequired: false,
+    userMergeApprovalRequired: false,
     ...overrides,
   };
 }
 
+function targetInput(target, overrides = {}) {
+  if (target === "chatgpt") {
+    return validInput({
+      pickupTarget: target,
+      category: "design-decision",
+      unresolvedQuestion: "Which accepted design should the repository implement?",
+      mechanicalRemainder: "Codex may implement the selected design after reassignment.",
+      ...overrides,
+    });
+  }
+  if (target === "human") {
+    return validInput({
+      pickupTarget: target,
+      category: "human-action",
+      humanAction: "Approve or reject the prepared pull request.",
+      agentLimitation: "Only the repository owner can authorize merge.",
+      requiredArtifact: "A plain approval or rejection comment; no secrets.",
+      blockedWork: "The reviewed pull request cannot merge.",
+      nextStep: "An agent may merge only after explicit approval.",
+      completionEvidence: "A repository comment recording the decision.",
+      userMergeApprovalRequired: true,
+      ...overrides,
+    });
+  }
+  return validInput({ pickupTarget: target, ...overrides });
+}
+
 function metadataFromBody(body) {
-  const matches = [...body.matchAll(/```codex-task\n([\s\S]*?)```/g)];
+  const matches = [...body.matchAll(/```task-intake\n([\s\S]*?)```/g)];
   assert.equal(matches.length, 1);
   return JSON.parse(matches[0][1]);
 }
 
-test("builds one canonical validated Codex intake issue", () => {
-  const result = buildIntakeIssue(validInput());
-  assert.equal(result.title, "Codex: verify bounded state");
+test("supports every creator and pickup-target combination with one primary target", () => {
+  assert.deepEqual([...ALLOWED_CREATORS], ["chatgpt", "codex", "human"]);
+  assert.deepEqual([...ALLOWED_PICKUP_TARGETS], ["codex", "chatgpt", "human"]);
+  for (const createdBy of ALLOWED_CREATORS) {
+    for (const pickupTarget of ALLOWED_PICKUP_TARGETS) {
+      const result = buildIntakeIssue(targetInput(pickupTarget, { createdBy }));
+      assert.equal(result.metadata.created_by, createdBy);
+      assert.equal(result.metadata.pickup_target, pickupTarget);
+      assert.equal(result.metadata.active_pickup_owner, pickupTarget);
+      assert.deepEqual(metadataFromBody(result.body), result.metadata);
+      assert.deepEqual(validateTaskMetadata(result.metadata), []);
+    }
+  }
+  assert.throws(
+    () => buildIntakeIssue(validInput({ pickupTarget: ["codex", "chatgpt"] })),
+    /pickup target must be one of/,
+  );
+});
+
+test("generates Codex start gate, manual status, and claim policy", () => {
+  const result = buildIntakeIssue(targetInput("codex"));
   assert.ok(result.body.startsWith(CANONICAL_BOOTSTRAP));
-  assert.match(result.body, /## Outcome/);
-  assert.match(result.body, /- Add focused tests/);
-  assert.deepEqual(metadataFromBody(result.body), result.metadata);
-  assert.deepEqual(validateTaskMetadata(result.metadata), []);
-  assert.deepEqual(result.metadata.protected_state, ["main", "runtime_behavior"]);
+  assert.match(result.body, /### BEGIN NOW when all are true/);
+  assert.match(result.body, /### WAIT FOR CHATGPT when any are true/);
+  assert.match(result.body, /create the semantic work claim and exact branch/);
+  assert.equal(result.metadata.pickup_status, "manual-pickup-required");
+  assert.equal(result.metadata.work_claim_required, true);
+  assert.equal(result.metadata.user_merge_approval_required, true);
+  assert.equal(result.metadata.codex_self_screen_required, true);
   assert.deepEqual(result.labels.map((label) => label.name), [
     "codex-ready",
-    "codex:verification-audit",
+    "pickup:codex",
+    "task:verification-audit",
     "risk:low",
   ]);
 });
 
-test("accepts every canonical Codex-ready category", () => {
-  assert.equal(ALLOWED_CATEGORIES.size, 10);
-  for (const category of ALLOWED_CATEGORIES) {
-    const result = buildIntakeIssue(validInput({ category }));
-    assert.equal(result.metadata.category, category);
-    assert.ok(result.labels.some((label) => label.name === `codex:${category}`));
+test("generates required ChatGPT question, evidence, remainder, and status", () => {
+  const result = buildIntakeIssue(targetInput("chatgpt", { humanInputRequired: true }));
+  assert.match(result.body, /## ChatGPT pickup/);
+  assert.match(result.body, /Which accepted design/);
+  assert.match(result.body, /Use the accepted specification/);
+  assert.match(result.body, /Codex may implement the selected design/);
+  assert.match(result.body, /Human input also required\n\nYes\./);
+  assert.doesNotMatch(result.body, /create the semantic work claim/);
+  assert.equal(result.metadata.pickup_status, "chatgpt-pickup-required");
+  assert.equal(result.metadata.work_claim_required, false);
+  assert.ok(result.labels.some((label) => label.name === "pickup:chatgpt"));
+});
+
+test("generates required human action, block, continuation, evidence, and status", () => {
+  const result = buildIntakeIssue(targetInput("human"));
+  for (const heading of [
+    "One concrete human action",
+    "Why an agent cannot perform it",
+    "Exact information or artifact needed",
+    "Work blocked",
+    "What happens after completion",
+    "Safe completion evidence",
+  ]) {
+    assert.ok(result.body.includes(heading));
+  }
+  assert.match(result.body, /must not simulate completion/);
+  assert.equal(result.metadata.pickup_status, "human-pickup-required");
+  assert.equal(result.metadata.user_merge_approval_required, true);
+  assert.ok(result.labels.some((label) => label.name === "pickup:human"));
+});
+
+test("rejects missing target-specific fields", () => {
+  for (const field of ["unresolvedQuestion", "mechanicalRemainder"]) {
+    assert.throws(
+      () => buildIntakeIssue(targetInput("chatgpt", { [field]: "" })),
+      (error) => error instanceof IntakeValidationError && error.message.includes("is required"),
+    );
+  }
+  for (const field of [
+    "humanAction", "agentLimitation", "requiredArtifact",
+    "blockedWork", "nextStep", "completionEvidence",
+  ]) {
+    assert.throws(
+      () => buildIntakeIssue(targetInput("human", { [field]: "" })),
+      (error) => error instanceof IntakeValidationError && error.message.includes("is required"),
+    );
   }
 });
 
-test("rejects unsupported category, risk, and execution mode values", () => {
+test("rejects invalid enum inputs and target-inconsistent pickup status", () => {
   for (const overrides of [
+    { createdBy: "bot" },
+    { pickupTarget: "both" },
     { category: "governance" },
     { risk: "critical" },
     { executionMode: "auto-dispatch" },
   ]) {
-    assert.throws(
-      () => buildIntakeIssue(validInput(overrides)),
-      (error) => error instanceof IntakeValidationError,
-    );
+    assert.throws(() => buildIntakeIssue(validInput(overrides)), IntakeValidationError);
   }
+  const metadata = buildIntakeIssue(targetInput("codex")).metadata;
+  assert.ok(validateTaskMetadata({
+    ...metadata,
+    pickup_status: "chatgpt-pickup-required",
+  }).some((error) => error.includes("conflicts with pickup_target")));
 });
 
-test("requires title, outcome, and acceptance criteria", () => {
-  for (const [field, label] of [
-    ["title", "title is required"],
-    ["outcome", "outcome is required"],
-    ["acceptanceCriteria", "acceptance criteria is required"],
-  ]) {
-    assert.throws(
-      () => buildIntakeIssue(validInput({ [field]: "  " })),
-      (error) => error instanceof IntakeValidationError && error.message.includes(label),
-    );
-  }
+test("validates resolve-blocker and clean takeover records", () => {
+  assert.deepEqual(validateInterventionRecord({
+    mode: "resolve-blocker",
+    reason: "blocking-active-work",
+    previous_pickup_target: "codex",
+    pickup_target_after_intervention: "codex",
+    active_pickup_owner: "codex",
+    resolved_decision: "Use the accepted schema.",
+    remaining_codex_work: "Implement and test the accepted schema.",
+    active_overlaps: ["claim #54"],
+  }), []);
+  assert.deepEqual(validateInterventionRecord({
+    mode: "takeover",
+    reason: "user-directed",
+    previous_pickup_target: "codex",
+    pickup_target_after_intervention: "chatgpt",
+    active_pickup_owner: "chatgpt",
+    scope_taken_over: "The bounded issue implementation.",
+    handoff_status: "no-active-codex-work",
+    active_overlaps: [],
+  }), []);
 });
 
-test("rejects every prohibited direct authorization class", () => {
-  const prohibited = [
-    "Push the final commit directly to main.",
-    "Merge the pull request after tests pass.",
-    "Enable auto-merge on the PR.",
-    "Publish a release from this workflow.",
-    "Deploy the survey when validation passes.",
-    "Promote AB30 after counting the fixtures.",
-    "Downgrade AB30 without expert review.",
-    "Park AA80 and unpark AA86.",
-    "Change repository policy to permit writers.",
-    "Make a governance decision for future agents.",
-    "Invent linguistic evidence for missing sources.",
-    "Do not merge the PR, but enable auto-merge.",
-  ];
-  for (const outcome of prohibited) {
-    assert.throws(
-      () => buildIntakeIssue(validInput({ outcome })),
-      (error) => error instanceof IntakeValidationError && error.message.includes("prohibited authorization"),
-      outcome,
-    );
-  }
+test("rejects takeover with active overlap unless handoff removes or narrows it", () => {
+  const takeover = {
+    mode: "takeover",
+    reason: "blocking-active-work",
+    previous_pickup_target: "codex",
+    pickup_target_after_intervention: "chatgpt",
+    active_pickup_owner: "chatgpt",
+    scope_taken_over: "The bounded issue implementation.",
+    handoff_status: "no-active-codex-work",
+    active_overlaps: ["claim #54"],
+  };
+  assert.ok(validateInterventionRecord(takeover).some((error) => error.includes("parallel edits")));
+  assert.deepEqual(validateInterventionRecord({
+    ...takeover,
+    handoff_status: "claim-released",
+    active_overlaps: [],
+  }), []);
+  assert.ok(validateInterventionRecord({ ...takeover, reason: "convenient" }).length);
 });
 
-test("allows explicit safeguards against prohibited actions", () => {
-  const result = buildIntakeIssue(validInput({
-    acceptanceCriteria: [
-      "Do not write directly to main.",
-      "Never merge the pull request or enable auto-merge.",
-      "Reject requests that publish a release or deploy a survey.",
-      "Construction promotion is prohibited.",
-    ].join("\n"),
-  }));
-  assert.deepEqual(validateTaskMetadata(result.metadata), []);
+test("validates explicit pickup reassignment", () => {
+  assert.deepEqual(validateReassignmentRecord({
+    previous_pickup_target: "chatgpt",
+    pickup_target: "codex",
+    active_pickup_owner: "codex",
+    reason: "The design decision is resolved.",
+  }), []);
+  assert.ok(validateReassignmentRecord({
+    previous_pickup_target: "codex",
+    pickup_target: "codex",
+    active_pickup_owner: "chatgpt",
+    reason: "",
+  }).length >= 3);
+});
+
+test("keeps legacy canto-span-codex-task-v1 metadata valid", () => {
+  const schemaPath = path.resolve(__dirname, "../../../schemas/codex-task.schema.json");
+  const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+  const metadata = {
+    schema: "canto-span-codex-task-v1",
+    category: schema.properties.category.enum[0],
+    risk: "medium",
+    execution_mode: "implementation",
+    dependencies: [],
+    protected_state: ["main"],
+    dispatch_status: "manual-pickup-required",
+    chatgpt_routing_complete: true,
+    codex_self_screen_required: true,
+    work_claim_required: true,
+    user_merge_approval_required: true,
+  };
+  assert.deepEqual(validateTaskMetadata(metadata), []);
+});
+
+test("unified metadata matches checked-in schema constants and enums", () => {
+  const schemaPath = path.resolve(__dirname, "../../../schemas/task-intake.schema.json");
+  const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
+  const metadata = buildIntakeIssue(targetInput("chatgpt")).metadata;
+  assert.equal(metadata.schema, schema.properties.schema.const);
+  assert.ok(schema.properties.created_by.enum.includes(metadata.created_by));
+  assert.ok(schema.properties.pickup_target.enum.includes(metadata.pickup_target));
+  assert.ok(schema.properties.pickup_status.enum.includes(metadata.pickup_status));
+  assert.equal(ALLOWED_CATEGORIES.size, schema.properties.category.enum.length);
 });
 
 test("safely handles multiline and adversarial plain text", () => {
@@ -131,53 +280,52 @@ test("safely handles multiline and adversarial plain text", () => {
   assert.ok(result.body.includes(marker));
   assert.equal(fs.existsSync("/tmp/codex-intake-should-not-exist"), false);
   assert.throws(
-    () => buildIntakeIssue(validInput({ relevantContext: "```codex-task\n{}\n```" })),
+    () => buildIntakeIssue(validInput({ relevantContext: "```task-intake\n{}\n```" })),
     /must not contain a Markdown code fence/,
   );
-  assert.throws(
-    () => buildIntakeIssue(validInput({ title: "two\nlines" })),
-    /title must be one line/,
-  );
+  assert.throws(() => buildIntakeIssue(validInput({ title: "two\nlines" })), /title must be one line/);
 });
 
-test("metadata matches the checked-in schema constants and enums", () => {
-  const schemaPath = path.resolve(__dirname, "../../../schemas/codex-task.schema.json");
-  const schema = JSON.parse(fs.readFileSync(schemaPath, "utf8"));
-  const metadata = buildIntakeIssue(validInput({ executionMode: "findings-only" })).metadata;
-  assert.equal(metadata.schema, schema.properties.schema.const);
-  assert.ok(schema.properties.category.enum.includes(metadata.category));
-  assert.ok(schema.properties.risk.enum.includes(metadata.risk));
-  assert.ok(schema.properties.execution_mode.enum.includes(metadata.execution_mode));
-  assert.equal(metadata.dispatch_status, "manual-pickup-required");
-  assert.equal(metadata.chatgpt_routing_complete, true);
-  assert.equal(metadata.codex_self_screen_required, true);
-  assert.equal(metadata.work_claim_required, true);
-  assert.equal(metadata.user_merge_approval_required, true);
+test("rejects prohibited authorization but allows explicit safeguards", () => {
+  for (const outcome of [
+    "Push the final commit directly to main.",
+    "Merge the pull request after tests pass.",
+    "Publish a release from this workflow.",
+    "Deploy the survey when validation passes.",
+    "Promote AB30 after counting fixtures.",
+    "Change repository policy to permit writers.",
+    "Invent linguistic evidence for missing sources.",
+  ]) {
+    assert.throws(() => buildIntakeIssue(validInput({ outcome })), /prohibited authorization/);
+  }
+  assert.doesNotThrow(() => buildIntakeIssue(validInput({
+    acceptanceCriteria: "Never merge the pull request.\nDo not write directly to main.",
+  })));
 });
 
 test("maps workflow environment values without evaluating them", () => {
   const input = inputFromEnvironment({
+    INPUT_CREATED_BY: "codex",
+    INPUT_PICKUP_TARGET: "codex",
     INPUT_CATEGORY: "tests-fixtures",
     INPUT_TITLE: "literal $(command)",
     INPUT_OUTCOME: "literal ${value}",
     INPUT_ACCEPTANCE_CRITERIA: "Keep input as data",
     INPUT_RELEVANT_CONTEXT: "context",
+    INPUT_DEPENDENCIES: "Issue #44",
     INPUT_PROTECTED_STATE: "main",
     INPUT_RISK: "medium",
     INPUT_EXECUTION_MODE: "implementation",
   });
+  assert.equal(input.createdBy, "codex");
+  assert.equal(input.pickupTarget, "codex");
   assert.equal(input.title, "literal $(command)");
   assert.equal(input.outcome, "literal ${value}");
 });
 
 test("finds only exact duplicate open intake issues", () => {
   const intake = buildIntakeIssue(validInput());
-  const duplicate = {
-    number: 50,
-    state: "open",
-    title: intake.title,
-    body: intake.body,
-  };
+  const duplicate = { number: 50, state: "open", title: intake.title, body: intake.body };
   assert.equal(findExactDuplicate([duplicate], intake), duplicate);
   assert.equal(findExactDuplicate([{ ...duplicate, state: "closed" }], intake), null);
   assert.equal(findExactDuplicate([{ ...duplicate, body: `${intake.body}\nchanged` }], intake), null);

--- a/tools/coordination/codex-intake.js
+++ b/tools/coordination/codex-intake.js
@@ -4,86 +4,67 @@
 const fs = require("fs");
 const path = require("path");
 
-const TASK_SCHEMA_PATH = path.resolve(__dirname, "../../schemas/codex-task.schema.json");
+const LEGACY_SCHEMA_PATH = path.resolve(__dirname, "../../schemas/codex-task.schema.json");
+const TASK_SCHEMA_PATH = path.resolve(__dirname, "../../schemas/task-intake.schema.json");
+const LEGACY_SCHEMA = JSON.parse(fs.readFileSync(LEGACY_SCHEMA_PATH, "utf8"));
 const TASK_SCHEMA = JSON.parse(fs.readFileSync(TASK_SCHEMA_PATH, "utf8"));
+const LEGACY_PROPERTIES = LEGACY_SCHEMA.properties;
 const TASK_PROPERTIES = TASK_SCHEMA.properties;
 const ALLOWED_CATEGORIES = new Set(TASK_PROPERTIES.category.enum);
+const ALLOWED_CREATORS = new Set(TASK_PROPERTIES.created_by.enum);
+const ALLOWED_PICKUP_TARGETS = new Set(TASK_PROPERTIES.pickup_target.enum);
 const ALLOWED_RISKS = new Set(TASK_PROPERTIES.risk.enum);
 const ALLOWED_EXECUTION_MODES = new Set(TASK_PROPERTIES.execution_mode.enum);
+
+const PICKUP_POLICY = {
+  codex: {
+    status: "manual-pickup-required",
+    workClaimRequired: true,
+    userMergeApprovalRequired: true,
+    codexSelfScreenRequired: true,
+  },
+  chatgpt: {
+    status: "chatgpt-pickup-required",
+    codexSelfScreenRequired: false,
+  },
+  human: {
+    status: "human-pickup-required",
+    codexSelfScreenRequired: false,
+  },
+};
 
 const CANONICAL_BOOTSTRAP = [
   "Read `AGENTS.md`, `docs/current/00-START-HERE.md`, and",
   "`docs/current/CODEX-ISSUE-WORKFLOW.md` in full. Before creating a claim, branch,",
   "or edit, self-screen this task against the ChatGPT-first and Codex eligibility",
-  "rules. If it is misrouted or requires an unresolved decision, report",
-  "`needs-chatgpt` and stop without changing the repository. Otherwise inspect",
-  "current `main`, open pull requests, intake issues, and work claims; create the",
-  "required semantic work claim and exact branch; complete the bounded outcome;",
-  "run every applicable check; open one coherent pull request; notify the user when",
-  "it is ready; and stop without merging.",
+  "rules. Inspect current `main`, open pull requests, intake issues, and work claims.",
 ].join(" ");
 
 const PROHIBITED_DIRECTIVES = [
-  {
-    name: "direct write to main",
-    pattern: /\b(?:write|commit|push|apply|land)\b.{0,50}\b(?:to|into|on)\s+(?:the\s+)?main\b/i,
-  },
-  {
-    name: "merge or auto-merge authorization",
-    pattern: /\b(?:merge(?:\s+the)?\s+(?:pull request|pr|changes?)|enable\s+auto-?merge|auto-?merge)\b/i,
-  },
-  {
-    name: "release publication",
-    pattern: /\b(?:publish|cut|ship)\b.{0,40}\b(?:a\s+|the\s+)?release\b/i,
-  },
-  {
-    name: "survey deployment",
-    pattern: /\b(?:deploy|launch|publish)\b.{0,40}\b(?:survey|instrument)\b/i,
-  },
-  {
-    name: "construction status decision",
-    pattern: /\b(?:promote|downgrade|park|unpark)\b/i,
-  },
-  {
-    name: "governance decision",
-    pattern: /\b(?:(?:decide|change|set|define|rewrite|override)\b.{0,60}\b(?:governance|project policy|repository policy)|(?:make|take)\b.{0,30}\bgovernance decision)\b/i,
-  },
-  {
-    name: "invented linguistic evidence",
-    pattern: /\b(?:invent|fabricate|manufacture|assume)\b.{0,50}\b(?:linguistic\s+)?evidence\b/i,
-  },
-];
+  ["direct write to main", /\b(?:write|commit|push|apply|land)\b.{0,50}\b(?:to|into|on)\s+(?:the\s+)?main\b/i],
+  ["merge or auto-merge authorization", /\b(?:merge(?:\s+the)?\s+(?:pull request|pr|changes?)|enable\s+auto-?merge|auto-?merge)\b/i],
+  ["release publication", /\b(?:publish|cut|ship)\b.{0,40}\b(?:a\s+|the\s+)?release\b/i],
+  ["survey deployment", /\b(?:deploy|launch|publish)\b.{0,40}\b(?:survey|instrument)\b/i],
+  ["construction status decision", /\b(?:promote|downgrade|park|unpark)\b/i],
+  ["governance decision", /\b(?:(?:decide|change|set|define|rewrite|override)\b.{0,60}\b(?:governance|project policy|repository policy)|(?:make|take)\b.{0,30}\bgovernance decision)\b/i],
+  ["invented linguistic evidence", /\b(?:invent|fabricate|manufacture|assume)\b.{0,50}\b(?:linguistic\s+)?evidence\b/i],
+].map(([name, pattern]) => ({ name, pattern }));
 
 const LABEL_STYLES = {
-  "codex-ready": {
-    color: "1D76DB",
-    description: "Bounded task eligible for Codex self-screening",
-  },
-  category: {
-    color: "5319E7",
-    description: "Codex intake task category",
-  },
-  "risk:low": {
-    color: "0E8A16",
-    description: "Low-risk Codex intake",
-  },
-  "risk:medium": {
-    color: "FBCA04",
-    description: "Medium-risk Codex intake",
-  },
-  "risk:high": {
-    color: "D93F0B",
-    description: "High-risk Codex intake",
-  },
-  "findings-only": {
-    color: "C5DEF5",
-    description: "Task produces findings without repairs",
-  },
+  "codex-ready": { color: "1D76DB", description: "Bounded task eligible for Codex self-screening" },
+  "chatgpt-pickup-required": { color: "A371F7", description: "Task requires ChatGPT judgment or review" },
+  "human-pickup-required": { color: "D4C5F9", description: "Task requires one concrete human action" },
+  pickup: { color: "0052CC", description: "Primary intake pickup target" },
+  category: { color: "5319E7", description: "Unified intake task category or decision type" },
+  "risk:low": { color: "0E8A16", description: "Low-risk intake" },
+  "risk:medium": { color: "FBCA04", description: "Medium-risk intake" },
+  "risk:high": { color: "D93F0B", description: "High-risk intake" },
+  "findings-only": { color: "C5DEF5", description: "Task produces findings without repairs" },
 };
 
 class IntakeValidationError extends Error {
   constructor(errors) {
-    super(`invalid Codex intake:\n- ${errors.join("\n- ")}`);
+    super(`invalid task intake:\n- ${errors.join("\n- ")}`);
     this.name = "IntakeValidationError";
     this.errors = errors;
   }
@@ -93,6 +74,11 @@ function text(value) {
   return String(value == null ? "" : value).trim();
 }
 
+function booleanValue(value) {
+  if (typeof value === "boolean") return value;
+  return text(value).toLowerCase() === "true";
+}
+
 function validateTextField(name, value, options = {}) {
   const errors = [];
   const normalized = text(value);
@@ -100,12 +86,8 @@ function validateTextField(name, value, options = {}) {
   if (normalized.length > (options.maxLength || 12000)) {
     errors.push(`${name} exceeds ${options.maxLength || 12000} characters`);
   }
-  if (options.singleLine && /[\r\n]/.test(normalized)) {
-    errors.push(`${name} must be one line`);
-  }
-  if (/```/.test(normalized)) {
-    errors.push(`${name} must not contain a Markdown code fence`);
-  }
+  if (options.singleLine && /[\r\n]/.test(normalized)) errors.push(`${name} must be one line`);
+  if (/```/.test(normalized)) errors.push(`${name} must not contain a Markdown code fence`);
   if (/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/.test(normalized)) {
     errors.push(`${name} contains unsupported control characters`);
   }
@@ -122,21 +104,16 @@ function directiveIsGuarded(clause, match) {
 
 function findProhibitedDirectives(values) {
   const hits = [];
-  const clauses = values
-    .map(text)
-    .join("\n")
+  const clauses = values.map(text).join("\n")
     .split(/\r?\n|[.;!?]+|,\s*|\b(?:but|however|then)\b/i)
-    .map((clause) => clause.trim())
-    .filter(Boolean);
+    .map((clause) => clause.trim()).filter(Boolean);
   for (const clause of clauses) {
     for (const rule of PROHIBITED_DIRECTIVES) {
       const flags = rule.pattern.flags.includes("g") ? rule.pattern.flags : `${rule.pattern.flags}g`;
       const pattern = new RegExp(rule.pattern.source, flags);
       let match = pattern.exec(clause);
       while (match) {
-        if (!directiveIsGuarded(clause, match)) {
-          hits.push(`${rule.name}: ${clause}`);
-        }
+        if (!directiveIsGuarded(clause, match)) hits.push(`${rule.name}: ${clause}`);
         match = pattern.exec(clause);
       }
     }
@@ -145,31 +122,49 @@ function findProhibitedDirectives(values) {
 }
 
 function parseList(value) {
-  const items = text(value)
-    .split(/\r?\n|,/)
-    .map((item) => item.trim().replace(/^[-*]\s+/, ""))
-    .filter(Boolean);
-  return [...new Set(items)];
+  return [...new Set(text(value).split(/\r?\n|,/)
+    .map((item) => item.trim().replace(/^[-*]\s+/, "")).filter(Boolean))];
 }
 
 function normalizeInput(input) {
   const normalized = {
+    createdBy: input.createdBy,
+    pickupTarget: input.pickupTarget,
     category: text(input.category),
     title: text(input.title),
     outcome: text(input.outcome),
     acceptanceCriteria: text(input.acceptanceCriteria),
     relevantContext: text(input.relevantContext),
+    dependenciesText: text(input.dependencies),
     protectedStateText: text(input.protectedState),
     risk: text(input.risk || "medium"),
     executionMode: text(input.executionMode || "implementation"),
+    unresolvedQuestion: text(input.unresolvedQuestion),
+    mechanicalRemainder: text(input.mechanicalRemainder),
+    humanInputRequired: booleanValue(input.humanInputRequired),
+    humanAction: text(input.humanAction),
+    agentLimitation: text(input.agentLimitation),
+    requiredArtifact: text(input.requiredArtifact),
+    blockedWork: text(input.blockedWork),
+    nextStep: text(input.nextStep),
+    completionEvidence: text(input.completionEvidence),
+    workClaimRequired: booleanValue(input.workClaimRequired),
+    userMergeApprovalRequired: booleanValue(input.userMergeApprovalRequired),
   };
   const errors = [
     ...validateTextField("title", normalized.title, { required: true, singleLine: true, maxLength: 256 }),
     ...validateTextField("outcome", normalized.outcome, { required: true, maxLength: 8000 }),
-    ...validateTextField("acceptance criteria", normalized.acceptanceCriteria, { required: true, maxLength: 12000 }),
-    ...validateTextField("relevant context", normalized.relevantContext, { maxLength: 12000 }),
+    ...validateTextField("acceptance criteria", normalized.acceptanceCriteria, { required: true }),
+    ...validateTextField("relevant context", normalized.relevantContext),
+    ...validateTextField("dependencies", normalized.dependenciesText, { maxLength: 8000 }),
     ...validateTextField("protected state", normalized.protectedStateText, { maxLength: 8000 }),
   ];
+  if (typeof normalized.createdBy !== "string" || !ALLOWED_CREATORS.has(normalized.createdBy)) {
+    errors.push(`created by must be one of: ${[...ALLOWED_CREATORS].join(", ")}`);
+  }
+  if (typeof normalized.pickupTarget !== "string" || !ALLOWED_PICKUP_TARGETS.has(normalized.pickupTarget)) {
+    errors.push(`pickup target must be one of: ${[...ALLOWED_PICKUP_TARGETS].join(", ")}`);
+  }
   if (!ALLOWED_CATEGORIES.has(normalized.category)) {
     errors.push(`category must be one of: ${[...ALLOWED_CATEGORIES].join(", ")}`);
   }
@@ -179,55 +174,49 @@ function normalizeInput(input) {
   if (!ALLOWED_EXECUTION_MODES.has(normalized.executionMode)) {
     errors.push(`execution mode must be one of: ${[...ALLOWED_EXECUTION_MODES].join(", ")}`);
   }
-  for (const hit of findProhibitedDirectives([
-    normalized.title,
-    normalized.outcome,
-    normalized.acceptanceCriteria,
-    normalized.relevantContext,
-    normalized.protectedStateText,
-  ])) {
+  const targetFields = normalized.pickupTarget === "chatgpt"
+    ? [["unresolved question", "unresolvedQuestion"], ["mechanical remainder", "mechanicalRemainder"]]
+    : normalized.pickupTarget === "human"
+      ? [
+        ["human action", "humanAction"], ["agent limitation", "agentLimitation"],
+        ["required artifact", "requiredArtifact"], ["blocked work", "blockedWork"],
+        ["next step", "nextStep"], ["completion evidence", "completionEvidence"],
+      ]
+      : [];
+  for (const [label, field] of targetFields) {
+    errors.push(...validateTextField(label, normalized[field], { required: true }));
+  }
+  const allText = Object.values(normalized).filter((value) => typeof value === "string");
+  for (const value of allText) errors.push(...validateTextField("input", value));
+  for (const hit of findProhibitedDirectives(allText)) {
     errors.push(`prohibited authorization (${hit})`);
   }
   if (errors.length) throw new IntakeValidationError(errors);
+  normalized.dependencies = parseList(normalized.dependenciesText);
   normalized.protectedState = parseList(normalized.protectedStateText);
   return normalized;
 }
 
 function buildMetadata(input) {
+  const policy = PICKUP_POLICY[input.pickupTarget];
   return {
     schema: TASK_PROPERTIES.schema.const,
+    created_by: input.createdBy,
+    pickup_target: input.pickupTarget,
+    pickup_status: policy.status,
     category: input.category,
     risk: input.risk,
     execution_mode: input.executionMode,
-    dependencies: [],
+    dependencies: input.dependencies,
     protected_state: input.protectedState,
-    dispatch_status: TASK_PROPERTIES.dispatch_status.const,
-    chatgpt_routing_complete: true,
-    codex_self_screen_required: true,
-    work_claim_required: true,
-    user_merge_approval_required: true,
+    active_pickup_owner: input.pickupTarget,
+    work_claim_required: input.pickupTarget === "codex" ? true : input.workClaimRequired,
+    user_merge_approval_required: input.pickupTarget === "codex" ? true : input.userMergeApprovalRequired,
+    codex_self_screen_required: policy.codexSelfScreenRequired,
   };
 }
 
-function validateTaskMetadata(metadata) {
-  const errors = [];
-  const expectedKeys = Object.keys(TASK_PROPERTIES).sort();
-  const actualKeys = metadata && typeof metadata === "object" && !Array.isArray(metadata)
-    ? Object.keys(metadata).sort()
-    : [];
-  if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
-    errors.push("metadata keys do not match the checked-in schema");
-  }
-  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return errors;
-  for (const [name, property] of Object.entries(TASK_PROPERTIES)) {
-    const value = metadata[name];
-    if (Object.hasOwn(property, "const") && value !== property.const) {
-      errors.push(`${name} must equal ${JSON.stringify(property.const)}`);
-    }
-    if (property.enum && !property.enum.includes(value)) {
-      errors.push(`${name} must be one of: ${property.enum.join(", ")}`);
-    }
-  }
+function validateArrayFields(metadata, errors) {
   for (const name of ["dependencies", "protected_state"]) {
     const value = metadata[name];
     if (!Array.isArray(value)) {
@@ -236,35 +225,188 @@ function validateTaskMetadata(metadata) {
       errors.push(`${name} must contain unique items`);
     }
   }
-  if (Array.isArray(metadata.protected_state)) {
-    if (metadata.protected_state.some((item) => typeof item !== "string" || !item.trim())) {
-      errors.push("protected_state items must be non-empty strings");
-    }
+  if (Array.isArray(metadata.protected_state)
+      && metadata.protected_state.some((item) => typeof item !== "string" || !item.trim())) {
+    errors.push("protected_state items must be non-empty strings");
   }
-  if (Array.isArray(metadata.dependencies)) {
-    if (metadata.dependencies.some((item) => !((Number.isInteger(item) && item >= 1) || (typeof item === "string" && item.trim())))) {
-      errors.push("dependencies items must be positive integers or non-empty strings");
+  if (Array.isArray(metadata.dependencies)
+      && metadata.dependencies.some((item) => !((Number.isInteger(item) && item >= 1)
+        || (typeof item === "string" && item.trim())))) {
+    errors.push("dependencies items must be positive integers or non-empty strings");
+  }
+}
+
+function validateAgainstProperties(metadata, properties) {
+  const errors = [];
+  const expectedKeys = Object.keys(properties).sort();
+  const actualKeys = metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? Object.keys(metadata).sort() : [];
+  if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
+    errors.push("metadata keys do not match the checked-in schema");
+  }
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return errors;
+  for (const [name, property] of Object.entries(properties)) {
+    const value = metadata[name];
+    if (Object.hasOwn(property, "const") && value !== property.const) {
+      errors.push(`${name} must equal ${JSON.stringify(property.const)}`);
+    }
+    if (property.enum && !property.enum.includes(value)) {
+      errors.push(`${name} must be one of: ${property.enum.join(", ")}`);
+    }
+    if (property.type === "boolean" && typeof value !== "boolean") errors.push(`${name} must be a boolean`);
+  }
+  validateArrayFields(metadata, errors);
+  return errors;
+}
+
+function validateTaskMetadata(metadata) {
+  if (metadata?.schema === LEGACY_PROPERTIES.schema.const) {
+    return validateAgainstProperties(metadata, LEGACY_PROPERTIES);
+  }
+  const errors = validateAgainstProperties(metadata, TASK_PROPERTIES);
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return errors;
+  const target = metadata.pickup_target;
+  const policy = PICKUP_POLICY[target];
+  if (policy) {
+    const expected = {
+      pickup_status: policy.status,
+      active_pickup_owner: target,
+      codex_self_screen_required: policy.codexSelfScreenRequired,
+    };
+    if (target === "codex") {
+      expected.work_claim_required = true;
+      expected.user_merge_approval_required = true;
+    }
+    for (const [field, value] of Object.entries(expected)) {
+      if (metadata[field] !== value) errors.push(`${field} conflicts with pickup_target ${target}`);
     }
   }
   return errors;
 }
 
+function validateInterventionRecord(record) {
+  const errors = [];
+  if (!record || typeof record !== "object" || Array.isArray(record)) {
+    return ["intervention record must be an object"];
+  }
+  if (!["resolve-blocker", "takeover"].includes(record.mode)) {
+    errors.push("mode must be resolve-blocker or takeover");
+  }
+  if (!["user-directed", "blocking-active-work"].includes(record.reason)) {
+    errors.push("reason must be user-directed or blocking-active-work");
+  }
+  if (record.previous_pickup_target !== "codex") errors.push("previous pickup target must be codex");
+  if (!Array.isArray(record.active_overlaps)) errors.push("active overlaps must be an array");
+  if (record.mode === "resolve-blocker") {
+    if (!text(record.resolved_decision)) errors.push("resolved decision is required");
+    if (!text(record.remaining_codex_work)) errors.push("remaining codex work is required");
+    if (record.pickup_target_after_intervention !== "codex") errors.push("resolve-blocker must return pickup to codex");
+    if (record.active_pickup_owner !== "codex") errors.push("resolve-blocker active owner must be codex");
+  }
+  if (record.mode === "takeover") {
+    if (!text(record.scope_taken_over)) errors.push("scope taken over is required");
+    if (record.pickup_target_after_intervention !== "chatgpt") errors.push("takeover must assign pickup to chatgpt");
+    if (record.active_pickup_owner !== "chatgpt") errors.push("takeover active owner must be chatgpt");
+    const safeHandoffs = ["no-active-codex-work", "claim-released", "claim-narrowed", "disjoint-decision-only"];
+    if (!safeHandoffs.includes(record.handoff_status)) errors.push("takeover requires a valid handoff status");
+    if (Array.isArray(record.active_overlaps) && record.active_overlaps.length) {
+      errors.push("takeover must not authorize parallel edits against active overlapping Codex work");
+    }
+  }
+  return errors;
+}
+
+function validateReassignmentRecord(record) {
+  const errors = [];
+  if (!record || typeof record !== "object" || Array.isArray(record)) {
+    return ["reassignment record must be an object"];
+  }
+  for (const field of ["previous_pickup_target", "pickup_target", "active_pickup_owner"]) {
+    if (typeof record[field] !== "string" || !ALLOWED_PICKUP_TARGETS.has(record[field])) {
+      errors.push(`${field} must be one supported pickup target`);
+    }
+  }
+  if (record.previous_pickup_target === record.pickup_target) {
+    errors.push("reassignment must change the pickup target");
+  }
+  if (record.active_pickup_owner !== record.pickup_target) {
+    errors.push("active pickup owner must match the reassigned pickup target");
+  }
+  if (!text(record.reason)) errors.push("reassignment reason is required");
+  return errors;
+}
+
 function markdownList(value) {
-  return text(value)
-    .split(/\r?\n/)
-    .map((line) => line.trim().replace(/^[-*]\s+/, ""))
-    .filter(Boolean)
-    .map((line) => `- ${line}`)
-    .join("\n");
+  return text(value).split(/\r?\n/).map((line) => line.trim().replace(/^[-*]\s+/, ""))
+    .filter(Boolean).map((line) => `- ${line}`).join("\n");
 }
 
 function labelDefinitions(input) {
-  const names = ["codex-ready", `codex:${input.category}`, `risk:${input.risk}`];
+  const policy = PICKUP_POLICY[input.pickupTarget];
+  const names = [policy.status === "manual-pickup-required" ? "codex-ready" : policy.status,
+    `pickup:${input.pickupTarget}`, `task:${input.category}`, `risk:${input.risk}`];
   if (input.executionMode === "findings-only") names.push("findings-only");
   return names.map((name) => ({
     name,
-    ...(name.startsWith("codex:") ? LABEL_STYLES.category : LABEL_STYLES[name]),
+    ...(name.startsWith("pickup:") ? LABEL_STYLES.pickup
+      : name.startsWith("task:") ? LABEL_STYLES.category : LABEL_STYLES[name]),
   }));
+}
+
+function codexSections() {
+  return [
+    CANONICAL_BOOTSTRAP,
+    "",
+    "## Codex start gate",
+    "",
+    "### BEGIN NOW when all are true",
+    "",
+    "- The outcome is bounded and the specification is accepted.",
+    "- No unresolved ChatGPT or human decision blocks implementation.",
+    "- No active claim or pull request overlaps the semantic target.",
+    "",
+    "### WAIT FOR CHATGPT when any are true",
+    "",
+    "- The task is misrouted, ambiguous, policy-setting, or evidence-dependent.",
+    "- A protected decision is unresolved or live work overlaps the target.",
+    "",
+    "Before edits, post the routing result, create the semantic work claim and exact branch,",
+    "then complete one coherent pull request and stop without merging.",
+  ];
+}
+
+function targetSections(input) {
+  if (input.pickupTarget === "codex") return codexSections();
+  if (input.pickupTarget === "chatgpt") {
+    return [
+      "## ChatGPT pickup",
+      "",
+      "Do not tell Codex to claim, branch, or implement while this decision remains unresolved.",
+      "",
+      "### Exact question, decision, or review outcome",
+      "", input.unresolvedQuestion,
+      "", "### Relevant evidence, repository context, or conflicting authorities",
+      "", input.relevantContext || "No additional context provided.",
+      "", "### Bounded mechanical remainder",
+      "", input.mechanicalRemainder,
+      "", "### Human input also required",
+      "", input.humanInputRequired ? "Yes." : "No.",
+      "", "### Observable completion criteria",
+      "", markdownList(input.acceptanceCriteria),
+    ];
+  }
+  return [
+    "## Human pickup",
+    "",
+    "Agents must not simulate completion of this human action.",
+    "",
+    "### One concrete human action", "", input.humanAction,
+    "", "### Why an agent cannot perform it", "", input.agentLimitation,
+    "", "### Exact information or artifact needed", "", input.requiredArtifact,
+    "", "### Work blocked", "", input.blockedWork,
+    "", "### What happens after completion", "", input.nextStep,
+    "", "### Safe completion evidence", "", input.completionEvidence,
+  ];
 }
 
 function buildIntakeIssue(rawInput) {
@@ -272,62 +414,58 @@ function buildIntakeIssue(rawInput) {
   const metadata = buildMetadata(input);
   const metadataErrors = validateTaskMetadata(metadata);
   if (metadataErrors.length) throw new IntakeValidationError(metadataErrors);
-  const acceptance = markdownList(input.acceptanceCriteria);
-  const context = input.relevantContext || "No additional context provided.";
-  const protectedState = input.protectedState.length
-    ? input.protectedState.map((item) => `- ${item}`).join("\n")
-    : "No additional protected state declared.";
+  const commonSections = [
+    "## Outcome", "", input.outcome,
+    "", "## Acceptance criteria", "", markdownList(input.acceptanceCriteria),
+  ];
+  if (input.pickupTarget !== "chatgpt") {
+    commonSections.push("", "## Relevant context", "", input.relevantContext || "No additional context provided.");
+  }
+  commonSections.push(
+    "", "## Dependencies", "",
+    input.dependencies.length ? input.dependencies.map((item) => `- ${item}`).join("\n") : "No declared dependencies.",
+    "", "## Protected state", "",
+    input.protectedState.length ? input.protectedState.map((item) => `- ${item}`).join("\n") : "No additional protected state declared.",
+  );
   const body = [
-    CANONICAL_BOOTSTRAP,
-    "",
-    "## Outcome",
-    "",
-    input.outcome,
-    "",
-    "## Acceptance criteria",
-    "",
-    acceptance,
-    "",
-    "## Relevant context",
-    "",
-    context,
-    "",
-    "## Protected state",
-    "",
-    protectedState,
-    "",
-    "```codex-task",
-    JSON.stringify(metadata, null, 2),
-    "```",
+    ...targetSections(input), "", ...commonSections,
+    "", "```task-intake", JSON.stringify(metadata, null, 2), "```",
   ].join("\n");
   if (body.length > 60000) throw new IntakeValidationError(["generated issue body exceeds 60000 characters"]);
-  return {
-    title: input.title,
-    body,
-    metadata,
-    labels: labelDefinitions(input),
-  };
+  return { title: input.title, body, metadata, labels: labelDefinitions(input) };
 }
 
 function inputFromEnvironment(env) {
   return {
+    createdBy: env.INPUT_CREATED_BY,
+    pickupTarget: env.INPUT_PICKUP_TARGET,
     category: env.INPUT_CATEGORY,
     title: env.INPUT_TITLE,
     outcome: env.INPUT_OUTCOME,
     acceptanceCriteria: env.INPUT_ACCEPTANCE_CRITERIA,
     relevantContext: env.INPUT_RELEVANT_CONTEXT,
+    dependencies: env.INPUT_DEPENDENCIES,
     protectedState: env.INPUT_PROTECTED_STATE,
     risk: env.INPUT_RISK,
     executionMode: env.INPUT_EXECUTION_MODE,
+    unresolvedQuestion: env.INPUT_UNRESOLVED_QUESTION,
+    mechanicalRemainder: env.INPUT_MECHANICAL_REMAINDER,
+    humanInputRequired: env.INPUT_HUMAN_INPUT_REQUIRED,
+    humanAction: env.INPUT_HUMAN_ACTION,
+    agentLimitation: env.INPUT_AGENT_LIMITATION,
+    requiredArtifact: env.INPUT_REQUIRED_ARTIFACT,
+    blockedWork: env.INPUT_BLOCKED_WORK,
+    nextStep: env.INPUT_NEXT_STEP,
+    completionEvidence: env.INPUT_COMPLETION_EVIDENCE,
+    workClaimRequired: env.INPUT_WORK_CLAIM_REQUIRED,
+    userMergeApprovalRequired: env.INPUT_USER_MERGE_APPROVAL_REQUIRED,
   };
 }
 
 function findExactDuplicate(issues, intake) {
   return (issues || []).find((issue) => (
-    !issue.pull_request
-    && issue.state === "open"
-    && text(issue.title) === intake.title
-    && text(issue.body) === intake.body
+    !issue.pull_request && issue.state === "open"
+    && text(issue.title) === intake.title && text(issue.body) === intake.body
   )) || null;
 }
 
@@ -337,39 +475,31 @@ async function ensureRoutingLabels(github, repository, labels) {
     try {
       const response = await github.rest.issues.getLabel({ owner, repo, name: label.name });
       const current = response.data;
-      if (
-        String(current.color || "").toUpperCase() !== label.color.toUpperCase()
-        || String(current.description || "") !== label.description
-      ) {
+      if (String(current.color || "").toUpperCase() !== label.color.toUpperCase()
+          || String(current.description || "") !== label.description) {
         await github.rest.issues.updateLabel({
-          owner,
-          repo,
-          name: label.name,
-          new_name: label.name,
-          color: label.color,
-          description: label.description,
+          owner, repo, name: label.name, new_name: label.name,
+          color: label.color, description: label.description,
         });
       }
     } catch (error) {
       if (error.status !== 404) throw error;
-      await github.rest.issues.createLabel({
-        owner,
-        repo,
-        name: label.name,
-        color: label.color,
-        description: label.description,
-      });
+      await github.rest.issues.createLabel({ owner, repo, ...label });
     }
   }
 }
 
 module.exports = {
   ALLOWED_CATEGORIES,
+  ALLOWED_CREATORS,
+  ALLOWED_PICKUP_TARGETS,
   CANONICAL_BOOTSTRAP,
   IntakeValidationError,
   buildIntakeIssue,
   ensureRoutingLabels,
   findExactDuplicate,
   inputFromEnvironment,
+  validateInterventionRecord,
+  validateReassignmentRecord,
   validateTaskMetadata,
 };

--- a/tools/verify-coordination-system.js
+++ b/tools/verify-coordination-system.js
@@ -44,6 +44,7 @@ const requiredFiles = [
   "docs/current/USER-MERGE-REVIEW.md",
   "schemas/change-set.schema.json",
   "schemas/codex-task.schema.json",
+  "schemas/task-intake.schema.json",
   "schemas/work-claim.schema.json",
   "tools/coordination/codex-intake.js",
   "tools/coordination/change-set.js",
@@ -58,6 +59,7 @@ for (const file of [
   "config/coordination-targets.json",
   "schemas/change-set.schema.json",
   "schemas/codex-task.schema.json",
+  "schemas/task-intake.schema.json",
   "schemas/work-claim.schema.json",
 ]) {
   try {
@@ -107,6 +109,8 @@ requireText(".github/workflows/codex-intake-issue.yml", "actions/github-script@v
 requireText(".github/workflows/codex-intake-issue.yml", "inputFromEnvironment(process.env)", "untrusted input environment boundary");
 requireText(".github/workflows/codex-intake-issue.yml", "findExactDuplicate", "bounded exact duplicate check");
 requireText(".github/workflows/codex-intake-issue.yml", "ensureRoutingLabels", "idempotent routing labels");
+requireText(".github/workflows/codex-intake-issue.yml", "created_by:", "separate intake creator");
+requireText(".github/workflows/codex-intake-issue.yml", "pickup_target:", "one primary pickup target");
 forbidText(".github/workflows/codex-intake-issue.yml", "contents: write", "intake content write permission");
 forbidText(".github/workflows/codex-intake-issue.yml", "pull-requests: write", "intake PR write permission");
 forbidText(".github/workflows/codex-intake-issue.yml", "run:", "intake shell execution");
@@ -114,17 +118,36 @@ forbidText(".github/workflows/codex-intake-issue.yml", "run:", "intake shell exe
 requireText("docs/current/CODEX-ISSUE-WORKFLOW.md", "manual-issue-generator-implemented", "manual generator status");
 requireText("docs/current/CODEX-ISSUE-WORKFLOW.md", "manual-pickup-required", "truthful manual dispatch");
 requireText("docs/current/CODEX-ISSUE-WORKFLOW.md", ".github/workflows/codex-intake-issue.yml", "manual generator path");
-requireText("tools/coordination/codex-intake.js", "schemas/codex-task.schema.json", "checked-in intake schema");
+requireText("docs/current/CODEX-ISSUE-WORKFLOW.md", "chatgpt-pickup-required", "ChatGPT pickup status");
+requireText("docs/current/CODEX-ISSUE-WORKFLOW.md", "human-pickup-required", "human pickup status");
+requireText("tools/coordination/codex-intake.js", "schemas/task-intake.schema.json", "checked-in unified intake schema");
+requireText("tools/coordination/codex-intake.js", "schemas/codex-task.schema.json", "legacy intake compatibility");
+requireText("tools/coordination/codex-intake.js", "validateInterventionRecord", "ChatGPT intervention validation");
 requireText("tools/coordination/codex-intake.js", "CANONICAL_BOOTSTRAP", "canonical intake bootstrap");
 
 try {
   const codexTaskSchema = JSON.parse(read("schemas/codex-task.schema.json"));
-  const categories = codexTaskSchema?.properties?.category?.enum;
   if (codexTaskSchema?.properties?.schema?.const !== "canto-span-codex-task-v1") {
     errors.push({ type: "invalid_schema", file: "schemas/codex-task.schema.json", detail: "wrong task schema identifier" });
   }
-  if (!Array.isArray(categories) || categories.length !== 10 || new Set(categories).size !== 10) {
+  const legacyCategories = codexTaskSchema?.properties?.category?.enum;
+  if (!Array.isArray(legacyCategories) || legacyCategories.length !== 10 || new Set(legacyCategories).size !== 10) {
     errors.push({ type: "invalid_schema", file: "schemas/codex-task.schema.json", detail: "expected ten unique Codex-ready categories" });
+  }
+  const taskIntakeSchema = JSON.parse(read("schemas/task-intake.schema.json"));
+  const categories = taskIntakeSchema?.properties?.category?.enum;
+  const creators = taskIntakeSchema?.properties?.created_by?.enum;
+  const pickupTargets = taskIntakeSchema?.properties?.pickup_target?.enum;
+  if (taskIntakeSchema?.properties?.schema?.const !== "canto-span-task-intake-v1") {
+    errors.push({ type: "invalid_schema", file: "schemas/task-intake.schema.json", detail: "wrong unified intake schema identifier" });
+  }
+  for (const [field, values, expected] of [
+    ["created_by", creators, ["chatgpt", "codex", "human"]],
+    ["pickup_target", pickupTargets, ["codex", "chatgpt", "human"]],
+  ]) {
+    if (JSON.stringify(values) !== JSON.stringify(expected)) {
+      errors.push({ type: "invalid_schema", file: "schemas/task-intake.schema.json", detail: `${field} must contain exactly chatgpt, codex, and human` });
+    }
   }
   const workflow = read(".github/workflows/codex-intake-issue.yml");
   const categoryBlock = workflow.match(/      category:\n[\s\S]*?        options:\n([\s\S]*?)      title:/);
@@ -132,7 +155,17 @@ try {
     ? [...categoryBlock[1].matchAll(/^\s*-\s+([a-z][a-z-]+)\s*$/gm)].map((match) => match[1])
     : [];
   if (JSON.stringify(workflowCategories) !== JSON.stringify(categories)) {
-    errors.push({ type: "invalid_workflow", file: ".github/workflows/codex-intake-issue.yml", detail: "category choices must exactly match the checked-in task schema" });
+    errors.push({ type: "invalid_workflow", file: ".github/workflows/codex-intake-issue.yml", detail: "category choices must exactly match the unified task schema" });
+  }
+  for (const [input, expected] of [["created_by", creators], ["pickup_target", pickupTargets]]) {
+    const nextInput = input === "created_by" ? "pickup_target" : "category";
+    const block = workflow.match(new RegExp(`      ${input}:\\n[\\s\\S]*?        options:\\n([\\s\\S]*?)      ${nextInput}:`));
+    const actual = block
+      ? [...block[1].matchAll(/^\s*-\s+([a-z]+)\s*$/gm)].map((match) => match[1])
+      : [];
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+      errors.push({ type: "invalid_workflow", file: ".github/workflows/codex-intake-issue.yml", detail: `${input} choices must exactly match the unified task schema` });
+    }
   }
   if (codexTaskSchema?.properties?.dispatch_status?.const !== "manual-pickup-required") {
     errors.push({ type: "invalid_schema", file: "schemas/codex-task.schema.json", detail: "dispatch status must remain manual-pickup-required" });


### PR DESCRIPTION
<!-- coordination-claim: #54 -->

Work claim: #54

Closes #44
Closes #54

## Outcome and scope

Generalize the existing manual intake generator into one validated format for Codex, ChatGPT, or human pickup while keeping legacy `canto-span-codex-task-v1` records valid.

Changed only the claimed workflow, unified schema, generator, coordination tests/verifier, and canonical routing documentation.

## Coordination

- Work ID: `CS-WORK-0054`
- Claim mode: `exclusive`
- Integration role: `worker`
- Semantic regions: unified task-intake schema, manual intake workflow, generator validation, intervention/reassignment checks, coordination tests, routing documentation
- Dependencies: Issues #40 and #42 closed; merged intake implementation present on `main`
- Overlapping physical files with disjoint regions: none
- Pending changesets, if this PR is still a draft: none

## Canonical inputs and generated outputs

- Canonical inputs: Issue #44 accepted routing specification; current coordination and merge-review contracts
- Generated outputs: none committed; verifier snapshots were restored after validation
- Integration-owned files reconciled by the integrator: none

## Explicitly protected or unchanged

- Parser runtime and executable grammar behavior
- Construction identity, linguistic status, evidence, corpus, and survey decisions
- Releases, tags, packages, and version numbers
- `main`, merge authorization, automatic dispatch, secrets, and repository settings
- Legacy `schemas/codex-task.schema.json` contents

## Validation

Validated head: `124484cbdfd8a4f30c7f50f459269629fe70b184`

- `node --test tests/tooling/coordination/codex-intake.test.js` — PASS
- `npm run verify:coordination` — PASS
- `npm run verify` — PASS (core 14/14)
- `npm run verify:research` — PASS (research 12/12)
- `git diff --check` — PASS
- GitHub Actions — PASS, including the rerun coordination claim check

## Human merge review

- Review status: `PENDING_USER_REVIEW`
- User notified that this exact head is ready: `yes`
- Explicit approval for this pull request and exact head: `not received`

The agent must stop after notifying the user that the pull request is ready. Do not merge or enable auto-merge until the user explicitly approves this specific pull request after reviewing the ready-for-review notice. Any new commit invalidates the approval and requires a new notice and fresh approval.

## Remaining work

All required local and GitHub checks pass. Explicit user review and merge approval remain.