### PR TITLE
Generalize HKCanCor mining workbench

### DIFF
--- a/external-evidence/ab30-hkcancor/query-hkcancor-ab30-zo-r.py
+++ b/external-evidence/ab30-hkcancor/query-hkcancor-ab30-zo-r.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python3
-"""Cross-reference AB30 claims against bounded HKCanCor V-咗-POS slices.
+"""AB30 profiles for the reusable deterministic HKCanCor workbench.
 
-This is a token/POS retrieval and review-accounting tool.  It does not treat
+This is a token/POS retrieval and review-accounting tool. It does not treat
 HKCanCor annotations, token adjacency, or frequency as a gold syntactic
 analysis, a productivity result, or a readiness/status decision.
 """
 
 from __future__ import annotations
 
-import argparse
-import csv
-import hashlib
-import io
-import json
-import re
+import sys
 from collections import Counter
 from pathlib import Path
+from typing import Sequence
 
-import pycantonese
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools" / "corpus-review"))
+
+from hkcancor_workbench import (  # noqa: E402
+    Match,
+    QueryProfile,
+    WorkbenchContext,
+    profile_cli,
+)
 
 
 CONSTRUCTION = {
@@ -29,464 +34,154 @@ CONSTRUCTION = {
 R_QUERY_ID = "AB30-HKCANCOR-V-ZO-R-R2"
 M_QUERY_ID = "AB30-HKCANCOR-V-ZO-M-R1"
 LEGACY_KEOI_QUERY_ID = "AB30-HKCANCOR-V-ZO-KEOI-R1"
-PY_CANTONESE_VERSION = "5.0.0"
-CLASSIFICATIONS = {"genuine", "false_positive", "ambiguous", "unusable"}
 PRECEDING_VERBAL_POS = {"v", "v1", "xv"}
+
+
+def token_predicate(following_pos: str, query_id: str):
+    def match(tokens: Sequence[object], token_index: int) -> Match | None:
+        token = tokens[token_index]
+        if not (
+            token.word == "咗"
+            and token_index > 0
+            and token_index + 1 < len(tokens)
+            and tokens[token_index - 1].pos in PRECEDING_VERBAL_POS
+            and tokens[token_index + 1].pos == following_pos
+        ):
+            return None
+        id_namespace = (
+            LEGACY_KEOI_QUERY_ID
+            if following_pos == "r" and tokens[token_index + 1].word == "佢"
+            else query_id
+        )
+        return Match(
+            start_index=token_index - 1,
+            end_index_exclusive=token_index + 2,
+            id_token_index=token_index,
+            matched_surface="".join(
+                item.word for item in tokens[token_index - 1 : token_index + 2]
+            ),
+            id_namespace=id_namespace,
+        )
+
+    return match
+
+
+def summary_builder(following_pos: str, query_id: str):
+    def build(
+        context: WorkbenchContext, rows: list[dict[str, object]]
+    ) -> dict[str, object]:
+        corpus = context.corpus
+        verb_counts = Counter(
+            row["matchedTokens"][0]["word"]  # type: ignore[index]
+            for row in rows
+        )
+        following_counts = Counter(
+            row["matchedTokens"][2]["word"]  # type: ignore[index]
+            for row in rows
+        )
+        return {
+            "checkpoint": query_id,
+            "status": "COMPLETE_MECHANICAL_INVENTORY_REVIEW_REQUIRED",
+            "construction": CONSTRUCTION,
+            "endpoint": (
+                (
+                    "Every exact HKCanCor token matching preceding POS v, v1, or xv + "
+                    "咗 + following POS r is inventoried and must be accounted for in "
+                    "the R2 decision ledger."
+                )
+                if following_pos == "r"
+                else (
+                    "Every exact HKCanCor token matching preceding POS v, v1, or xv + "
+                    "咗 + following POS m is inventoried and must be accounted for in "
+                    "the M-R1 decision ledger."
+                )
+            ),
+            "generatedWithPycantonese": context.pycantonese_version,
+            "corpusName": "HKCanCor",
+            "corpusFilesInDistribution": corpus.n_files,
+            "corpusUtterancesInDistribution": len(corpus.utterances()),
+            "corpusWordsInDistribution": len(corpus.words()),
+            "sourceAllowlist": {
+                "path": context.source_manifest_path.as_posix(),
+                "sha256": context.source_manifest_sha256,
+                "files": corpus.n_files,
+            },
+            "query": {
+                "exactMarkerToken": "咗",
+                "precedingTokenPosAllowlist": sorted(PRECEDING_VERBAL_POS),
+                "followingTokenPos": following_pos,
+                "selectionUnit": "token adjacency within one HKCanCor utterance",
+                "parserOutputConsulted": False,
+                "semanticSelectionPerformed": False,
+            },
+            "counts": {
+                "candidateTokens": len(rows),
+                "candidateUtterances": len(
+                    {
+                        (row["sourceFile"], row["turnIndexZeroBased"])
+                        for row in rows
+                    }
+                ),
+                "sourceFilesWithCandidates": len(
+                    {row["sourceFile"] for row in rows}
+                ),
+                "precedingVerbForms": dict(sorted(verb_counts.items())),
+                "followingForms": dict(sorted(following_counts.items())),
+            },
+            "stableIdPolicy": {
+                **(
+                    {
+                        "currentNamespace": query_id,
+                        "preservedNamespaceForExactFollowing佢": LEGACY_KEOI_QUERY_ID,
+                        "reason": (
+                            "The 27 exact-佢 candidates were reviewed in R1. Their "
+                            "existing candidate IDs remain unchanged inside this "
+                            "superseding R2 ledger."
+                        ),
+                    }
+                    if following_pos == "r"
+                    else {
+                        "currentNamespace": query_id,
+                        "reason": (
+                            "The disjoint following-m profile uses its own query "
+                            "namespace and does not alter R1 or R2 candidate IDs."
+                        ),
+                    }
+                )
+            },
+            "interpretationWarning": (
+                f"The POS tags and V-咗-{following_pos} adjacency define a high-recall comparison "
+                "slice only. Expert context review must distinguish an overt object "
+                "from a following clause subject, possessive-NP onset, repair, or "
+                "other analysis. Counts do not establish productivity or readiness."
+            ),
+        }
+
+    return build
+
+
 QUERY_PROFILES = {
-    "r": {
-        "query_id": R_QUERY_ID,
-        "inventory_json": "hkcancor-ab30-zo-r-candidate-inventory.json",
-        "inventory_tsv": "hkcancor-ab30-zo-r-candidate-inventory.tsv",
-        "summary_json": "hkcancor-ab30-zo-r-query-summary.json",
-    },
-    "m": {
-        "query_id": M_QUERY_ID,
-        "inventory_json": "hkcancor-ab30-zo-m-candidate-inventory.json",
-        "inventory_tsv": "hkcancor-ab30-zo-m-candidate-inventory.tsv",
-        "summary_json": "hkcancor-ab30-zo-m-query-summary.json",
-    },
+    following_pos: QueryProfile(
+        query_id=query_id,
+        candidate_id_namespace=query_id,
+        candidate_id_prefix="ab30-",
+        inventory_json=f"hkcancor-ab30-zo-{following_pos}-candidate-inventory.json",
+        inventory_tsv=f"hkcancor-ab30-zo-{following_pos}-candidate-inventory.tsv",
+        summary_json=f"hkcancor-ab30-zo-{following_pos}-query-summary.json",
+        construction=CONSTRUCTION,
+        token_predicate=token_predicate(following_pos, query_id),
+        summary_builder=summary_builder(following_pos, query_id),
+    )
+    for following_pos, query_id in (("r", R_QUERY_ID), ("m", M_QUERY_ID))
 }
 
 
-def sha256_bytes(value: bytes) -> str:
-    return hashlib.sha256(value).hexdigest()
-
-
-def sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def text_of(utterance) -> str:
-    return "".join(token.word for token in utterance.tokens)
-
-
-def token_record(token) -> dict[str, str]:
-    return {"word": token.word, "pos": token.pos, "jyutping": token.jyutping}
-
-
-def participant_record(header, code: str) -> dict[str, object]:
-    for participant in header.participants:
-        if participant.code == code:
-            return {
-                "code": participant.code,
-                "name": participant.name,
-                "role": participant.role,
-                "language": participant.language,
-                "l1": participant.l1,
-                "sex": participant.sex,
-                "age": str(participant.age) if participant.age is not None else None,
-            }
-    return {"code": code}
-
-
-def context_record(utterances, index: int) -> dict[str, object]:
-    def one(position: int):
-        if position < 0 or position >= len(utterances):
-            return None
-        utterance = utterances[position]
-        return {
-            "turnIndexZeroBased": position,
-            "participant": utterance.participant,
-            "text": text_of(utterance),
-            "tokens": [token_record(token) for token in utterance.tokens],
-        }
-
-    return {"previous": one(index - 1), "next": one(index + 1)}
-
-
-def read_source_allowlist(path: Path) -> tuple[dict[str, str], str]:
-    entries: dict[str, str] = {}
-    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-        match = re.fullmatch(r"([0-9a-f]{64})  ([^/]+)", line)
-        if not match:
-            raise RuntimeError(
-                f"Malformed source-manifest line {line_number} in {path}"
-            )
-        digest, filename = match.groups()
-        if filename in entries:
-            raise RuntimeError(f"Duplicate source filename in {path}: {filename}")
-        entries[filename] = digest
-    return entries, sha256_file(path)
-
-
-def verify_distribution(corpus, allowlist: dict[str, str]) -> dict[str, str]:
-    source_paths = [Path(path) for path in corpus.file_paths]
-    actual_names = [path.name for path in source_paths]
-    if set(actual_names) != set(allowlist):
-        missing = sorted(set(allowlist) - set(actual_names))
-        extra = sorted(set(actual_names) - set(allowlist))
-        raise RuntimeError(
-            f"PyCantonese source distribution differs from allowlist; "
-            f"missing={missing}, extra={extra}"
-        )
-    actual_hashes = {path.name: sha256_file(path) for path in source_paths}
-    mismatches = [
-        name for name, digest in actual_hashes.items() if allowlist[name] != digest
-    ]
-    if mismatches:
-        raise RuntimeError(
-            "PyCantonese source hashes differ from allowlist: "
-            + ", ".join(sorted(mismatches))
-        )
-    return actual_hashes
-
-
-def candidate_id(
-    id_namespace: str,
-    source_file: str,
-    source_hash: str,
-    turn_index: int,
-    token_index: int,
-    matched_surface: str,
-) -> str:
-    identity = "\0".join(
-        [
-            id_namespace,
-            source_file,
-            source_hash,
-            str(turn_index),
-            str(token_index),
-            matched_surface,
-        ]
-    )
-    return "ab30-" + sha256_bytes(identity.encode("utf-8"))[:20]
-
-
-def extract_rows(
-    corpus, source_hashes: dict[str, str], following_pos: str, query_id: str
-) -> list[dict[str, object]]:
-    rows: list[dict[str, object]] = []
-    utterances_by_file = corpus.utterances(by_file=True)
-    headers = corpus.headers()
-    source_paths = [Path(path) for path in corpus.file_paths]
-
-    for file_index, utterances in enumerate(utterances_by_file):
-        source_file = source_paths[file_index].name
-        header = headers[file_index]
-        for turn_index, utterance in enumerate(utterances):
-            tokens = utterance.tokens
-            for token_index, token in enumerate(tokens):
-                if not (
-                    token.word == "咗"
-                    and token_index > 0
-                    and token_index + 1 < len(tokens)
-                    and tokens[token_index - 1].pos in PRECEDING_VERBAL_POS
-                    and tokens[token_index + 1].pos == following_pos
-                ):
-                    continue
-                id_namespace = (
-                    LEGACY_KEOI_QUERY_ID
-                    if following_pos == "r" and tokens[token_index + 1].word == "佢"
-                    else query_id
-                )
-                matched_surface = "".join(
-                    item.word for item in tokens[token_index - 1 : token_index + 2]
-                )
-                rows.append(
-                    {
-                        "candidateId": candidate_id(
-                            id_namespace,
-                            source_file,
-                            source_hashes[source_file],
-                            turn_index,
-                            token_index,
-                            matched_surface,
-                        ),
-                        "queryId": query_id,
-                        "candidateIdNamespace": id_namespace,
-                        "sourceFile": source_file,
-                        "sourceFileSha256": source_hashes[source_file],
-                        "fileIndexZeroBased": file_index,
-                        "turnIndexZeroBased": turn_index,
-                        "tokenIndexZeroBased": token_index,
-                        "recordingDate": (
-                            str(header.date) if header.date is not None else None
-                        ),
-                        "participant": utterance.participant,
-                        "participantMetadata": participant_record(
-                            header, utterance.participant
-                        ),
-                        "text": text_of(utterance),
-                        "tokens": [token_record(item) for item in tokens],
-                        "matchedSurfaceSpan": matched_surface,
-                        "matchedTokens": [
-                            token_record(item)
-                            for item in tokens[token_index - 1 : token_index + 2]
-                        ],
-                        "localContext": context_record(utterances, turn_index),
-                        "annotationStatus": "REQUIRES_EXPERT_CONTEXT_REVIEW",
-                    }
-                )
-    return rows
-
-
-def build_summary(
-    corpus,
-    rows: list[dict[str, object]],
-    source_manifest_path: Path,
-    source_manifest_sha256: str,
-    following_pos: str,
-    query_id: str,
-) -> dict[str, object]:
-    verb_counts = Counter(
-        row["matchedTokens"][0]["word"]  # type: ignore[index]
-        for row in rows
-    )
-    following_counts = Counter(
-        row["matchedTokens"][2]["word"]  # type: ignore[index]
-        for row in rows
-    )
-    return {
-        "checkpoint": query_id,
-        "status": "COMPLETE_MECHANICAL_INVENTORY_REVIEW_REQUIRED",
-        "construction": CONSTRUCTION,
-        "endpoint": (
-            (
-                "Every exact HKCanCor token matching preceding POS v, v1, or xv + "
-                "咗 + following POS r is inventoried and must be accounted for in "
-                "the R2 decision ledger."
-            )
-            if following_pos == "r"
-            else (
-                "Every exact HKCanCor token matching preceding POS v, v1, or xv + "
-                "咗 + following POS m is inventoried and must be accounted for in "
-                "the M-R1 decision ledger."
-            )
-        ),
-        "generatedWithPycantonese": pycantonese.__version__,
-        "corpusName": "HKCanCor",
-        "corpusFilesInDistribution": corpus.n_files,
-        "corpusUtterancesInDistribution": len(corpus.utterances()),
-        "corpusWordsInDistribution": len(corpus.words()),
-        "sourceAllowlist": {
-            "path": source_manifest_path.as_posix(),
-            "sha256": source_manifest_sha256,
-            "files": corpus.n_files,
-        },
-        "query": {
-            "exactMarkerToken": "咗",
-            "precedingTokenPosAllowlist": sorted(PRECEDING_VERBAL_POS),
-            "followingTokenPos": following_pos,
-            "selectionUnit": "token adjacency within one HKCanCor utterance",
-            "parserOutputConsulted": False,
-            "semanticSelectionPerformed": False,
-        },
-        "counts": {
-            "candidateTokens": len(rows),
-            "candidateUtterances": len(
-                {
-                    (row["sourceFile"], row["turnIndexZeroBased"])
-                    for row in rows
-                }
-            ),
-            "sourceFilesWithCandidates": len(
-                {row["sourceFile"] for row in rows}
-            ),
-            "precedingVerbForms": dict(sorted(verb_counts.items())),
-            "followingForms": dict(sorted(following_counts.items())),
-        },
-        "stableIdPolicy": {
-            **(
-                {
-                    "currentNamespace": query_id,
-                    "preservedNamespaceForExactFollowing佢": LEGACY_KEOI_QUERY_ID,
-                    "reason": (
-                        "The 27 exact-佢 candidates were reviewed in R1. Their "
-                        "existing candidate IDs remain unchanged inside this "
-                        "superseding R2 ledger."
-                    ),
-                }
-                if following_pos == "r"
-                else {
-                    "currentNamespace": query_id,
-                    "reason": (
-                        "The disjoint following-m profile uses its own query "
-                        "namespace and does not alter R1 or R2 candidate IDs."
-                    ),
-                }
-            )
-        },
-        "interpretationWarning": (
-            f"The POS tags and V-咗-{following_pos} adjacency define a high-recall comparison "
-            "slice only. Expert context review must distinguish an overt object "
-            "from a following clause subject, possessive-NP onset, repair, or "
-            "other analysis. Counts do not establish productivity or readiness."
-        ),
-    }
-
-
-def render_tsv(rows: list[dict[str, object]]) -> str:
-    fields = [
-        "candidate_id",
-        "source_file",
-        "source_file_sha256",
-        "file_index_zero_based",
-        "turn_index_zero_based",
-        "token_index_zero_based",
-        "participant",
-        "matched_surface_span",
-        "text",
-        "previous_text",
-        "next_text",
-        "tokens_json",
-        "annotation_status",
-    ]
-    output = io.StringIO()
-    writer = csv.DictWriter(output, fieldnames=fields, delimiter="\t", lineterminator="\n")
-    writer.writeheader()
-    for row in rows:
-        context = row["localContext"]
-        writer.writerow(
-            {
-                "candidate_id": row["candidateId"],
-                "source_file": row["sourceFile"],
-                "source_file_sha256": row["sourceFileSha256"],
-                "file_index_zero_based": row["fileIndexZeroBased"],
-                "turn_index_zero_based": row["turnIndexZeroBased"],
-                "token_index_zero_based": row["tokenIndexZeroBased"],
-                "participant": row["participant"],
-                "matched_surface_span": row["matchedSurfaceSpan"],
-                "text": row["text"],
-                "previous_text": (
-                    context["previous"]["text"] if context["previous"] else ""
-                ),
-                "next_text": context["next"]["text"] if context["next"] else "",
-                "tokens_json": json.dumps(
-                    row["tokens"], ensure_ascii=False, separators=(",", ":")
-                ),
-                "annotation_status": row["annotationStatus"],
-            }
-        )
-    return output.getvalue()
-
-
-def rendered_outputs(
-    summary: dict[str, object],
-    rows: list[dict[str, object]],
-    profile: dict[str, str],
-) -> dict[str, str]:
-    return {
-        profile["inventory_json"]: json.dumps(
-            {"summary": summary, "candidates": rows},
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        profile["inventory_tsv"]: render_tsv(rows),
-        profile["summary_json"]: json.dumps(summary, ensure_ascii=False, indent=2) + "\n",
-    }
-
-
-def validate_decisions(
-    path: Path, rows: list[dict[str, object]], query_id: str
-) -> None:
-    ledger = json.loads(path.read_text(encoding="utf-8"))
-    if ledger.get("schema") != "canto-span-corpus-claim-cross-reference-decisions-v1":
-        raise RuntimeError("Decision ledger has an unsupported schema")
-    if ledger.get("construction") != CONSTRUCTION:
-        raise RuntimeError("Decision ledger construction identity does not match AB30")
-    if ledger.get("queryId") != query_id:
-        raise RuntimeError("Decision ledger queryId does not match this query")
-
-    expected = {row["candidateId"]: row for row in rows}
-    decisions = ledger.get("decisions")
-    if not isinstance(decisions, list):
-        raise RuntimeError("Decision ledger decisions must be an array")
-    actual: dict[str, dict[str, object]] = {}
-    counts: Counter[str] = Counter()
-    for decision in decisions:
-        candidate = expected.get(decision.get("candidateId"))
-        if candidate is None:
-            raise RuntimeError(
-                f"Decision references an unknown candidate: {decision.get('candidateId')}"
-            )
-        candidate_key = str(decision["candidateId"])
-        if candidate_key in actual:
-            raise RuntimeError(f"Duplicate decision for {candidate_key}")
-        if decision.get("matchedSurfaceSpan") != candidate["matchedSurfaceSpan"]:
-            raise RuntimeError(f"Decision span mismatch for {candidate_key}")
-        classification = decision.get("classification")
-        if classification not in CLASSIFICATIONS:
-            raise RuntimeError(f"Invalid classification for {candidate_key}")
-        if not isinstance(decision.get("reviewerNote"), str) or not decision["reviewerNote"]:
-            raise RuntimeError(f"Decision requires reviewerNote for {candidate_key}")
-        if not isinstance(decision.get("exclusionReason"), str):
-            raise RuntimeError(f"Decision requires exclusionReason for {candidate_key}")
-        relations = decision.get("claimRelations")
-        if not isinstance(relations, list) or not relations:
-            raise RuntimeError(f"Decision requires claimRelations for {candidate_key}")
-        actual[candidate_key] = decision
-        counts[classification] += 1
-
-    if set(actual) != set(expected):
-        missing = sorted(set(expected) - set(actual))
-        raise RuntimeError(f"Decision ledger does not account for candidates: {missing}")
-    expected_counts = {name: counts.get(name, 0) for name in sorted(CLASSIFICATIONS)}
-    if ledger.get("counts") != expected_counts:
-        raise RuntimeError(
-            f"Decision ledger counts differ; expected {expected_counts}"
-        )
-    if ledger.get("packetStatus") != "complete":
-        raise RuntimeError("Decision ledger packetStatus must be complete")
-
-
 def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--output-dir", type=Path, required=True)
-    parser.add_argument("--source-manifest", type=Path, required=True)
-    parser.add_argument("--decisions", type=Path)
-    parser.add_argument(
-        "--following-pos", choices=sorted(QUERY_PROFILES), default="r"
+    profile_cli(
+        QUERY_PROFILES,
+        profile_argument="--following-pos",
+        description="Generate or check deterministic AB30 HKCanCor query slices.",
     )
-    parser.add_argument("--check", action="store_true")
-    args = parser.parse_args()
-
-    profile = QUERY_PROFILES[args.following_pos]
-    query_id = profile["query_id"]
-
-    if pycantonese.__version__ != PY_CANTONESE_VERSION:
-        raise RuntimeError(
-            f"{query_id} is frozen to PyCantonese {PY_CANTONESE_VERSION}; "
-            f"got {pycantonese.__version__}"
-        )
-
-    allowlist, source_manifest_sha256 = read_source_allowlist(args.source_manifest)
-    corpus = pycantonese.hkcancor()
-    source_hashes = verify_distribution(corpus, allowlist)
-    rows = extract_rows(corpus, source_hashes, args.following_pos, query_id)
-    summary = build_summary(
-        corpus,
-        rows,
-        args.source_manifest,
-        source_manifest_sha256,
-        args.following_pos,
-        query_id,
-    )
-    outputs = rendered_outputs(summary, rows, profile)
-
-    if args.check:
-        for filename, expected in outputs.items():
-            path = args.output_dir / filename
-            if not path.exists() or path.read_text(encoding="utf-8") != expected:
-                raise RuntimeError(f"Generated output is stale: {path}")
-    else:
-        args.output_dir.mkdir(parents=True, exist_ok=True)
-        for filename, value in outputs.items():
-            (args.output_dir / filename).write_text(value, encoding="utf-8")
-
-    if args.decisions:
-        validate_decisions(args.decisions, rows, query_id)
-
-    print(
-        f"{query_id}: {len(rows)} candidates; "
-        f"{'checked' if args.check else 'generated'} deterministic outputs."
-    )
-    if args.decisions:
-        print(f"Validated complete decisions: {args.decisions}")
 
 
 if __name__ == "__main__":

--- a/tests/tooling/corpus-review/test_hkcancor_workbench.py
+++ b/tests/tooling/corpus-review/test_hkcancor_workbench.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "tools" / "corpus-review" / "hkcancor_workbench.py"
+sys.path.insert(0, str(MODULE_PATH.parent))
+import hkcancor_workbench as workbench
+
+
+@dataclass
+class Token:
+    word: str
+    pos: str
+    jyutping: str
+
+
+@dataclass
+class Participant:
+    code: str = "A"
+    name: str = "Speaker"
+    role: str = "Target_Child"
+    language: str = "yue"
+    l1: str = "yue"
+    sex: str = "female"
+    age: int = 5
+
+
+@dataclass
+class Header:
+    date: str = "1998-01-01"
+    participants: tuple[Participant, ...] = field(
+        default_factory=lambda: (Participant(),)
+    )
+
+
+@dataclass
+class Utterance:
+    tokens: list[Token]
+    participant: str = "A"
+
+
+class Corpus:
+    def __init__(self, file_paths: list[Path], utterances: list[list[Utterance]]):
+        self.file_paths = [str(path) for path in file_paths]
+        self._utterances = utterances
+        self.n_files = len(file_paths)
+
+    def utterances(self, by_file: bool = False):
+        if by_file:
+            return self._utterances
+        return [utterance for source in self._utterances for utterance in source]
+
+    def headers(self):
+        return [Header() for _path in self.file_paths]
+
+    def words(self):
+        return [
+            token.word
+            for utterance in self.utterances()
+            for token in utterance.tokens
+        ]
+
+
+def profile():
+    def predicate(tokens, index):
+        if tokens[index].word != "中":
+            return None
+        return workbench.Match(
+            start_index=index,
+            end_index_exclusive=index + 1,
+            id_token_index=index,
+            matched_surface=tokens[index].word,
+            duplicate_group_inputs={"normalizedSurface": tokens[index].word},
+        )
+
+    def summary(context, rows):
+        return {
+            "queryId": "TEST-HKCANCOR-R1",
+            "sourceManifestSha256": context.source_manifest_sha256,
+            "candidateTokens": len(rows),
+        }
+
+    return workbench.QueryProfile(
+        query_id="TEST-HKCANCOR-R1",
+        candidate_id_namespace="TEST-HKCANCOR-R1",
+        candidate_id_prefix="test-",
+        inventory_json="inventory.json",
+        inventory_tsv="inventory.tsv",
+        summary_json="summary.json",
+        construction={"permanentCode": "TEST"},
+        token_predicate=predicate,
+        summary_builder=summary,
+        context_before_tokens=1,
+        context_after_tokens=1,
+    )
+
+
+class HkcancorWorkbenchTests(unittest.TestCase):
+    def test_source_manifest_and_distribution_reject_drift(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source.cha"
+            source.write_text("original", encoding="utf-8")
+            digest = workbench.sha256_file(source)
+            manifest = root / "manifest.sha256"
+            manifest.write_text(f"{digest}  source.cha\n", encoding="utf-8")
+
+            allowlist, manifest_digest = workbench.read_source_allowlist(manifest)
+            self.assertEqual(allowlist, {"source.cha": digest})
+            self.assertEqual(manifest_digest, workbench.sha256_file(manifest))
+            corpus = Corpus([source], [[]])
+            self.assertEqual(
+                workbench.verify_distribution(corpus, allowlist),
+                {"source.cha": digest},
+            )
+
+            source.write_text("changed", encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeError, "source hashes differ"):
+                workbench.verify_distribution(corpus, allowlist)
+
+    def test_stable_ids_context_and_deterministic_rendering(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "source.cha"
+            source.write_text("source", encoding="utf-8")
+            source_hash = workbench.sha256_file(source)
+            manifest = root / "manifest.sha256"
+            manifest.write_text(f"{source_hash}  source.cha\n", encoding="utf-8")
+            corpus = Corpus(
+                [source],
+                [[
+                    Utterance(
+                        [
+                            Token("前", "n", "cin4"),
+                            Token("中", "v", "zung1"),
+                            Token("後", "n", "hau6"),
+                        ]
+                    )
+                ]],
+            )
+            context = workbench.WorkbenchContext(
+                corpus=corpus,
+                source_manifest_path=manifest,
+                source_manifest_sha256=workbench.sha256_file(manifest),
+                source_hashes={"source.cha": source_hash},
+                pycantonese_version="5.0.0",
+            )
+            query = profile()
+            first = workbench.extract_candidates(context, query)
+            second = workbench.extract_candidates(context, query)
+            self.assertEqual(first, second)
+            self.assertEqual(first[0]["candidateId"], second[0]["candidateId"])
+            self.assertEqual(
+                first[0]["tokenContext"]["tokens"],
+                [
+                    {"word": "前", "pos": "n", "jyutping": "cin4"},
+                    {"word": "中", "pos": "v", "jyutping": "zung1"},
+                    {"word": "後", "pos": "n", "jyutping": "hau6"},
+                ],
+            )
+            self.assertEqual(
+                first[0]["duplicateGroupInputs"],
+                {"normalizedSurface": "中"},
+            )
+
+            summary = query.summary_builder(context, first)
+            outputs = workbench.rendered_outputs(query, summary, first)
+            output_dir = root / "outputs"
+            workbench.check_or_write_outputs(output_dir, outputs, check=False)
+            workbench.check_or_write_outputs(output_dir, outputs, check=True)
+            (output_dir / "summary.json").write_text("stale\n", encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeError, "Generated output is stale"):
+                workbench.check_or_write_outputs(output_dir, outputs, check=True)
+
+    def test_complete_decision_accounting(self):
+        rows = [
+            {"candidateId": "test-a", "matchedSurfaceSpan": "甲"},
+            {"candidateId": "test-b", "matchedSurfaceSpan": "乙"},
+        ]
+        decisions = [
+            {
+                "candidateId": "test-a",
+                "matchedSurfaceSpan": "甲",
+                "classification": "genuine",
+                "reviewerNote": "Reviewed in context.",
+                "exclusionReason": "",
+                "claimRelations": ["direct_candidate"],
+            },
+            {
+                "candidateId": "test-b",
+                "matchedSurfaceSpan": "乙",
+                "classification": "false_positive",
+                "reviewerNote": "Different construction.",
+                "exclusionReason": "boundary",
+                "claimRelations": ["boundary_candidate"],
+            },
+        ]
+        ledger = {
+            "schema": "canto-span-corpus-claim-cross-reference-decisions-v1",
+            "construction": {"permanentCode": "TEST"},
+            "queryId": "TEST-HKCANCOR-R1",
+            "counts": {
+                "ambiguous": 0,
+                "false_positive": 1,
+                "genuine": 1,
+                "unusable": 0,
+            },
+            "packetStatus": "complete",
+            "decisions": decisions,
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "decisions.json"
+            path.write_text(json.dumps(ledger), encoding="utf-8")
+            workbench.validate_decisions(
+                path,
+                rows,
+                query_id="TEST-HKCANCOR-R1",
+                construction={"permanentCode": "TEST"},
+            )
+
+            ledger["decisions"] = decisions[:1]
+            path.write_text(json.dumps(ledger), encoding="utf-8")
+            with self.assertRaisesRegex(
+                RuntimeError, "does not account for candidates"
+            ):
+                workbench.validate_decisions(
+                    path,
+                    rows,
+                    query_id="TEST-HKCANCOR-R1",
+                    construction={"permanentCode": "TEST"},
+                )
+
+    def test_rejects_pycantonese_version_drift_before_loading_corpus(self):
+        class WrongVersion:
+            __version__ = "5.0.1"
+
+            @staticmethod
+            def hkcancor():
+                raise AssertionError("version drift must stop before corpus loading")
+
+        with self.assertRaisesRegex(RuntimeError, "frozen to PyCantonese 5.0.0"):
+            workbench.load_verified_hkcancor(
+                Path("unused-manifest"),
+                pycantonese_module=WrongVersion,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/corpus-review/README.md
+++ b/tools/corpus-review/README.md
@@ -84,3 +84,63 @@ editor, then validated and rendered.
 Rerunning extraction does not determine whether any candidate is genuine, does
 not transfer evidence to a related construction, and does not complete the
 AB30 corpus gate.
+
+## Reusable HKCanCor query workbench
+
+`hkcancor_workbench.py` is the shared deterministic engine for bounded
+PyCantonese/HKCanCor query profiles. It is part of this corpus-review architecture;
+construction-specific scripts define profiles and import the engine instead of
+copying distribution verification, candidate provenance, output handling, or
+decision-ledger validation.
+
+Each `QueryProfile` defines:
+
+- one query ID and stable candidate-ID namespace/prefix;
+- a token predicate returning the exact matched span and ID anchor;
+- preceding/following token-context sizes;
+- JSON inventory, TSV inventory, and JSON summary filenames;
+- the permanent construction identity;
+- a summary builder for query-specific fields;
+- an optional TSV renderer when the standard provenance columns are insufficient.
+
+The engine loads PyCantonese lazily, requires the profile's frozen version
+(`5.0.0` by default), verifies every HKCanCor source file against the one checked-in
+SHA-256 allowlist, and rejects missing, extra, duplicate-named, or hash-drifted
+files. Candidate records retain their stable ID, query namespace, exact text and
+matched span, token/POS/Jyutping data, source file/hash, file/turn/token location,
+participant metadata, previous/next utterance context, optional token context and
+profile fields, and `REQUIRES_EXPERT_CONTEXT_REVIEW`.
+
+Profiles call `profile_cli(...)` to expose the common `--output-dir`,
+`--source-manifest`, optional `--decisions`, and `--check` interface. `--check`
+renders in memory and fails if any committed output is missing or stale. Optional
+decision validation requires complete one-to-one candidate accounting, a nonblank
+review note, an exclusion-reason string, at least one claim relation, canonical
+classification counts, and one of `genuine`, `false_positive`, `ambiguous`, or
+`unusable`.
+
+The existing AB30 `r` and `m` profiles use the shared engine without changing their
+commands or outputs:
+
+```bash
+python external-evidence/ab30-hkcancor/query-hkcancor-ab30-zo-r.py \
+  --following-pos r \
+  --output-dir external-evidence/ab30-hkcancor \
+  --source-manifest \
+    external-evidence/cp021b/hkcancor-cp021b-source-manifest.sha256 \
+  --check
+
+python external-evidence/ab30-hkcancor/query-hkcancor-ab30-zo-r.py \
+  --following-pos m \
+  --output-dir external-evidence/ab30-hkcancor \
+  --source-manifest \
+    external-evidence/cp021b/hkcancor-cp021b-source-manifest.sha256 \
+  --check
+
+python -m unittest \
+  tests/tooling/corpus-review/test_hkcancor_workbench.py
+```
+
+Query results remain mechanical candidate inventories. A profile, candidate count,
+POS mapping, or successful check does not classify construction membership or
+change evidence, readiness, status, identity, runtime, or release state.

--- a/tools/corpus-review/hkcancor_workbench.py
+++ b/tools/corpus-review/hkcancor_workbench.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python3
+"""Reusable deterministic HKCanCor extraction and review-accounting workbench."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import importlib
+import io
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+
+CLASSIFICATIONS = frozenset(
+    {"genuine", "false_positive", "ambiguous", "unusable"}
+)
+ANNOTATION_STATUS = "REQUIRES_EXPERT_CONTEXT_REVIEW"
+
+
+@dataclass(frozen=True)
+class Match:
+    """One profile match inside an utterance."""
+
+    start_index: int
+    end_index_exclusive: int
+    id_token_index: int
+    matched_surface: str
+    id_namespace: str | None = None
+    dedupe_key: str | None = None
+    duplicate_group_inputs: Mapping[str, object] | None = None
+    extra_fields: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WorkbenchContext:
+    corpus: Any
+    source_manifest_path: Path
+    source_manifest_sha256: str
+    source_hashes: Mapping[str, str]
+    pycantonese_version: str
+
+
+TokenPredicate = Callable[[Sequence[Any], int], Match | None]
+SummaryBuilder = Callable[[WorkbenchContext, list[dict[str, object]]], dict[str, object]]
+TsvRenderer = Callable[[list[dict[str, object]]], str]
+
+
+@dataclass(frozen=True)
+class QueryProfile:
+    """Construction-specific configuration for the shared workbench."""
+
+    query_id: str
+    candidate_id_namespace: str
+    candidate_id_prefix: str
+    inventory_json: str
+    inventory_tsv: str
+    summary_json: str
+    construction: Mapping[str, object]
+    token_predicate: TokenPredicate
+    summary_builder: SummaryBuilder
+    context_before_tokens: int = 0
+    context_after_tokens: int = 0
+    tsv_renderer: TsvRenderer | None = None
+
+    def __post_init__(self) -> None:
+        for name in (
+            "query_id",
+            "candidate_id_namespace",
+            "candidate_id_prefix",
+            "inventory_json",
+            "inventory_tsv",
+            "summary_json",
+        ):
+            if not getattr(self, name):
+                raise ValueError(f"{name} must not be empty")
+        if self.context_before_tokens < 0 or self.context_after_tokens < 0:
+            raise ValueError("token context sizes must be non-negative")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def text_of(utterance: Any) -> str:
+    return "".join(token.word for token in utterance.tokens)
+
+
+def token_record(token: Any) -> dict[str, str]:
+    return {"word": token.word, "pos": token.pos, "jyutping": token.jyutping}
+
+
+def participant_record(header: Any, code: str) -> dict[str, object]:
+    for participant in header.participants:
+        if participant.code == code:
+            return {
+                "code": participant.code,
+                "name": participant.name,
+                "role": participant.role,
+                "language": participant.language,
+                "l1": participant.l1,
+                "sex": participant.sex,
+                "age": str(participant.age) if participant.age is not None else None,
+            }
+    return {"code": code}
+
+
+def utterance_context(utterances: Sequence[Any], index: int) -> dict[str, object]:
+    def one(position: int) -> dict[str, object] | None:
+        if position < 0 or position >= len(utterances):
+            return None
+        utterance = utterances[position]
+        return {
+            "turnIndexZeroBased": position,
+            "participant": utterance.participant,
+            "text": text_of(utterance),
+            "tokens": [token_record(token) for token in utterance.tokens],
+        }
+
+    return {"previous": one(index - 1), "next": one(index + 1)}
+
+
+def token_context(
+    tokens: Sequence[Any],
+    match: Match,
+    before: int,
+    after: int,
+) -> dict[str, object]:
+    start = max(0, match.start_index - before)
+    end = min(len(tokens), match.end_index_exclusive + after)
+    return {
+        "startTokenIndexZeroBased": start,
+        "endTokenIndexExclusive": end,
+        "tokens": [token_record(token) for token in tokens[start:end]],
+    }
+
+
+def read_source_allowlist(path: Path) -> tuple[dict[str, str], str]:
+    entries: dict[str, str] = {}
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        match = re.fullmatch(r"([0-9a-f]{64})  ([^/]+)", line)
+        if not match:
+            raise RuntimeError(
+                f"Malformed source-manifest line {line_number} in {path}"
+            )
+        digest, filename = match.groups()
+        if filename in entries:
+            raise RuntimeError(f"Duplicate source filename in {path}: {filename}")
+        entries[filename] = digest
+    return entries, sha256_file(path)
+
+
+def verify_distribution(
+    corpus: Any, allowlist: Mapping[str, str]
+) -> dict[str, str]:
+    source_paths = [Path(path) for path in corpus.file_paths]
+    actual_names = [path.name for path in source_paths]
+    if len(actual_names) != len(set(actual_names)):
+        raise RuntimeError("PyCantonese distribution contains duplicate filenames")
+    if set(actual_names) != set(allowlist):
+        missing = sorted(set(allowlist) - set(actual_names))
+        extra = sorted(set(actual_names) - set(allowlist))
+        raise RuntimeError(
+            "PyCantonese source distribution differs from allowlist; "
+            f"missing={missing}, extra={extra}"
+        )
+    actual_hashes = {path.name: sha256_file(path) for path in source_paths}
+    mismatches = [
+        name for name, digest in actual_hashes.items() if allowlist[name] != digest
+    ]
+    if mismatches:
+        raise RuntimeError(
+            "PyCantonese source hashes differ from allowlist: "
+            + ", ".join(sorted(mismatches))
+        )
+    return actual_hashes
+
+
+def load_verified_hkcancor(
+    source_manifest_path: Path,
+    *,
+    expected_pycantonese_version: str = "5.0.0",
+    pycantonese_module: Any | None = None,
+) -> WorkbenchContext:
+    module = pycantonese_module or importlib.import_module("pycantonese")
+    if module.__version__ != expected_pycantonese_version:
+        raise RuntimeError(
+            "HKCanCor workbench is frozen to PyCantonese "
+            f"{expected_pycantonese_version}; got {module.__version__}"
+        )
+    allowlist, manifest_sha256 = read_source_allowlist(source_manifest_path)
+    corpus = module.hkcancor()
+    source_hashes = verify_distribution(corpus, allowlist)
+    return WorkbenchContext(
+        corpus=corpus,
+        source_manifest_path=source_manifest_path,
+        source_manifest_sha256=manifest_sha256,
+        source_hashes=source_hashes,
+        pycantonese_version=module.__version__,
+    )
+
+
+def candidate_id(
+    *,
+    prefix: str,
+    namespace: str,
+    source_file: str,
+    source_hash: str,
+    turn_index: int,
+    token_index: int,
+    matched_surface: str,
+) -> str:
+    identity = "\0".join(
+        [
+            namespace,
+            source_file,
+            source_hash,
+            str(turn_index),
+            str(token_index),
+            matched_surface,
+        ]
+    )
+    return prefix + sha256_bytes(identity.encode("utf-8"))[:20]
+
+
+def extract_candidates(
+    context: WorkbenchContext, profile: QueryProfile
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    candidate_ids: set[str] = set()
+    corpus = context.corpus
+    utterances_by_file = corpus.utterances(by_file=True)
+    headers = corpus.headers()
+    source_paths = [Path(path) for path in corpus.file_paths]
+
+    for file_index, utterances in enumerate(utterances_by_file):
+        source_file = source_paths[file_index].name
+        header = headers[file_index]
+        for turn_index, utterance in enumerate(utterances):
+            tokens = utterance.tokens
+            seen_match_keys: set[str] = set()
+            for token_index, _token in enumerate(tokens):
+                match = profile.token_predicate(tokens, token_index)
+                if match is None:
+                    continue
+                if not (
+                    0 <= match.start_index < match.end_index_exclusive <= len(tokens)
+                ):
+                    raise RuntimeError(
+                        f"{profile.query_id} produced an invalid token span"
+                    )
+                if not 0 <= match.id_token_index < len(tokens):
+                    raise RuntimeError(
+                        f"{profile.query_id} produced an invalid ID token index"
+                    )
+                if match.dedupe_key is not None:
+                    if match.dedupe_key in seen_match_keys:
+                        continue
+                    seen_match_keys.add(match.dedupe_key)
+                namespace = match.id_namespace or profile.candidate_id_namespace
+                row: dict[str, object] = {
+                    "candidateId": candidate_id(
+                        prefix=profile.candidate_id_prefix,
+                        namespace=namespace,
+                        source_file=source_file,
+                        source_hash=context.source_hashes[source_file],
+                        turn_index=turn_index,
+                        token_index=match.id_token_index,
+                        matched_surface=match.matched_surface,
+                    ),
+                    "queryId": profile.query_id,
+                    "candidateIdNamespace": namespace,
+                    "sourceFile": source_file,
+                    "sourceFileSha256": context.source_hashes[source_file],
+                    "fileIndexZeroBased": file_index,
+                    "turnIndexZeroBased": turn_index,
+                    "tokenIndexZeroBased": match.id_token_index,
+                    "recordingDate": (
+                        str(header.date) if header.date is not None else None
+                    ),
+                    "participant": utterance.participant,
+                    "participantMetadata": participant_record(
+                        header, utterance.participant
+                    ),
+                    "text": text_of(utterance),
+                    "tokens": [token_record(item) for item in tokens],
+                    "matchedSurfaceSpan": match.matched_surface,
+                    "matchedTokens": [
+                        token_record(item)
+                        for item in tokens[
+                            match.start_index : match.end_index_exclusive
+                        ]
+                    ],
+                    "localContext": utterance_context(utterances, turn_index),
+                    "annotationStatus": ANNOTATION_STATUS,
+                }
+                if profile.context_before_tokens or profile.context_after_tokens:
+                    row["tokenContext"] = token_context(
+                        tokens,
+                        match,
+                        profile.context_before_tokens,
+                        profile.context_after_tokens,
+                    )
+                if match.duplicate_group_inputs is not None:
+                    row["duplicateGroupInputs"] = dict(match.duplicate_group_inputs)
+                reserved_overrides = sorted(set(row).intersection(match.extra_fields))
+                if reserved_overrides:
+                    raise RuntimeError(
+                        f"{profile.query_id} profile fields override canonical fields: "
+                        + ", ".join(reserved_overrides)
+                    )
+                row.update(match.extra_fields)
+                candidate_key = str(row["candidateId"])
+                if candidate_key in candidate_ids:
+                    raise RuntimeError(
+                        f"{profile.query_id} produced duplicate candidate ID "
+                        f"{candidate_key}; define a dedupe key or distinct ID anchor"
+                    )
+                candidate_ids.add(candidate_key)
+                rows.append(row)
+    return rows
+
+
+def render_default_tsv(rows: list[dict[str, object]]) -> str:
+    fields = [
+        "candidate_id",
+        "source_file",
+        "source_file_sha256",
+        "file_index_zero_based",
+        "turn_index_zero_based",
+        "token_index_zero_based",
+        "participant",
+        "matched_surface_span",
+        "text",
+        "previous_text",
+        "next_text",
+        "tokens_json",
+        "annotation_status",
+    ]
+    output = io.StringIO()
+    writer = csv.DictWriter(
+        output, fieldnames=fields, delimiter="\t", lineterminator="\n"
+    )
+    writer.writeheader()
+    for row in rows:
+        context = row["localContext"]
+        writer.writerow(
+            {
+                "candidate_id": row["candidateId"],
+                "source_file": row["sourceFile"],
+                "source_file_sha256": row["sourceFileSha256"],
+                "file_index_zero_based": row["fileIndexZeroBased"],
+                "turn_index_zero_based": row["turnIndexZeroBased"],
+                "token_index_zero_based": row["tokenIndexZeroBased"],
+                "participant": row["participant"],
+                "matched_surface_span": row["matchedSurfaceSpan"],
+                "text": row["text"],
+                "previous_text": (
+                    context["previous"]["text"] if context["previous"] else ""
+                ),
+                "next_text": context["next"]["text"] if context["next"] else "",
+                "tokens_json": json.dumps(
+                    row["tokens"], ensure_ascii=False, separators=(",", ":")
+                ),
+                "annotation_status": row["annotationStatus"],
+            }
+        )
+    return output.getvalue()
+
+
+def rendered_outputs(
+    profile: QueryProfile,
+    summary: dict[str, object],
+    rows: list[dict[str, object]],
+) -> dict[str, str]:
+    tsv_renderer = profile.tsv_renderer or render_default_tsv
+    return {
+        profile.inventory_json: json.dumps(
+            {"summary": summary, "candidates": rows},
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        profile.inventory_tsv: tsv_renderer(rows),
+        profile.summary_json: json.dumps(summary, ensure_ascii=False, indent=2)
+        + "\n",
+    }
+
+
+def check_or_write_outputs(
+    output_dir: Path, outputs: Mapping[str, str], *, check: bool
+) -> None:
+    if check:
+        for filename, expected in outputs.items():
+            path = output_dir / filename
+            if not path.exists() or path.read_text(encoding="utf-8") != expected:
+                raise RuntimeError(f"Generated output is stale: {path}")
+        return
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for filename, value in outputs.items():
+        (output_dir / filename).write_text(value, encoding="utf-8")
+
+
+def validate_decisions(
+    path: Path,
+    rows: list[dict[str, object]],
+    *,
+    query_id: str,
+    construction: Mapping[str, object],
+) -> None:
+    ledger = json.loads(path.read_text(encoding="utf-8"))
+    if ledger.get("schema") != "canto-span-corpus-claim-cross-reference-decisions-v1":
+        raise RuntimeError("Decision ledger has an unsupported schema")
+    if ledger.get("construction") != construction:
+        raise RuntimeError("Decision ledger construction identity does not match")
+    if ledger.get("queryId") != query_id:
+        raise RuntimeError("Decision ledger queryId does not match this query")
+
+    expected = {row["candidateId"]: row for row in rows}
+    decisions = ledger.get("decisions")
+    if not isinstance(decisions, list):
+        raise RuntimeError("Decision ledger decisions must be an array")
+    actual: dict[str, dict[str, object]] = {}
+    counts: dict[str, int] = {name: 0 for name in sorted(CLASSIFICATIONS)}
+    for decision in decisions:
+        if not isinstance(decision, dict):
+            raise RuntimeError("Decision ledger entries must be objects")
+        candidate = expected.get(decision.get("candidateId"))
+        if candidate is None:
+            raise RuntimeError(
+                f"Decision references an unknown candidate: {decision.get('candidateId')}"
+            )
+        candidate_key = str(decision["candidateId"])
+        if candidate_key in actual:
+            raise RuntimeError(f"Duplicate decision for {candidate_key}")
+        if decision.get("matchedSurfaceSpan") != candidate["matchedSurfaceSpan"]:
+            raise RuntimeError(f"Decision span mismatch for {candidate_key}")
+        classification = decision.get("classification")
+        if classification not in CLASSIFICATIONS:
+            raise RuntimeError(f"Invalid classification for {candidate_key}")
+        if (
+            not isinstance(decision.get("reviewerNote"), str)
+            or not decision["reviewerNote"]
+        ):
+            raise RuntimeError(f"Decision requires reviewerNote for {candidate_key}")
+        if not isinstance(decision.get("exclusionReason"), str):
+            raise RuntimeError(
+                f"Decision requires exclusionReason for {candidate_key}"
+            )
+        relations = decision.get("claimRelations")
+        if not isinstance(relations, list) or not relations:
+            raise RuntimeError(
+                f"Decision requires claimRelations for {candidate_key}"
+            )
+        actual[candidate_key] = decision
+        counts[str(classification)] += 1
+
+    if set(actual) != set(expected):
+        missing = sorted(set(expected) - set(actual))
+        raise RuntimeError(f"Decision ledger does not account for candidates: {missing}")
+    if ledger.get("counts") != counts:
+        raise RuntimeError(f"Decision ledger counts differ; expected {counts}")
+    if ledger.get("packetStatus") != "complete":
+        raise RuntimeError("Decision ledger packetStatus must be complete")
+
+
+def execute_profile(
+    profile: QueryProfile,
+    *,
+    output_dir: Path,
+    source_manifest: Path,
+    decisions: Path | None = None,
+    check: bool = False,
+    expected_pycantonese_version: str = "5.0.0",
+    pycantonese_module: Any | None = None,
+) -> tuple[WorkbenchContext, list[dict[str, object]], dict[str, object]]:
+    context = load_verified_hkcancor(
+        source_manifest,
+        expected_pycantonese_version=expected_pycantonese_version,
+        pycantonese_module=pycantonese_module,
+    )
+    rows = extract_candidates(context, profile)
+    summary = profile.summary_builder(context, rows)
+    outputs = rendered_outputs(profile, summary, rows)
+    check_or_write_outputs(output_dir, outputs, check=check)
+    if decisions:
+        validate_decisions(
+            decisions,
+            rows,
+            query_id=profile.query_id,
+            construction=profile.construction,
+        )
+    return context, rows, summary
+
+
+def profile_cli(
+    profiles: Mapping[str, QueryProfile],
+    *,
+    profile_argument: str,
+    description: str,
+    argv: Sequence[str] | None = None,
+) -> None:
+    if not profiles:
+        raise ValueError("at least one query profile is required")
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--source-manifest", type=Path, required=True)
+    parser.add_argument("--decisions", type=Path)
+    parser.add_argument(
+        profile_argument,
+        choices=sorted(profiles),
+        default=next(iter(profiles)),
+    )
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args(argv)
+    profile_key = getattr(args, profile_argument.lstrip("-").replace("-", "_"))
+    profile = profiles[profile_key]
+    _context, rows, _summary = execute_profile(
+        profile,
+        output_dir=args.output_dir,
+        source_manifest=args.source_manifest,
+        decisions=args.decisions,
+        check=args.check,
+    )
+    print(
+        f"{profile.query_id}: {len(rows)} candidates; "
+        f"{'checked' if args.check else 'generated'} deterministic outputs."
+    )
+    if args.decisions:
+        print(f"Validated complete decisions: {args.decisions}")


### PR DESCRIPTION
<!-- coordination-claim: #67 -->

Work claim: #67
Intake issue: #64

Closes #67
Closes #64

## Outcome and scope

Generalize the frozen PyCantonese/HKCanCor extraction machinery into one reusable profile-driven corpus-review workbench, then refactor the existing AB30 `r` and `m` queries onto it without changing any committed candidate ID or generated byte.

The shared engine now owns source-manifest verification, frozen-version loading, stable IDs, provenance/context records, optional duplicate-group inputs, deterministic JSON/TSV/summary rendering, stale-output checks, and complete decision-ledger accounting. Construction-specific scripts retain only predicates and summary fields.

## Coordination

- Work ID: `CS-WORK-0067`
- Claim mode: `exclusive`
- Integration role: `worker`
- Active worker: `codex`
- Ownership revision: 2
- Live intake `active_pr`: 72
- Semantic regions: reusable HKCanCor engine, AB30 adapter, focused tests, and existing corpus-review documentation
- Dependencies: #64
- Overlapping physical files with disjoint regions: none
- Pending changesets: none

## Canonical inputs and generated outputs

- Canonical inputs: PyCantonese `5.0.0`, `external-evidence/cp021b/hkcancor-cp021b-source-manifest.sha256`, existing AB30 query script and reviewed decision ledgers
- Generated outputs: six existing AB30 JSON/TSV/summary files, all verified byte-for-byte unchanged
- Integration-owned files reconciled by the integrator: none

## Explicitly protected or unchanged

Reviewed AB30 classifications and ledgers, all 227 existing candidate IDs, construction identity/code/UUID, runtime behavior and labels, linguistic status, readiness, fixtures, survey state, release state, merge authorization, repository settings, and secrets remain unchanged.

## Validation

Validated exact tree at head `23c3f4a` on current `main` `cb5f0ed`; the two intervening main commits have no tree diff from the fully verified `691e821` base:

- `python3 -m unittest tests/tooling/corpus-review/test_hkcancor_workbench.py` — PASS (4 tests)
- `node --test tests/tooling/corpus-review/*.test.js` — PASS
- AB30 `r` profile with `--check` and the complete R2 decision ledger — PASS, 121 candidates
- AB30 `m` profile with `--check` and the complete M-R1 decision ledger — PASS, 106 candidates
- `npm run verify:coordination` — PASS
- `npm run verify` — PASS (14/14 core checks)
- `npm run verify:research` — PASS (12/12 research checks)
- `git diff --cached --check` — PASS before commit
- GitHub Actions — PASS at exact head `23c3f4a`

## Human merge review

- Review status: `USER_APPROVED`
- Live intake owner/revision rechecked: `yes`
- User notified that this exact head is ready: `yes`
- Explicit approval for this pull request and exact head: `received — user explicitly approved PR #72 at head 23c3f4a in the current conversation on 2026-07-25`

Approval applies only to PR #72 and unchanged head `23c3f4a`.

## Remaining work

Run the final unchanged-head checks and merge PR #72. No implementation work remains.