### PR TITLE
Extract modality, intention, preference, and priority

### DIFF
--- a/main.js
+++ b/main.js
@@ -6641,6 +6641,137 @@ var require_classifier_head_rules = __commonJS({
   }
 });
 
+// src/parser/detectors/discourse/priority.js
+var require_priority = __commonJS({
+  "src/parser/detectors/discourse/priority.js"(exports2, module2) {
+    "use strict";
+    module2.exports = function createPriorityDetectors2(dependencies = {}) {
+      const {
+        categorySubspanFor: categorySubspanFor2,
+        cleanSlots: cleanSlots2,
+        construction: construction2,
+        flattenSurface: flattenSurface2,
+        isParticle: isParticle2,
+        isToken: isToken2,
+        isVerbLike: isVerbLike2,
+        nodeCanFillSlot: nodeCanFillSlot2,
+        nodeSlots: nodeSlots2,
+        parserInactiveTokenClone: parserInactiveTokenClone2,
+        traceInfo: traceInfo2,
+        withoutIgnorableSpaceText: withoutIgnorableSpaceText2,
+        withoutTrailingParticles: withoutTrailingParticles2
+      } = dependencies;
+      function isPriorityActionCandidate(node) {
+        if (!node || node.kind === "text") return false;
+        if (node.kind === "construction") {
+          const slots = nodeSlots2(node);
+          return slots.includes("vp") || slots.includes("action_vp") || slots.includes("predicate") || slots.includes("directional_motion_vp") || slots.includes("productive_vo");
+        }
+        return isVerbLike2(node);
+      }
+      function priorityMarkerTokenClone(node) {
+        return parserInactiveTokenClone2(node, {
+          label: "how",
+          pos: "adverbial",
+          syntax: "priority_sequence_marker",
+          slots: ["priority_marker", "sequence_marker", "how"],
+          reason: "先 is being interpreted as a priority/sequence marker here, so it stays parser-inactive inside the parent clause wrapper."
+        });
+      }
+      function priorityParticleClone(node) {
+        return parserInactiveTokenClone2(node, {
+          label: "particle",
+          pos: "particle",
+          syntax: "sentence_final_particle",
+          slots: ["particle"],
+          reason: "Final particle stays parser-inactive inside a priority-marker clause wrapper."
+        });
+      }
+      function makePriorityMarkerClause(actionNode, markerNode, particleNode = null) {
+        const children = [actionNode, priorityMarkerTokenClone(markerNode)];
+        if (particleNode) children.push(priorityParticleClone(particleNode));
+        return construction2("PriorityMarkerClause", "Priority先", children, {
+          slots: ["priority_marker_clause", "sequence_priority_marker", "priority_marker", "vp", "action_vp", "predicate"],
+          note: "Priority/sequence marker clause: action + 先 + optional final particle, e.g. 你食先啦 = you eat first.",
+          trace: traceInfo2("generative_template", {
+            construction_type: "PriorityMarkerClause",
+            template_family: "generative_template",
+            template: particleNode ? ["action_vp!", "priority_marker!", "particle?"] : ["action_vp!", "priority_marker!"],
+            assigned_slots: particleNode ? ["action_vp", "priority_marker", "particle"] : ["action_vp", "priority_marker"],
+            pattern: particleNode ? "predicate + priority_marker + final_particle" : "predicate + priority_marker",
+            reason: "Native speech uses 先 after an action predicate to mark priority/order ('do this first'); the action remains visible as the child predicate.",
+            surfaces: children.map((node) => flattenSurface2(node))
+          })
+        });
+      }
+      function priorityMarkerClauseWithTrailingParticle2(node, particleNode) {
+        if (!node || node.kind !== "construction" || node.type !== "PriorityMarkerClause" || !particleNode) return node;
+        if ((node.children || []).some((child) => isParticle2(child))) return node;
+        return {
+          ...node,
+          children: [...node.children || [], priorityParticleClone(particleNode)],
+          trace: {
+            ...node.trace || {},
+            pattern: "predicate + priority_marker + final_particle",
+            attached_trailing_particle: flattenSurface2(particleNode)
+          }
+        };
+      }
+      function priorityMarkerPatternAt(nodes, index) {
+        if (!isPriorityActionCandidate(nodes[index])) return null;
+        if (!isToken2(nodes[index + 1], "先")) return null;
+        if (isParticle2(nodes[index + 2]) && ["啦", "喇", "呀", "啊"].includes(flattenSurface2(nodes[index + 2]))) {
+          return { length: 3, particle: nodes[index + 2] };
+        }
+        return { length: 2, particle: null };
+      }
+      function wrapPriorityMarkerSubspans2(nodes) {
+        const result = [];
+        let i = 0;
+        while (i < nodes.length) {
+          const match = priorityMarkerPatternAt(nodes, i);
+          if (match) {
+            result.push(makePriorityMarkerClause(nodes[i], nodes[i + 1], match.particle));
+            i += match.length;
+            continue;
+          }
+          result.push(nodes[i]);
+          i += 1;
+        }
+        return result;
+      }
+      function sourceLinkedPriorityMarkerClauseFallback2(core) {
+        const { core: bareCore, particles } = withoutTrailingParticles2(core);
+        const compact = withoutIgnorableSpaceText2(bareCore);
+        if (compact.length < 3 || !nodeCanFillSlot2(compact[0], "subject")) return null;
+        const markerIndex = compact.findIndex((node, index) => index > 1 && isToken2(node, "先"));
+        if (markerIndex < 0 || markerIndex !== compact.length - 1) return null;
+        const action = categorySubspanFor2(compact.slice(1, markerIndex), ["ProductiveVO", "TransitiveVP"]);
+        if (!action || flattenSurface2(action) !== "打電話") return null;
+        if (particles.length !== 1 || !isToken2(particles[0], "啦")) return null;
+        const children = [compact[0], action, priorityMarkerTokenClone(compact[markerIndex]), priorityParticleClone(particles[0])];
+        return construction2("PriorityMarkerClause", "Priority先", children, {
+          note: "Source-linked postverbal 先 profile in 你打電話先啦.",
+          slots: cleanSlots2(["priority_marker_clause", "sequence_priority_marker", "priority_marker", "subject", "vp", "action_vp", "predicate"]),
+          trace: traceInfo2("generative_template", {
+            construction_type: "PriorityMarkerClause",
+            template: ["subject!", "action_vp!", "priority_marker!", "particle!"],
+            constraints: { surface_sequence: "你打電話先啦" },
+            assigned_slots: ["subject", "action_vp", "priority_marker", "particle"],
+            surfaces: children.map((node) => flattenSurface2(node)),
+            reason: "Retains the exact attested action + postverbal 先 + 啦 profile while excluding preverbal and deferral uses."
+          })
+        });
+      }
+      return {
+        priorityMarkerClauseWithTrailingParticle: priorityMarkerClauseWithTrailingParticle2,
+        sourceLinkedPriorityMarkerClauseFallback: sourceLinkedPriorityMarkerClauseFallback2,
+        wrapPriorityMarkerSubspans: wrapPriorityMarkerSubspans2
+      };
+    };
+  }
+});
+
 // src/parser/detectors/np/token-splits.js
 var require_token_splits = __commonJS({
   "src/parser/detectors/np/token-splits.js"(exports2, module2) {
@@ -8519,6 +8650,261 @@ var require_fragments_content = __commonJS({
         cognitionContentFrameFallback: cognitionContentFrameFallback2,
         cognitionStatementFallback: cognitionStatementFallback2,
         negativeCognitionFragmentFallback: negativeCognitionFragmentFallback2
+      };
+    };
+  }
+});
+
+// src/parser/detectors/modality/modal-predicates.js
+var require_modal_predicates = __commonJS({
+  "src/parser/detectors/modality/modal-predicates.js"(exports2, module2) {
+    "use strict";
+    module2.exports = function createModalPredicateDetectors2(dependencies = {}) {
+      const {
+        categorySubspanFor: categorySubspanFor2,
+        construction: construction2,
+        coordinatedNPFromParts: coordinatedNPFromParts2,
+        firstToken: firstToken2,
+        flattenSurface: flattenSurface2,
+        isModalToken: isModalToken2,
+        nodeCanFillSlot: nodeCanFillSlot2,
+        templateConstructionFor: templateConstructionFor2,
+        templateDerivedSlots: templateDerivedSlots2,
+        traceInfo: traceInfo2,
+        withoutIgnorableSpaceText: withoutIgnorableSpaceText2,
+        withoutTrailingParticles: withoutTrailingParticles2
+      } = dependencies;
+      function isModalPredicateConstruction(node) {
+        return node && node.kind === "construction" && node.type === "ModalVP";
+      }
+      function isPremodalClauseModifier(node) {
+        if (!node) return false;
+        if (node.kind === "text") return false;
+        return nodeCanFillSlot2(node, "time") || nodeCanFillSlot2(node, "how") || nodeCanFillSlot2(node, "manner");
+      }
+      function modalClauseTypeForLeadingNode(node) {
+        if (!node) return "";
+        if (nodeCanFillSlot2(node, "location") || nodeCanFillSlot2(node, "locative_phrase")) return "LocativeModalPredicateClause";
+        if (nodeCanFillSlot2(node, "subject") && !nodeCanFillSlot2(node, "object")) return "SubjectModalPredicateClause";
+        if (nodeCanFillSlot2(node, "subject") && (firstToken2(node) || {}).label === "who") return "SubjectModalPredicateClause";
+        if (nodeCanFillSlot2(node, "topic") || nodeCanFillSlot2(node, "np") || nodeCanFillSlot2(node, "head_noun")) return "TopicModalPredicateClause";
+        return "";
+      }
+      function modalClauseLabelForType(type) {
+        if (type === "LocativeModalPredicateClause") return "LocModal";
+        if (type === "SubjectModalPredicateClause") return "SubjModal";
+        if (type === "TopicModalPredicateClause") return "TopicModal";
+        return "ModalClause";
+      }
+      function modalPredicateFromNodes(nodes) {
+        if (!nodes || !nodes.length) return null;
+        if (nodes.length === 1 && nodeCanFillSlot2(nodes[0], "vp")) return nodes[0];
+        const templated = categorySubspanFor2(nodes, ["VerbComplementVP", "DirectionalMotionVP", "CompoundDirectionalMotionVP", "NegatedDirectionalMotionVP", "DegreeMannerAdverbial"]) || templateConstructionFor2(nodes, ["VerbComplementVP", "TransitiveVP", "ProductiveVO", "CompletionVP", "DirectionalMotionVP", "MotionPurposeChain", "SerialVerbPurposeChain"]);
+        if (templated && nodeCanFillSlot2(templated, "vp")) return templated;
+        return null;
+      }
+      function modalVPFromNodes2(nodes) {
+        if (!nodes || !nodes.length) return null;
+        const generated = templateConstructionFor2(nodes, ["ModalVP"]);
+        if (generated) return generated;
+        const { core: bareCore, particles } = withoutTrailingParticles2(nodes);
+        if (!bareCore.length || !nodeCanFillSlot2(bareCore[0], "modal")) return null;
+        const modal = bareCore[0];
+        const predicateNodes = bareCore.slice(1);
+        if (!predicateNodes.length) return null;
+        const predicate = modalPredicateFromNodes(predicateNodes);
+        if (!predicate || !nodeCanFillSlot2(predicate, "vp")) return null;
+        const children = [modal, predicate, ...particles];
+        return construction2("ModalVP", "ModalVP", children, {
+          note: "Broad modal VP: modal auxiliary plus VP/predicate complement. Matched by governed generated slots rather than the old modal-token heuristic.",
+          slots: templateDerivedSlots2("ModalVP", children),
+          trace: traceInfo2("generative_template", {
+            construction_type: "ModalVP",
+            template_family: "generative_template",
+            template: ["modal!", "vp!", "particle?"],
+            assigned_slots: ["modal", "vp", ...particles.map(() => "particle")],
+            surfaces: children.map((node) => flattenSurface2(node)),
+            reason: "Promotes modal + VP/predicate material into the governed generative-template lane while preserving the predicate child span."
+          })
+        });
+      }
+      function modalClauseTemplateForType(type, modifiers) {
+        const first = type === "LocativeModalPredicateClause" ? "location!" : type === "SubjectModalPredicateClause" ? "subject!" : "topic!";
+        const middle = modifiers.map((node) => nodeCanFillSlot2(node, "time") ? "time?" : nodeCanFillSlot2(node, "how") ? "how?" : "manner?");
+        return [first, ...middle, "modal_vp!"];
+      }
+      function modalPredicateClauseFromParts(beforeModal, modalSpan) {
+        if (!isModalPredicateConstruction(modalSpan)) return null;
+        if (!beforeModal.length) return null;
+        if (beforeModal.some((node) => node.kind === "text")) return null;
+        const leading = beforeModal[0];
+        const modifiers = beforeModal.slice(1);
+        if (modifiers.some((node) => !isPremodalClauseModifier(node))) return null;
+        const type = modalClauseTypeForLeadingNode(leading);
+        if (!type) return null;
+        const children = [...beforeModal, modalSpan];
+        return construction2(type, modalClauseLabelForType(type), children, {
+          note: "v0.5.31 subject/topic/location-preserving modal clause. The existing ModalVP is kept as the visible predicate child instead of becoming a separate top-level span.",
+          slots: templateDerivedSlots2(type, children),
+          trace: traceInfo2("generative_template", {
+            construction_type: type,
+            template: modalClauseTemplateForType(type, modifiers),
+            assigned_slots: [type === "LocativeModalPredicateClause" ? "location" : type === "SubjectModalPredicateClause" ? "subject" : "topic", ...modifiers.map((node) => nodeCanFillSlot2(node, "time") ? "time" : nodeCanFillSlot2(node, "how") ? "how" : "manner"), "modal_vp"],
+            surfaces: children.map((node) => flattenSurface2(node)),
+            reason: "Wraps a generated topic/subject/location prefix plus an existing ModalVP without changing the ModalVP internals."
+          })
+        });
+      }
+      function coordinatedSubjectModalPredicateClauseFallback2(core) {
+        const { core: bareCore, particles } = withoutTrailingParticles2(core);
+        const compact = withoutIgnorableSpaceText2(bareCore);
+        if (compact.length < 5) return null;
+        const coord = coordinatedNPFromParts2(compact.slice(0, 3));
+        if (!coord) return null;
+        const rest = compact.slice(3);
+        const modalVP = modalVPFromNodes2(rest);
+        if (!modalVP || !nodeCanFillSlot2(modalVP, "modal_vp")) return null;
+        const children = [coord, modalVP, ...particles];
+        return construction2("CoordinatedSubjectModalPredicateClause", "CoordSubjModal", children, {
+          note: "v0.5.35 coordinated-subject modal clause: coordinated subject + existing ModalVP child.",
+          slots: templateDerivedSlots2("CoordinatedSubjectModalPredicateClause", children),
+          trace: traceInfo2("generative_template", {
+            construction_type: "CoordinatedSubjectModalPredicateClause",
+            template: ["subject!", "modal_vp!", "particle?"],
+            assigned_slots: ["subject", "modal_vp", ...particles.map(() => "particle")],
+            surfaces: children.map((node) => flattenSurface2(node)),
+            reason: "Adds a subject-preserving wrapper for the reviewed coordinated-subject modal pattern while keeping the ModalVP internals unchanged."
+          })
+        });
+      }
+      function modalPredicateWrapCoreFallback2(core) {
+        const modalIndex = core.findIndex(isModalToken2);
+        if (modalIndex < 0 || modalIndex >= core.length - 1) return null;
+        const before = core.slice(0, modalIndex);
+        let modalSpan = modalVPFromNodes2(core.slice(modalIndex));
+        if (!modalSpan) {
+          modalSpan = construction2("ModalVP", "ModalVP", core.slice(modalIndex), {
+            note: "Modal/desiderative construction wrapping following predicate.",
+            trace: traceInfo2("generative_or_heuristic_slot_rule", {
+              rule: "modal token followed by predicate material",
+              reason: "Fallback only; governed ModalVP should normally catch modal + VP material."
+            })
+          });
+        }
+        const modalClause = modalPredicateClauseFromParts(before, modalSpan);
+        if (modalClause) return [modalClause];
+        return [...before, modalSpan];
+      }
+      return {
+        coordinatedSubjectModalPredicateClauseFallback: coordinatedSubjectModalPredicateClauseFallback2,
+        modalPredicateWrapCoreFallback: modalPredicateWrapCoreFallback2,
+        modalVPFromNodes: modalVPFromNodes2
+      };
+    };
+  }
+});
+
+// src/parser/detectors/modality/intention-preference.js
+var require_intention_preference = __commonJS({
+  "src/parser/detectors/modality/intention-preference.js"(exports2, module2) {
+    "use strict";
+    module2.exports = function createIntentionPreferenceDetectors2(dependencies = {}) {
+      const {
+        categorySubspanFor: categorySubspanFor2,
+        construction: construction2,
+        flattenSurface: flattenSurface2,
+        hasSurface: hasSurface2,
+        isToken: isToken2,
+        nodeCanFillSlot: nodeCanFillSlot2,
+        templateConstructionFor: templateConstructionFor2,
+        templateDerivedSlots: templateDerivedSlots2,
+        traceInfo: traceInfo2,
+        withoutIgnorableSpaceText: withoutIgnorableSpaceText2,
+        withoutTrailingParticles: withoutTrailingParticles2
+      } = dependencies;
+      function sourceLinkedIntentionFrameFallback2(core) {
+        const { core: bareCore, particles } = withoutTrailingParticles2(core);
+        const compact = withoutIgnorableSpaceText2(bareCore);
+        if (compact.length < 3) return null;
+        const [subject, intentionPredicate, ...predicateNodes] = compact;
+        if (!nodeCanFillSlot2(subject, "subject") || !isToken2(intentionPredicate, "諗住")) return null;
+        const predicate = categorySubspanFor2(predicateNodes, [
+          "DirectionalMotionVP",
+          "CompoundDirectionalMotionVP",
+          "VerbComplementVP",
+          "TransitiveVP",
+          "ProductiveVO"
+        ]);
+        if (!predicate || !nodeCanFillSlot2(predicate, "vp")) return null;
+        const children = [subject, intentionPredicate, predicate, ...particles];
+        return construction2("IntentionFrame", "Intention", children, {
+          note: "Source-linked lexical intention profile: overt subject + 諗住 + visible VP.",
+          slots: templateDerivedSlots2("IntentionFrame", children),
+          trace: traceInfo2("generative_template", {
+            construction_type: "IntentionFrame",
+            template: ["subject!", "intention_predicate!", "vp!", "particle?"],
+            constraints: { slot_surface_in: { intention_predicate: ["諗住"] } },
+            assigned_slots: ["subject", "intention_predicate", "vp", ...particles.map(() => "particle")],
+            surfaces: children.map((node) => flattenSurface2(node)),
+            reason: "Runs before broad VP-complement subspan wrapping so the overt subject and lexical intention predicate remain visible."
+          })
+        });
+      }
+      function sourceLinkedPreferenceVPFallback2(core) {
+        const { core: bareCore, particles } = withoutTrailingParticles2(core);
+        const compact = withoutIgnorableSpaceText2(bareCore);
+        if (compact.length < 3 || !nodeCanFillSlot2(compact[0], "subject") || !isToken2(compact[1], "鍾意")) return null;
+        const complement = categorySubspanFor2(compact.slice(2), [
+          "TransitiveVP",
+          "ProductiveVO",
+          "DirectionalMotionVP",
+          "CompoundDirectionalMotionVP",
+          "VerbComplementVP"
+        ]);
+        if (!complement || !nodeCanFillSlot2(complement, "vp")) return null;
+        const children = [compact[0], compact[1], complement, ...particles];
+        return construction2("PreferenceVP", "Preference", children, {
+          note: "Source-linked preference predicate with an overt subject and visible activity VP complement.",
+          slots: templateDerivedSlots2("PreferenceVP", children),
+          trace: traceInfo2("generative_template", {
+            construction_type: "PreferenceVP",
+            template: ["subject!", "preference_predicate!", "vp!", "particle?"],
+            constraints: { slot_surface_in: { preference_predicate: ["鍾意"] } },
+            assigned_slots: ["subject", "preference_predicate", "vp", ...particles.map(() => "particle")],
+            surfaces: children.map((node) => flattenSurface2(node)),
+            reason: "Runs before broad nominal wrapping so the sourced 鍾意 + activity complement remains visible."
+          })
+        });
+      }
+      function rawPreferenceTemplateFallback2(core) {
+        return templateConstructionFor2(core, ["PreferenceVP"]);
+      }
+      function desiderativeVPWrapCoreFallback2(core) {
+        if (!hasSurface2(core, "想") || !hasSurface2(core, "好") && !hasSurface2(core, "試吓")) return null;
+        return construction2("DesiderativeVP", "WantVP", core, {
+          note: "Desire/wanting construction, often 好想 + VP.",
+          trace: traceInfo2("legacy_surface_rule", {
+            rule: "has 想 plus degree/VP",
+            reason: "Surface modal fallback."
+          })
+        });
+      }
+      function preferenceVPWrapCoreFallback2(core) {
+        if (!hasSurface2(core, "鍾意")) return null;
+        return construction2("PreferenceVP", "Preference", core, {
+          note: "Preference fallback: preference predicate taking a VP/object complement.",
+          trace: traceInfo2("construction_function", {
+            construction_type: "PreferenceVP",
+            reason: "Fallback only; generative PreferenceVP should normally catch this before ModifiedNP wrapping."
+          })
+        });
+      }
+      return {
+        desiderativeVPWrapCoreFallback: desiderativeVPWrapCoreFallback2,
+        preferenceVPWrapCoreFallback: preferenceVPWrapCoreFallback2,
+        rawPreferenceTemplateFallback: rawPreferenceTemplateFallback2,
+        sourceLinkedIntentionFrameFallback: sourceLinkedIntentionFrameFallback2,
+        sourceLinkedPreferenceVPFallback: sourceLinkedPreferenceVPFallback2
       };
     };
   }
@@ -13693,85 +14079,26 @@ function wrapAgreementResponseSubspans(nodes) {
   }
   return result;
 }
-function isPriorityActionCandidate(node) {
-  if (!node || node.kind === "text") return false;
-  if (node.kind === "construction") {
-    const slots = nodeSlots(node);
-    return slots.includes("vp") || slots.includes("action_vp") || slots.includes("predicate") || slots.includes("directional_motion_vp") || slots.includes("productive_vo");
-  }
-  return isVerbLike(node);
-}
-function priorityMarkerTokenClone(node) {
-  return parserInactiveTokenClone(node, {
-    label: "how",
-    pos: "adverbial",
-    syntax: "priority_sequence_marker",
-    slots: ["priority_marker", "sequence_marker", "how"],
-    reason: "先 is being interpreted as a priority/sequence marker here, so it stays parser-inactive inside the parent clause wrapper."
-  });
-}
-function priorityParticleClone(node) {
-  return parserInactiveTokenClone(node, {
-    label: "particle",
-    pos: "particle",
-    syntax: "sentence_final_particle",
-    slots: ["particle"],
-    reason: "Final particle stays parser-inactive inside a priority-marker clause wrapper."
-  });
-}
-function makePriorityMarkerClause(actionNode, markerNode, particleNode = null) {
-  const children = [actionNode, priorityMarkerTokenClone(markerNode)];
-  if (particleNode) children.push(priorityParticleClone(particleNode));
-  return construction("PriorityMarkerClause", "Priority先", children, {
-    slots: ["priority_marker_clause", "sequence_priority_marker", "priority_marker", "vp", "action_vp", "predicate"],
-    note: "Priority/sequence marker clause: action + 先 + optional final particle, e.g. 你食先啦 = you eat first.",
-    trace: traceInfo("generative_template", {
-      construction_type: "PriorityMarkerClause",
-      template_family: "generative_template",
-      template: particleNode ? ["action_vp!", "priority_marker!", "particle?"] : ["action_vp!", "priority_marker!"],
-      assigned_slots: particleNode ? ["action_vp", "priority_marker", "particle"] : ["action_vp", "priority_marker"],
-      pattern: particleNode ? "predicate + priority_marker + final_particle" : "predicate + priority_marker",
-      reason: "Native speech uses 先 after an action predicate to mark priority/order ('do this first'); the action remains visible as the child predicate.",
-      surfaces: children.map((node) => flattenSurface(node))
-    })
-  });
-}
-function priorityMarkerClauseWithTrailingParticle(node, particleNode) {
-  if (!node || node.kind !== "construction" || node.type !== "PriorityMarkerClause" || !particleNode) return node;
-  if ((node.children || []).some((child) => isParticle(child))) return node;
-  return {
-    ...node,
-    children: [...node.children || [], priorityParticleClone(particleNode)],
-    trace: {
-      ...node.trace || {},
-      pattern: "predicate + priority_marker + final_particle",
-      attached_trailing_particle: flattenSurface(particleNode)
-    }
-  };
-}
-function priorityMarkerPatternAt(nodes, index) {
-  if (!isPriorityActionCandidate(nodes[index])) return null;
-  if (!isToken(nodes[index + 1], "先")) return null;
-  if (isParticle(nodes[index + 2]) && ["啦", "喇", "呀", "啊"].includes(flattenSurface(nodes[index + 2]))) {
-    return { length: 3, particle: nodes[index + 2] };
-  }
-  return { length: 2, particle: null };
-}
-function wrapPriorityMarkerSubspans(nodes) {
-  const result = [];
-  let i = 0;
-  while (i < nodes.length) {
-    const match = priorityMarkerPatternAt(nodes, i);
-    if (match) {
-      result.push(makePriorityMarkerClause(nodes[i], nodes[i + 1], match.particle));
-      i += match.length;
-      continue;
-    }
-    result.push(nodes[i]);
-    i += 1;
-  }
-  return result;
-}
+var createPriorityDetectors = require_priority();
+var {
+  priorityMarkerClauseWithTrailingParticle,
+  sourceLinkedPriorityMarkerClauseFallback,
+  wrapPriorityMarkerSubspans
+} = createPriorityDetectors({
+  categorySubspanFor,
+  cleanSlots,
+  construction,
+  flattenSurface,
+  isParticle,
+  isToken,
+  isVerbLike,
+  nodeCanFillSlot,
+  nodeSlots,
+  parserInactiveTokenClone,
+  traceInfo,
+  withoutIgnorableSpaceText,
+  withoutTrailingParticles
+});
 function isSubjectLike(node) {
   return nodeSlots(node).includes("subject");
 }
@@ -14214,6 +14541,45 @@ var {
   withoutTrailingParticles,
   wrapCategorySubspans
 });
+var createModalPredicateDetectors = require_modal_predicates();
+var {
+  coordinatedSubjectModalPredicateClauseFallback,
+  modalPredicateWrapCoreFallback,
+  modalVPFromNodes
+} = createModalPredicateDetectors({
+  categorySubspanFor,
+  construction,
+  coordinatedNPFromParts,
+  firstToken,
+  flattenSurface,
+  isModalToken,
+  nodeCanFillSlot,
+  templateConstructionFor,
+  templateDerivedSlots,
+  traceInfo,
+  withoutIgnorableSpaceText,
+  withoutTrailingParticles
+});
+var createIntentionPreferenceDetectors = require_intention_preference();
+var {
+  desiderativeVPWrapCoreFallback,
+  preferenceVPWrapCoreFallback,
+  rawPreferenceTemplateFallback,
+  sourceLinkedIntentionFrameFallback,
+  sourceLinkedPreferenceVPFallback
+} = createIntentionPreferenceDetectors({
+  categorySubspanFor,
+  construction,
+  flattenSurface,
+  hasSurface,
+  isToken,
+  nodeCanFillSlot,
+  templateConstructionFor,
+  templateDerivedSlots,
+  traceInfo,
+  withoutIgnorableSpaceText,
+  withoutTrailingParticles
+});
 var createOpinionDetectors = require_stance();
 var { opinionStanceFrameFallback } = createOpinionDetectors({
   applyConstructionPatterns,
@@ -14433,87 +14799,6 @@ function subjectStativePredicateClauseFallback(nodes) {
     })
   });
 }
-function isModalPredicateConstruction(node) {
-  return node && node.kind === "construction" && node.type === "ModalVP";
-}
-function isPremodalClauseModifier(node) {
-  if (!node) return false;
-  if (node.kind === "text") return false;
-  return nodeCanFillSlot(node, "time") || nodeCanFillSlot(node, "how") || nodeCanFillSlot(node, "manner");
-}
-function modalClauseTypeForLeadingNode(node) {
-  if (!node) return "";
-  if (nodeCanFillSlot(node, "location") || nodeCanFillSlot(node, "locative_phrase")) return "LocativeModalPredicateClause";
-  if (nodeCanFillSlot(node, "subject") && !nodeCanFillSlot(node, "object")) return "SubjectModalPredicateClause";
-  if (nodeCanFillSlot(node, "subject") && (firstToken(node) || {}).label === "who") return "SubjectModalPredicateClause";
-  if (nodeCanFillSlot(node, "topic") || nodeCanFillSlot(node, "np") || nodeCanFillSlot(node, "head_noun")) return "TopicModalPredicateClause";
-  return "";
-}
-function modalClauseLabelForType(type) {
-  if (type === "LocativeModalPredicateClause") return "LocModal";
-  if (type === "SubjectModalPredicateClause") return "SubjModal";
-  if (type === "TopicModalPredicateClause") return "TopicModal";
-  return "ModalClause";
-}
-function modalPredicateFromNodes(nodes) {
-  if (!nodes || !nodes.length) return null;
-  if (nodes.length === 1 && nodeCanFillSlot(nodes[0], "vp")) return nodes[0];
-  const templated = categorySubspanFor(nodes, ["VerbComplementVP", "DirectionalMotionVP", "CompoundDirectionalMotionVP", "NegatedDirectionalMotionVP", "DegreeMannerAdverbial"]) || templateConstructionFor(nodes, ["VerbComplementVP", "TransitiveVP", "ProductiveVO", "CompletionVP", "DirectionalMotionVP", "MotionPurposeChain", "SerialVerbPurposeChain"]);
-  if (templated && nodeCanFillSlot(templated, "vp")) return templated;
-  return null;
-}
-function modalVPFromNodes(nodes) {
-  if (!nodes || !nodes.length) return null;
-  const generated = templateConstructionFor(nodes, ["ModalVP"]);
-  if (generated) return generated;
-  const { core: bareCore, particles } = withoutTrailingParticles(nodes);
-  if (!bareCore.length || !nodeCanFillSlot(bareCore[0], "modal")) return null;
-  const modal = bareCore[0];
-  const predicateNodes = bareCore.slice(1);
-  if (!predicateNodes.length) return null;
-  const predicate = modalPredicateFromNodes(predicateNodes);
-  if (!predicate || !nodeCanFillSlot(predicate, "vp")) return null;
-  const children = [modal, predicate, ...particles];
-  return construction("ModalVP", "ModalVP", children, {
-    note: "Broad modal VP: modal auxiliary plus VP/predicate complement. Matched by governed generated slots rather than the old modal-token heuristic.",
-    slots: templateDerivedSlots("ModalVP", children),
-    trace: traceInfo("generative_template", {
-      construction_type: "ModalVP",
-      template_family: "generative_template",
-      template: ["modal!", "vp!", "particle?"],
-      assigned_slots: ["modal", "vp", ...particles.map(() => "particle")],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Promotes modal + VP/predicate material into the governed generative-template lane while preserving the predicate child span."
-    })
-  });
-}
-function modalClauseTemplateForType(type, modifiers) {
-  const first = type === "LocativeModalPredicateClause" ? "location!" : type === "SubjectModalPredicateClause" ? "subject!" : "topic!";
-  const middle = modifiers.map((node) => nodeCanFillSlot(node, "time") ? "time?" : nodeCanFillSlot(node, "how") ? "how?" : "manner?");
-  return [first, ...middle, "modal_vp!"];
-}
-function modalPredicateClauseFromParts(beforeModal, modalSpan) {
-  if (!isModalPredicateConstruction(modalSpan)) return null;
-  if (!beforeModal.length) return null;
-  if (beforeModal.some((node) => node.kind === "text")) return null;
-  const leading = beforeModal[0];
-  const modifiers = beforeModal.slice(1);
-  if (modifiers.some((node) => !isPremodalClauseModifier(node))) return null;
-  const type = modalClauseTypeForLeadingNode(leading);
-  if (!type) return null;
-  const children = [...beforeModal, modalSpan];
-  return construction(type, modalClauseLabelForType(type), children, {
-    note: "v0.5.31 subject/topic/location-preserving modal clause. The existing ModalVP is kept as the visible predicate child instead of becoming a separate top-level span.",
-    slots: templateDerivedSlots(type, children),
-    trace: traceInfo("generative_template", {
-      construction_type: type,
-      template: modalClauseTemplateForType(type, modifiers),
-      assigned_slots: [type === "LocativeModalPredicateClause" ? "location" : type === "SubjectModalPredicateClause" ? "subject" : "topic", ...modifiers.map((node) => nodeCanFillSlot(node, "time") ? "time" : nodeCanFillSlot(node, "how") ? "how" : "manner"), "modal_vp"],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Wraps a generated topic/subject/location prefix plus an existing ModalVP without changing the ModalVP internals."
-    })
-  });
-}
 function isIgnorableSpaceText(node) {
   return node && node.kind === "text" && !hasSentencePunctuation(node.text) && !normalizeSurface(node.text);
 }
@@ -14534,60 +14819,6 @@ function nameTokenClone(node) {
     syntax: "proper_name name_np",
     slots: ["name", "head_noun", "np", "object", "topic"],
     reason: "The final NP is interpreted as the visible name in a bounded self-introduction frame."
-  });
-}
-function sourceLinkedIntentionFrameFallback(core) {
-  const { core: bareCore, particles } = withoutTrailingParticles(core);
-  const compact = withoutIgnorableSpaceText(bareCore);
-  if (compact.length < 3) return null;
-  const [subject, intentionPredicate, ...predicateNodes] = compact;
-  if (!nodeCanFillSlot(subject, "subject") || !isToken(intentionPredicate, "諗住")) return null;
-  const predicate = categorySubspanFor(predicateNodes, [
-    "DirectionalMotionVP",
-    "CompoundDirectionalMotionVP",
-    "VerbComplementVP",
-    "TransitiveVP",
-    "ProductiveVO"
-  ]);
-  if (!predicate || !nodeCanFillSlot(predicate, "vp")) return null;
-  const children = [subject, intentionPredicate, predicate, ...particles];
-  return construction("IntentionFrame", "Intention", children, {
-    note: "Source-linked lexical intention profile: overt subject + 諗住 + visible VP.",
-    slots: templateDerivedSlots("IntentionFrame", children),
-    trace: traceInfo("generative_template", {
-      construction_type: "IntentionFrame",
-      template: ["subject!", "intention_predicate!", "vp!", "particle?"],
-      constraints: { slot_surface_in: { intention_predicate: ["諗住"] } },
-      assigned_slots: ["subject", "intention_predicate", "vp", ...particles.map(() => "particle")],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Runs before broad VP-complement subspan wrapping so the overt subject and lexical intention predicate remain visible."
-    })
-  });
-}
-function sourceLinkedPreferenceVPFallback(core) {
-  const { core: bareCore, particles } = withoutTrailingParticles(core);
-  const compact = withoutIgnorableSpaceText(bareCore);
-  if (compact.length < 3 || !nodeCanFillSlot(compact[0], "subject") || !isToken(compact[1], "鍾意")) return null;
-  const complement = categorySubspanFor(compact.slice(2), [
-    "TransitiveVP",
-    "ProductiveVO",
-    "DirectionalMotionVP",
-    "CompoundDirectionalMotionVP",
-    "VerbComplementVP"
-  ]);
-  if (!complement || !nodeCanFillSlot(complement, "vp")) return null;
-  const children = [compact[0], compact[1], complement, ...particles];
-  return construction("PreferenceVP", "Preference", children, {
-    note: "Source-linked preference predicate with an overt subject and visible activity VP complement.",
-    slots: templateDerivedSlots("PreferenceVP", children),
-    trace: traceInfo("generative_template", {
-      construction_type: "PreferenceVP",
-      template: ["subject!", "preference_predicate!", "vp!", "particle?"],
-      constraints: { slot_surface_in: { preference_predicate: ["鍾意"] } },
-      assigned_slots: ["subject", "preference_predicate", "vp", ...particles.map(() => "particle")],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Runs before broad nominal wrapping so the sourced 鍾意 + activity complement remains visible."
-    })
   });
 }
 function sourceLinkedDegreeMannerModifiedVPFallback(core) {
@@ -14620,29 +14851,6 @@ function sourceLinkedDegreeMannerModifiedVPFallback(core) {
       assigned_slots: ["degree_manner_adverbial", "directional_motion_vp", ...particles.map(() => "particle")],
       surfaces: children.map((node) => flattenSurface(node)),
       reason: "Preserves the exact sourced preposed order without conflating postverbal 行快啲 or punctuation-separated material."
-    })
-  });
-}
-function sourceLinkedPriorityMarkerClauseFallback(core) {
-  const { core: bareCore, particles } = withoutTrailingParticles(core);
-  const compact = withoutIgnorableSpaceText(bareCore);
-  if (compact.length < 3 || !nodeCanFillSlot(compact[0], "subject")) return null;
-  const markerIndex = compact.findIndex((node, index) => index > 1 && isToken(node, "先"));
-  if (markerIndex < 0 || markerIndex !== compact.length - 1) return null;
-  const action = categorySubspanFor(compact.slice(1, markerIndex), ["ProductiveVO", "TransitiveVP"]);
-  if (!action || flattenSurface(action) !== "打電話") return null;
-  if (particles.length !== 1 || !isToken(particles[0], "啦")) return null;
-  const children = [compact[0], action, priorityMarkerTokenClone(compact[markerIndex]), priorityParticleClone(particles[0])];
-  return construction("PriorityMarkerClause", "Priority先", children, {
-    note: "Source-linked postverbal 先 profile in 你打電話先啦.",
-    slots: cleanSlots(["priority_marker_clause", "sequence_priority_marker", "priority_marker", "subject", "vp", "action_vp", "predicate"]),
-    trace: traceInfo("generative_template", {
-      construction_type: "PriorityMarkerClause",
-      template: ["subject!", "action_vp!", "priority_marker!", "particle!"],
-      constraints: { surface_sequence: "你打電話先啦" },
-      assigned_slots: ["subject", "action_vp", "priority_marker", "particle"],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Retains the exact attested action + postverbal 先 + 啦 profile while excluding preverbal and deferral uses."
     })
   });
 }
@@ -15040,28 +15248,6 @@ var {
   withoutIgnorableSpaceText,
   withoutTrailingParticles
 });
-function coordinatedSubjectModalPredicateClauseFallback(core) {
-  const { core: bareCore, particles } = withoutTrailingParticles(core);
-  const compact = withoutIgnorableSpaceText(bareCore);
-  if (compact.length < 5) return null;
-  const coord = coordinatedNPFromParts(compact.slice(0, 3));
-  if (!coord) return null;
-  const rest = compact.slice(3);
-  const modalVP = modalVPFromNodes(rest);
-  if (!modalVP || !nodeCanFillSlot(modalVP, "modal_vp")) return null;
-  const children = [coord, modalVP, ...particles];
-  return construction("CoordinatedSubjectModalPredicateClause", "CoordSubjModal", children, {
-    note: "v0.5.35 coordinated-subject modal clause: coordinated subject + existing ModalVP child.",
-    slots: templateDerivedSlots("CoordinatedSubjectModalPredicateClause", children),
-    trace: traceInfo("generative_template", {
-      construction_type: "CoordinatedSubjectModalPredicateClause",
-      template: ["subject!", "modal_vp!", "particle?"],
-      assigned_slots: ["subject", "modal_vp", ...particles.map(() => "particle")],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Adds a subject-preserving wrapper for the reviewed coordinated-subject modal pattern while keeping the ModalVP internals unchanged."
-    })
-  });
-}
 function isBareQuantityNumeralNode(node) {
   const t = firstToken(node);
   if (!t) return false;
@@ -17343,7 +17529,7 @@ function wrapCore(core) {
   if (sourceLinkedPrioritySpan) return [sourceLinkedPrioritySpan];
   const sourceLinkedPreferenceSpan = sourceLinkedPreferenceVPFallback(core);
   if (sourceLinkedPreferenceSpan) return [sourceLinkedPreferenceSpan];
-  const rawPreferenceSpan = templateConstructionFor(core, ["PreferenceVP"]);
+  const rawPreferenceSpan = rawPreferenceTemplateFallback(core);
   if (rawPreferenceSpan) return [rawPreferenceSpan];
   const negativeCognitionSpan = negativeCognitionFragmentFallback(core);
   if (negativeCognitionSpan) return [negativeCognitionSpan];
@@ -17467,9 +17653,8 @@ function wrapCore(core) {
   }
   const experientialQuestionBoundary = experientialQuestionBoundaryFallback(core);
   if (experientialQuestionBoundary) return [experientialQuestionBoundary];
-  if (hasSurface(core, "想") && (hasSurface(core, "好") || hasSurface(core, "試吓"))) {
-    return [construction("DesiderativeVP", "WantVP", core, { note: "Desire/wanting construction, often 好想 + VP.", trace: traceInfo("legacy_surface_rule", { rule: "has 想 plus degree/VP", reason: "Surface modal fallback." }) })];
-  }
+  const desiderativeSpan = desiderativeVPWrapCoreFallback(core);
+  if (desiderativeSpan) return [desiderativeSpan];
   if (hasSurface(core, "唔") && hasSurface(core, "算") && hasSurface(core, "貴")) {
     return [construction("ScalarEvaluation", "ValueEval", core, {
       slots: ["scalar_evaluation", "evaluation_clause", "predicate", "stative_predicate", "negator", "evaluation_marker"],
@@ -17500,15 +17685,8 @@ function wrapCore(core) {
   if (acceptabilityANotAQuestion) return [acceptabilityANotAQuestion];
   const existentialWhQuestion = existentialWhQuestionFallback(core);
   if (existentialWhQuestion) return [existentialWhQuestion];
-  if (hasSurface(core, "鍾意")) {
-    return [construction("PreferenceVP", "Preference", core, {
-      note: "Preference fallback: preference predicate taking a VP/object complement.",
-      trace: traceInfo("construction_function", {
-        construction_type: "PreferenceVP",
-        reason: "Fallback only; generative PreferenceVP should normally catch this before ModifiedNP wrapping."
-      })
-    })];
-  }
+  const preferenceFallbackSpan = preferenceVPWrapCoreFallback(core);
+  if (preferenceFallbackSpan) return [preferenceFallbackSpan];
   if (core.length >= 2 && firstToken(core[0]) && firstToken(core[0]).label === "when") {
     return [construction("TemporalClause", "Time", core, {
       note: "Time expression fallback frames the following predicate.",
@@ -17543,17 +17721,8 @@ function wrapCore(core) {
   if (core.length >= 2 && isVerbLike(core[0]) && isToken(core[1], "到")) {
     return [construction("ResultComplement", "Result", core, { note: "Positive result/attainment complement.", trace: traceInfo("generative_or_heuristic_slot_rule", { rule: "verb + 到", reason: "Structural result complement heuristic." }) })];
   }
-  const modalIndex = core.findIndex(isModalToken);
-  if (modalIndex >= 0 && modalIndex < core.length - 1) {
-    const before = core.slice(0, modalIndex);
-    let modalSpan = modalVPFromNodes(core.slice(modalIndex));
-    if (!modalSpan) {
-      modalSpan = construction("ModalVP", "ModalVP", core.slice(modalIndex), { note: "Modal/desiderative construction wrapping following predicate.", trace: traceInfo("generative_or_heuristic_slot_rule", { rule: "modal token followed by predicate material", reason: "Fallback only; governed ModalVP should normally catch modal + VP material." }) });
-    }
-    const modalClause = modalPredicateClauseFromParts(before, modalSpan);
-    if (modalClause) return [modalClause];
-    return [...before, modalSpan];
-  }
+  const modalPredicateWrapSpan = modalPredicateWrapCoreFallback(core);
+  if (modalPredicateWrapSpan) return modalPredicateWrapSpan;
   return wrapPredicate(core);
 }
 function wrapPredicate(nodes) {

--- a/src/parser/detectors/discourse/priority.js
+++ b/src/parser/detectors/discourse/priority.js
@@ -1,0 +1,125 @@
+"use strict";
+
+module.exports = function createPriorityDetectors(dependencies = {}) {
+  const {
+    categorySubspanFor, cleanSlots, construction, flattenSurface, isParticle, isToken,
+    isVerbLike, nodeCanFillSlot, nodeSlots, parserInactiveTokenClone, traceInfo,
+    withoutIgnorableSpaceText, withoutTrailingParticles,
+  } = dependencies;
+
+  function isPriorityActionCandidate(node) {
+    if (!node || node.kind === "text") return false;
+    if (node.kind === "construction") {
+      const slots = nodeSlots(node);
+      return slots.includes("vp") || slots.includes("action_vp") || slots.includes("predicate") || slots.includes("directional_motion_vp") || slots.includes("productive_vo");
+    }
+    return isVerbLike(node);
+  }
+
+  function priorityMarkerTokenClone(node) {
+    return parserInactiveTokenClone(node, {
+      label: "how",
+      pos: "adverbial",
+      syntax: "priority_sequence_marker",
+      slots: ["priority_marker", "sequence_marker", "how"],
+      reason: "先 is being interpreted as a priority/sequence marker here, so it stays parser-inactive inside the parent clause wrapper.",
+    });
+  }
+
+  function priorityParticleClone(node) {
+    return parserInactiveTokenClone(node, {
+      label: "particle",
+      pos: "particle",
+      syntax: "sentence_final_particle",
+      slots: ["particle"],
+      reason: "Final particle stays parser-inactive inside a priority-marker clause wrapper.",
+    });
+  }
+
+  function makePriorityMarkerClause(actionNode, markerNode, particleNode = null) {
+    const children = [actionNode, priorityMarkerTokenClone(markerNode)];
+    if (particleNode) children.push(priorityParticleClone(particleNode));
+    return construction("PriorityMarkerClause", "Priority先", children, {
+      slots: ["priority_marker_clause", "sequence_priority_marker", "priority_marker", "vp", "action_vp", "predicate"],
+      note: "Priority/sequence marker clause: action + 先 + optional final particle, e.g. 你食先啦 = you eat first.",
+      trace: traceInfo("generative_template", {
+        construction_type: "PriorityMarkerClause",
+        template_family: "generative_template",
+        template: particleNode ? ["action_vp!", "priority_marker!", "particle?"] : ["action_vp!", "priority_marker!"],
+        assigned_slots: particleNode ? ["action_vp", "priority_marker", "particle"] : ["action_vp", "priority_marker"],
+        pattern: particleNode ? "predicate + priority_marker + final_particle" : "predicate + priority_marker",
+        reason: "Native speech uses 先 after an action predicate to mark priority/order ('do this first'); the action remains visible as the child predicate.",
+        surfaces: children.map((node) => flattenSurface(node)),
+      }),
+    });
+  }
+
+  function priorityMarkerClauseWithTrailingParticle(node, particleNode) {
+    if (!node || node.kind !== "construction" || node.type !== "PriorityMarkerClause" || !particleNode) return node;
+    if ((node.children || []).some((child) => isParticle(child))) return node;
+    return {
+      ...node,
+      children: [...(node.children || []), priorityParticleClone(particleNode)],
+      trace: {
+        ...(node.trace || {}),
+        pattern: "predicate + priority_marker + final_particle",
+        attached_trailing_particle: flattenSurface(particleNode),
+      },
+    };
+  }
+
+  function priorityMarkerPatternAt(nodes, index) {
+    if (!isPriorityActionCandidate(nodes[index])) return null;
+    if (!isToken(nodes[index + 1], "先")) return null;
+    if (isParticle(nodes[index + 2]) && ["啦", "喇", "呀", "啊"].includes(flattenSurface(nodes[index + 2]))) {
+      return { length: 3, particle: nodes[index + 2] };
+    }
+    return { length: 2, particle: null };
+  }
+
+  function wrapPriorityMarkerSubspans(nodes) {
+    const result = [];
+    let i = 0;
+    while (i < nodes.length) {
+      const match = priorityMarkerPatternAt(nodes, i);
+      if (match) {
+        result.push(makePriorityMarkerClause(nodes[i], nodes[i + 1], match.particle));
+        i += match.length;
+        continue;
+      }
+      result.push(nodes[i]);
+      i += 1;
+    }
+    return result;
+  }
+
+  function sourceLinkedPriorityMarkerClauseFallback(core) {
+    const { core: bareCore, particles } = withoutTrailingParticles(core);
+    const compact = withoutIgnorableSpaceText(bareCore);
+    if (compact.length < 3 || !nodeCanFillSlot(compact[0], "subject")) return null;
+    const markerIndex = compact.findIndex((node, index) => index > 1 && isToken(node, "先"));
+    if (markerIndex < 0 || markerIndex !== compact.length - 1) return null;
+    const action = categorySubspanFor(compact.slice(1, markerIndex), ["ProductiveVO", "TransitiveVP"]);
+    if (!action || flattenSurface(action) !== "打電話") return null;
+    if (particles.length !== 1 || !isToken(particles[0], "啦")) return null;
+    const children = [compact[0], action, priorityMarkerTokenClone(compact[markerIndex]), priorityParticleClone(particles[0])];
+    return construction("PriorityMarkerClause", "Priority先", children, {
+      note: "Source-linked postverbal 先 profile in 你打電話先啦.",
+      slots: cleanSlots(["priority_marker_clause", "sequence_priority_marker", "priority_marker", "subject", "vp", "action_vp", "predicate"]),
+      trace: traceInfo("generative_template", {
+        construction_type: "PriorityMarkerClause",
+        template: ["subject!", "action_vp!", "priority_marker!", "particle!"],
+        constraints: { surface_sequence: "你打電話先啦" },
+        assigned_slots: ["subject", "action_vp", "priority_marker", "particle"],
+        surfaces: children.map((node) => flattenSurface(node)),
+        reason: "Retains the exact attested action + postverbal 先 + 啦 profile while excluding preverbal and deferral uses.",
+      }),
+    });
+  }
+
+  return {
+    priorityMarkerClauseWithTrailingParticle,
+    sourceLinkedPriorityMarkerClauseFallback,
+    wrapPriorityMarkerSubspans,
+  };
+};

--- a/src/parser/detectors/modality/intention-preference.js
+++ b/src/parser/detectors/modality/intention-preference.js
@@ -1,0 +1,99 @@
+"use strict";
+
+module.exports = function createIntentionPreferenceDetectors(dependencies = {}) {
+  const {
+    categorySubspanFor, construction, flattenSurface, hasSurface, isToken,
+    nodeCanFillSlot, templateConstructionFor, templateDerivedSlots, traceInfo,
+    withoutIgnorableSpaceText, withoutTrailingParticles,
+  } = dependencies;
+
+  function sourceLinkedIntentionFrameFallback(core) {
+    const { core: bareCore, particles } = withoutTrailingParticles(core);
+    const compact = withoutIgnorableSpaceText(bareCore);
+    if (compact.length < 3) return null;
+    const [subject, intentionPredicate, ...predicateNodes] = compact;
+    if (!nodeCanFillSlot(subject, "subject") || !isToken(intentionPredicate, "諗住")) return null;
+    const predicate = categorySubspanFor(predicateNodes, [
+      "DirectionalMotionVP",
+      "CompoundDirectionalMotionVP",
+      "VerbComplementVP",
+      "TransitiveVP",
+      "ProductiveVO",
+    ]);
+    if (!predicate || !nodeCanFillSlot(predicate, "vp")) return null;
+    const children = [subject, intentionPredicate, predicate, ...particles];
+    return construction("IntentionFrame", "Intention", children, {
+      note: "Source-linked lexical intention profile: overt subject + 諗住 + visible VP.",
+      slots: templateDerivedSlots("IntentionFrame", children),
+      trace: traceInfo("generative_template", {
+        construction_type: "IntentionFrame",
+        template: ["subject!", "intention_predicate!", "vp!", "particle?"],
+        constraints: { slot_surface_in: { intention_predicate: ["諗住"] } },
+        assigned_slots: ["subject", "intention_predicate", "vp", ...particles.map(() => "particle")],
+        surfaces: children.map((node) => flattenSurface(node)),
+        reason: "Runs before broad VP-complement subspan wrapping so the overt subject and lexical intention predicate remain visible.",
+      }),
+    });
+  }
+
+  function sourceLinkedPreferenceVPFallback(core) {
+    const { core: bareCore, particles } = withoutTrailingParticles(core);
+    const compact = withoutIgnorableSpaceText(bareCore);
+    if (compact.length < 3 || !nodeCanFillSlot(compact[0], "subject") || !isToken(compact[1], "鍾意")) return null;
+    const complement = categorySubspanFor(compact.slice(2), [
+      "TransitiveVP",
+      "ProductiveVO",
+      "DirectionalMotionVP",
+      "CompoundDirectionalMotionVP",
+      "VerbComplementVP",
+    ]);
+    if (!complement || !nodeCanFillSlot(complement, "vp")) return null;
+    const children = [compact[0], compact[1], complement, ...particles];
+    return construction("PreferenceVP", "Preference", children, {
+      note: "Source-linked preference predicate with an overt subject and visible activity VP complement.",
+      slots: templateDerivedSlots("PreferenceVP", children),
+      trace: traceInfo("generative_template", {
+        construction_type: "PreferenceVP",
+        template: ["subject!", "preference_predicate!", "vp!", "particle?"],
+        constraints: { slot_surface_in: { preference_predicate: ["鍾意"] } },
+        assigned_slots: ["subject", "preference_predicate", "vp", ...particles.map(() => "particle")],
+        surfaces: children.map((node) => flattenSurface(node)),
+        reason: "Runs before broad nominal wrapping so the sourced 鍾意 + activity complement remains visible.",
+      }),
+    });
+  }
+
+  function rawPreferenceTemplateFallback(core) {
+    return templateConstructionFor(core, ["PreferenceVP"]);
+  }
+
+  function desiderativeVPWrapCoreFallback(core) {
+    if (!hasSurface(core, "想") || (!hasSurface(core, "好") && !hasSurface(core, "試吓"))) return null;
+    return construction("DesiderativeVP", "WantVP", core, {
+      note: "Desire/wanting construction, often 好想 + VP.",
+      trace: traceInfo("legacy_surface_rule", {
+        rule: "has 想 plus degree/VP",
+        reason: "Surface modal fallback.",
+      }),
+    });
+  }
+
+  function preferenceVPWrapCoreFallback(core) {
+    if (!hasSurface(core, "鍾意")) return null;
+    return construction("PreferenceVP", "Preference", core, {
+      note: "Preference fallback: preference predicate taking a VP/object complement.",
+      trace: traceInfo("construction_function", {
+        construction_type: "PreferenceVP",
+        reason: "Fallback only; generative PreferenceVP should normally catch this before ModifiedNP wrapping.",
+      }),
+    });
+  }
+
+  return {
+    desiderativeVPWrapCoreFallback,
+    preferenceVPWrapCoreFallback,
+    rawPreferenceTemplateFallback,
+    sourceLinkedIntentionFrameFallback,
+    sourceLinkedPreferenceVPFallback,
+  };
+};

--- a/src/parser/detectors/modality/modal-predicates.js
+++ b/src/parser/detectors/modality/modal-predicates.js
@@ -1,0 +1,147 @@
+"use strict";
+
+module.exports = function createModalPredicateDetectors(dependencies = {}) {
+  const {
+    categorySubspanFor, construction, coordinatedNPFromParts, firstToken, flattenSurface,
+    isModalToken, nodeCanFillSlot, templateConstructionFor, templateDerivedSlots,
+    traceInfo, withoutIgnorableSpaceText, withoutTrailingParticles,
+  } = dependencies;
+
+  function isModalPredicateConstruction(node) {
+    return node && node.kind === "construction" && node.type === "ModalVP";
+  }
+
+  function isPremodalClauseModifier(node) {
+    if (!node) return false;
+    if (node.kind === "text") return false;
+    return nodeCanFillSlot(node, "time") || nodeCanFillSlot(node, "how") || nodeCanFillSlot(node, "manner");
+  }
+
+  function modalClauseTypeForLeadingNode(node) {
+    if (!node) return "";
+    if (nodeCanFillSlot(node, "location") || nodeCanFillSlot(node, "locative_phrase")) return "LocativeModalPredicateClause";
+    if (nodeCanFillSlot(node, "subject") && !nodeCanFillSlot(node, "object")) return "SubjectModalPredicateClause";
+    if (nodeCanFillSlot(node, "subject") && (firstToken(node) || {}).label === "who") return "SubjectModalPredicateClause";
+    if (nodeCanFillSlot(node, "topic") || nodeCanFillSlot(node, "np") || nodeCanFillSlot(node, "head_noun")) return "TopicModalPredicateClause";
+    return "";
+  }
+
+  function modalClauseLabelForType(type) {
+    if (type === "LocativeModalPredicateClause") return "LocModal";
+    if (type === "SubjectModalPredicateClause") return "SubjModal";
+    if (type === "TopicModalPredicateClause") return "TopicModal";
+    return "ModalClause";
+  }
+
+  function modalPredicateFromNodes(nodes) {
+    if (!nodes || !nodes.length) return null;
+    if (nodes.length === 1 && nodeCanFillSlot(nodes[0], "vp")) return nodes[0];
+    const templated = categorySubspanFor(nodes, ["VerbComplementVP", "DirectionalMotionVP", "CompoundDirectionalMotionVP", "NegatedDirectionalMotionVP", "DegreeMannerAdverbial"])
+      || templateConstructionFor(nodes, ["VerbComplementVP", "TransitiveVP", "ProductiveVO", "CompletionVP", "DirectionalMotionVP", "MotionPurposeChain", "SerialVerbPurposeChain"]);
+    if (templated && nodeCanFillSlot(templated, "vp")) return templated;
+    return null;
+  }
+
+  function modalVPFromNodes(nodes) {
+    if (!nodes || !nodes.length) return null;
+    const generated = templateConstructionFor(nodes, ["ModalVP"]);
+    if (generated) return generated;
+    const { core: bareCore, particles } = withoutTrailingParticles(nodes);
+    if (!bareCore.length || !nodeCanFillSlot(bareCore[0], "modal")) return null;
+    const modal = bareCore[0];
+    const predicateNodes = bareCore.slice(1);
+    if (!predicateNodes.length) return null;
+    const predicate = modalPredicateFromNodes(predicateNodes);
+    if (!predicate || !nodeCanFillSlot(predicate, "vp")) return null;
+    const children = [modal, predicate, ...particles];
+    return construction("ModalVP", "ModalVP", children, {
+      note: "Broad modal VP: modal auxiliary plus VP/predicate complement. Matched by governed generated slots rather than the old modal-token heuristic.",
+      slots: templateDerivedSlots("ModalVP", children),
+      trace: traceInfo("generative_template", {
+        construction_type: "ModalVP",
+        template_family: "generative_template",
+        template: ["modal!", "vp!", "particle?"],
+        assigned_slots: ["modal", "vp", ...particles.map(() => "particle")],
+        surfaces: children.map((node) => flattenSurface(node)),
+        reason: "Promotes modal + VP/predicate material into the governed generative-template lane while preserving the predicate child span.",
+      }),
+    });
+  }
+
+  function modalClauseTemplateForType(type, modifiers) {
+    const first = type === "LocativeModalPredicateClause" ? "location!" : type === "SubjectModalPredicateClause" ? "subject!" : "topic!";
+    const middle = modifiers.map((node) => nodeCanFillSlot(node, "time") ? "time?" : nodeCanFillSlot(node, "how") ? "how?" : "manner?");
+    return [first, ...middle, "modal_vp!"];
+  }
+
+  function modalPredicateClauseFromParts(beforeModal, modalSpan) {
+    if (!isModalPredicateConstruction(modalSpan)) return null;
+    if (!beforeModal.length) return null;
+    if (beforeModal.some((node) => node.kind === "text")) return null;
+    const leading = beforeModal[0];
+    const modifiers = beforeModal.slice(1);
+    if (modifiers.some((node) => !isPremodalClauseModifier(node))) return null;
+    const type = modalClauseTypeForLeadingNode(leading);
+    if (!type) return null;
+    const children = [...beforeModal, modalSpan];
+    return construction(type, modalClauseLabelForType(type), children, {
+      note: "v0.5.31 subject/topic/location-preserving modal clause. The existing ModalVP is kept as the visible predicate child instead of becoming a separate top-level span.",
+      slots: templateDerivedSlots(type, children),
+      trace: traceInfo("generative_template", {
+        construction_type: type,
+        template: modalClauseTemplateForType(type, modifiers),
+        assigned_slots: [type === "LocativeModalPredicateClause" ? "location" : type === "SubjectModalPredicateClause" ? "subject" : "topic", ...modifiers.map((node) => nodeCanFillSlot(node, "time") ? "time" : nodeCanFillSlot(node, "how") ? "how" : "manner"), "modal_vp"],
+        surfaces: children.map((node) => flattenSurface(node)),
+        reason: "Wraps a generated topic/subject/location prefix plus an existing ModalVP without changing the ModalVP internals.",
+      }),
+    });
+  }
+
+  function coordinatedSubjectModalPredicateClauseFallback(core) {
+    const { core: bareCore, particles } = withoutTrailingParticles(core);
+    const compact = withoutIgnorableSpaceText(bareCore);
+    if (compact.length < 5) return null;
+    const coord = coordinatedNPFromParts(compact.slice(0, 3));
+    if (!coord) return null;
+    const rest = compact.slice(3);
+    const modalVP = modalVPFromNodes(rest);
+    if (!modalVP || !nodeCanFillSlot(modalVP, "modal_vp")) return null;
+    const children = [coord, modalVP, ...particles];
+    return construction("CoordinatedSubjectModalPredicateClause", "CoordSubjModal", children, {
+      note: "v0.5.35 coordinated-subject modal clause: coordinated subject + existing ModalVP child.",
+      slots: templateDerivedSlots("CoordinatedSubjectModalPredicateClause", children),
+      trace: traceInfo("generative_template", {
+        construction_type: "CoordinatedSubjectModalPredicateClause",
+        template: ["subject!", "modal_vp!", "particle?"],
+        assigned_slots: ["subject", "modal_vp", ...particles.map(() => "particle")],
+        surfaces: children.map((node) => flattenSurface(node)),
+        reason: "Adds a subject-preserving wrapper for the reviewed coordinated-subject modal pattern while keeping the ModalVP internals unchanged.",
+      }),
+    });
+  }
+
+  function modalPredicateWrapCoreFallback(core) {
+    const modalIndex = core.findIndex(isModalToken);
+    if (modalIndex < 0 || modalIndex >= core.length - 1) return null;
+    const before = core.slice(0, modalIndex);
+    let modalSpan = modalVPFromNodes(core.slice(modalIndex));
+    if (!modalSpan) {
+      modalSpan = construction("ModalVP", "ModalVP", core.slice(modalIndex), {
+        note: "Modal/desiderative construction wrapping following predicate.",
+        trace: traceInfo("generative_or_heuristic_slot_rule", {
+          rule: "modal token followed by predicate material",
+          reason: "Fallback only; governed ModalVP should normally catch modal + VP material.",
+        }),
+      });
+    }
+    const modalClause = modalPredicateClauseFromParts(before, modalSpan);
+    if (modalClause) return [modalClause];
+    return [...before, modalSpan];
+  }
+
+  return {
+    coordinatedSubjectModalPredicateClauseFallback,
+    modalPredicateWrapCoreFallback,
+    modalVPFromNodes,
+  };
+};

--- a/src/plugin-entry.js
+++ b/src/plugin-entry.js
@@ -2015,91 +2015,23 @@ function wrapAgreementResponseSubspans(nodes) {
   return result;
 }
 
-function isPriorityActionCandidate(node) {
-  if (!node || node.kind === "text") return false;
-  if (node.kind === "construction") {
-    const slots = nodeSlots(node);
-    return slots.includes("vp") || slots.includes("action_vp") || slots.includes("predicate") || slots.includes("directional_motion_vp") || slots.includes("productive_vo");
-  }
-  return isVerbLike(node);
-}
 
-function priorityMarkerTokenClone(node) {
-  return parserInactiveTokenClone(node, {
-    label: "how",
-    pos: "adverbial",
-    syntax: "priority_sequence_marker",
-    slots: ["priority_marker", "sequence_marker", "how"],
-    reason: "先 is being interpreted as a priority/sequence marker here, so it stays parser-inactive inside the parent clause wrapper.",
-  });
-}
 
-function priorityParticleClone(node) {
-  return parserInactiveTokenClone(node, {
-    label: "particle",
-    pos: "particle",
-    syntax: "sentence_final_particle",
-    slots: ["particle"],
-    reason: "Final particle stays parser-inactive inside a priority-marker clause wrapper.",
-  });
-}
 
-function makePriorityMarkerClause(actionNode, markerNode, particleNode = null) {
-  const children = [actionNode, priorityMarkerTokenClone(markerNode)];
-  if (particleNode) children.push(priorityParticleClone(particleNode));
-  return construction("PriorityMarkerClause", "Priority先", children, {
-    slots: ["priority_marker_clause", "sequence_priority_marker", "priority_marker", "vp", "action_vp", "predicate"],
-    note: "Priority/sequence marker clause: action + 先 + optional final particle, e.g. 你食先啦 = you eat first.",
-    trace: traceInfo("generative_template", {
-      construction_type: "PriorityMarkerClause",
-      template_family: "generative_template",
-      template: particleNode ? ["action_vp!", "priority_marker!", "particle?"] : ["action_vp!", "priority_marker!"],
-      assigned_slots: particleNode ? ["action_vp", "priority_marker", "particle"] : ["action_vp", "priority_marker"],
-      pattern: particleNode ? "predicate + priority_marker + final_particle" : "predicate + priority_marker",
-      reason: "Native speech uses 先 after an action predicate to mark priority/order ('do this first'); the action remains visible as the child predicate.",
-      surfaces: children.map((node) => flattenSurface(node)),
-    }),
-  });
-}
 
-function priorityMarkerClauseWithTrailingParticle(node, particleNode) {
-  if (!node || node.kind !== "construction" || node.type !== "PriorityMarkerClause" || !particleNode) return node;
-  if ((node.children || []).some((child) => isParticle(child))) return node;
-  return {
-    ...node,
-    children: [...(node.children || []), priorityParticleClone(particleNode)],
-    trace: {
-      ...(node.trace || {}),
-      pattern: "predicate + priority_marker + final_particle",
-      attached_trailing_particle: flattenSurface(particleNode),
-    },
-  };
-}
 
-function priorityMarkerPatternAt(nodes, index) {
-  if (!isPriorityActionCandidate(nodes[index])) return null;
-  if (!isToken(nodes[index + 1], "先")) return null;
-  if (isParticle(nodes[index + 2]) && ["啦", "喇", "呀", "啊"].includes(flattenSurface(nodes[index + 2]))) {
-    return { length: 3, particle: nodes[index + 2] };
-  }
-  return { length: 2, particle: null };
-}
 
-function wrapPriorityMarkerSubspans(nodes) {
-  const result = [];
-  let i = 0;
-  while (i < nodes.length) {
-    const match = priorityMarkerPatternAt(nodes, i);
-    if (match) {
-      result.push(makePriorityMarkerClause(nodes[i], nodes[i + 1], match.particle));
-      i += match.length;
-      continue;
-    }
-    result.push(nodes[i]);
-    i += 1;
-  }
-  return result;
-}
+
+const createPriorityDetectors = require("./parser/detectors/discourse/priority");
+const {
+  priorityMarkerClauseWithTrailingParticle,
+  sourceLinkedPriorityMarkerClauseFallback,
+  wrapPriorityMarkerSubspans,
+} = createPriorityDetectors({
+  categorySubspanFor, cleanSlots, construction, flattenSurface, isParticle, isToken,
+  isVerbLike, nodeCanFillSlot, nodeSlots, parserInactiveTokenClone, traceInfo,
+  withoutIgnorableSpaceText, withoutTrailingParticles,
+});
 
 function isSubjectLike(node) {
   return nodeSlots(node).includes("subject");
@@ -2534,6 +2466,30 @@ const {
   token, traceInfo, withoutTrailingParticles, wrapCategorySubspans,
 });
 
+const createModalPredicateDetectors = require("./parser/detectors/modality/modal-predicates");
+const {
+  coordinatedSubjectModalPredicateClauseFallback,
+  modalPredicateWrapCoreFallback,
+  modalVPFromNodes,
+} = createModalPredicateDetectors({
+  categorySubspanFor, construction, coordinatedNPFromParts, firstToken, flattenSurface,
+  isModalToken, nodeCanFillSlot, templateConstructionFor, templateDerivedSlots,
+  traceInfo, withoutIgnorableSpaceText, withoutTrailingParticles,
+});
+
+const createIntentionPreferenceDetectors = require("./parser/detectors/modality/intention-preference");
+const {
+  desiderativeVPWrapCoreFallback,
+  preferenceVPWrapCoreFallback,
+  rawPreferenceTemplateFallback,
+  sourceLinkedIntentionFrameFallback,
+  sourceLinkedPreferenceVPFallback,
+} = createIntentionPreferenceDetectors({
+  categorySubspanFor, construction, flattenSurface, hasSurface, isToken,
+  nodeCanFillSlot, templateConstructionFor, templateDerivedSlots, traceInfo,
+  withoutIgnorableSpaceText, withoutTrailingParticles,
+});
+
 const createOpinionDetectors = require("./parser/detectors/opinion/stance");
 const { opinionStanceFrameFallback } = createOpinionDetectors({
   applyConstructionPatterns, categorySubspanFor, cleanSlots, construction, copulaClone,
@@ -2751,95 +2707,13 @@ function subjectStativePredicateClauseFallback(nodes) {
   });
 }
 
-function isModalPredicateConstruction(node) {
-  return node && node.kind === "construction" && node.type === "ModalVP";
-}
 
-function isPremodalClauseModifier(node) {
-  if (!node) return false;
-  if (node.kind === "text") return false;
-  return nodeCanFillSlot(node, "time") || nodeCanFillSlot(node, "how") || nodeCanFillSlot(node, "manner");
-}
 
-function modalClauseTypeForLeadingNode(node) {
-  if (!node) return "";
-  if (nodeCanFillSlot(node, "location") || nodeCanFillSlot(node, "locative_phrase")) return "LocativeModalPredicateClause";
-  if (nodeCanFillSlot(node, "subject") && !nodeCanFillSlot(node, "object")) return "SubjectModalPredicateClause";
-  if (nodeCanFillSlot(node, "subject") && (firstToken(node) || {}).label === "who") return "SubjectModalPredicateClause";
-  if (nodeCanFillSlot(node, "topic") || nodeCanFillSlot(node, "np") || nodeCanFillSlot(node, "head_noun")) return "TopicModalPredicateClause";
-  return "";
-}
 
-function modalClauseLabelForType(type) {
-  if (type === "LocativeModalPredicateClause") return "LocModal";
-  if (type === "SubjectModalPredicateClause") return "SubjModal";
-  if (type === "TopicModalPredicateClause") return "TopicModal";
-  return "ModalClause";
-}
 
-function modalPredicateFromNodes(nodes) {
-  if (!nodes || !nodes.length) return null;
-  if (nodes.length === 1 && nodeCanFillSlot(nodes[0], "vp")) return nodes[0];
-  const templated = categorySubspanFor(nodes, ["VerbComplementVP", "DirectionalMotionVP", "CompoundDirectionalMotionVP", "NegatedDirectionalMotionVP", "DegreeMannerAdverbial"])
-    || templateConstructionFor(nodes, ["VerbComplementVP", "TransitiveVP", "ProductiveVO", "CompletionVP", "DirectionalMotionVP", "MotionPurposeChain", "SerialVerbPurposeChain"]);
-  if (templated && nodeCanFillSlot(templated, "vp")) return templated;
-  return null;
-}
 
-function modalVPFromNodes(nodes) {
-  if (!nodes || !nodes.length) return null;
-  const generated = templateConstructionFor(nodes, ["ModalVP"]);
-  if (generated) return generated;
-  const { core: bareCore, particles } = withoutTrailingParticles(nodes);
-  if (!bareCore.length || !nodeCanFillSlot(bareCore[0], "modal")) return null;
-  const modal = bareCore[0];
-  const predicateNodes = bareCore.slice(1);
-  if (!predicateNodes.length) return null;
-  const predicate = modalPredicateFromNodes(predicateNodes);
-  if (!predicate || !nodeCanFillSlot(predicate, "vp")) return null;
-  const children = [modal, predicate, ...particles];
-  return construction("ModalVP", "ModalVP", children, {
-    note: "Broad modal VP: modal auxiliary plus VP/predicate complement. Matched by governed generated slots rather than the old modal-token heuristic.",
-    slots: templateDerivedSlots("ModalVP", children),
-    trace: traceInfo("generative_template", {
-      construction_type: "ModalVP",
-      template_family: "generative_template",
-      template: ["modal!", "vp!", "particle?"],
-      assigned_slots: ["modal", "vp", ...particles.map(() => "particle")],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Promotes modal + VP/predicate material into the governed generative-template lane while preserving the predicate child span.",
-    }),
-  });
-}
 
-function modalClauseTemplateForType(type, modifiers) {
-  const first = type === "LocativeModalPredicateClause" ? "location!" : type === "SubjectModalPredicateClause" ? "subject!" : "topic!";
-  const middle = modifiers.map((node) => nodeCanFillSlot(node, "time") ? "time?" : nodeCanFillSlot(node, "how") ? "how?" : "manner?");
-  return [first, ...middle, "modal_vp!"];
-}
 
-function modalPredicateClauseFromParts(beforeModal, modalSpan) {
-  if (!isModalPredicateConstruction(modalSpan)) return null;
-  if (!beforeModal.length) return null;
-  if (beforeModal.some((node) => node.kind === "text")) return null;
-  const leading = beforeModal[0];
-  const modifiers = beforeModal.slice(1);
-  if (modifiers.some((node) => !isPremodalClauseModifier(node))) return null;
-  const type = modalClauseTypeForLeadingNode(leading);
-  if (!type) return null;
-  const children = [...beforeModal, modalSpan];
-  return construction(type, modalClauseLabelForType(type), children, {
-    note: "v0.5.31 subject/topic/location-preserving modal clause. The existing ModalVP is kept as the visible predicate child instead of becoming a separate top-level span.",
-    slots: templateDerivedSlots(type, children),
-    trace: traceInfo("generative_template", {
-      construction_type: type,
-      template: modalClauseTemplateForType(type, modifiers),
-      assigned_slots: [type === "LocativeModalPredicateClause" ? "location" : type === "SubjectModalPredicateClause" ? "subject" : "topic", ...modifiers.map((node) => nodeCanFillSlot(node, "time") ? "time" : nodeCanFillSlot(node, "how") ? "how" : "manner"), "modal_vp"],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Wraps a generated topic/subject/location prefix plus an existing ModalVP without changing the ModalVP internals.",
-    }),
-  });
-}
 
 function isIgnorableSpaceText(node) {
   return node && node.kind === "text" && !hasSentencePunctuation(node.text) && !normalizeSurface(node.text);
@@ -2868,61 +2742,7 @@ function nameTokenClone(node) {
   });
 }
 
-function sourceLinkedIntentionFrameFallback(core) {
-  const { core: bareCore, particles } = withoutTrailingParticles(core);
-  const compact = withoutIgnorableSpaceText(bareCore);
-  if (compact.length < 3) return null;
-  const [subject, intentionPredicate, ...predicateNodes] = compact;
-  if (!nodeCanFillSlot(subject, "subject") || !isToken(intentionPredicate, "諗住")) return null;
-  const predicate = categorySubspanFor(predicateNodes, [
-    "DirectionalMotionVP",
-    "CompoundDirectionalMotionVP",
-    "VerbComplementVP",
-    "TransitiveVP",
-    "ProductiveVO",
-  ]);
-  if (!predicate || !nodeCanFillSlot(predicate, "vp")) return null;
-  const children = [subject, intentionPredicate, predicate, ...particles];
-  return construction("IntentionFrame", "Intention", children, {
-    note: "Source-linked lexical intention profile: overt subject + 諗住 + visible VP.",
-    slots: templateDerivedSlots("IntentionFrame", children),
-    trace: traceInfo("generative_template", {
-      construction_type: "IntentionFrame",
-      template: ["subject!", "intention_predicate!", "vp!", "particle?"],
-      constraints: { slot_surface_in: { intention_predicate: ["諗住"] } },
-      assigned_slots: ["subject", "intention_predicate", "vp", ...particles.map(() => "particle")],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Runs before broad VP-complement subspan wrapping so the overt subject and lexical intention predicate remain visible.",
-    }),
-  });
-}
 
-function sourceLinkedPreferenceVPFallback(core) {
-  const { core: bareCore, particles } = withoutTrailingParticles(core);
-  const compact = withoutIgnorableSpaceText(bareCore);
-  if (compact.length < 3 || !nodeCanFillSlot(compact[0], "subject") || !isToken(compact[1], "鍾意")) return null;
-  const complement = categorySubspanFor(compact.slice(2), [
-    "TransitiveVP",
-    "ProductiveVO",
-    "DirectionalMotionVP",
-    "CompoundDirectionalMotionVP",
-    "VerbComplementVP",
-  ]);
-  if (!complement || !nodeCanFillSlot(complement, "vp")) return null;
-  const children = [compact[0], compact[1], complement, ...particles];
-  return construction("PreferenceVP", "Preference", children, {
-    note: "Source-linked preference predicate with an overt subject and visible activity VP complement.",
-    slots: templateDerivedSlots("PreferenceVP", children),
-    trace: traceInfo("generative_template", {
-      construction_type: "PreferenceVP",
-      template: ["subject!", "preference_predicate!", "vp!", "particle?"],
-      constraints: { slot_surface_in: { preference_predicate: ["鍾意"] } },
-      assigned_slots: ["subject", "preference_predicate", "vp", ...particles.map(() => "particle")],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Runs before broad nominal wrapping so the sourced 鍾意 + activity complement remains visible.",
-    }),
-  });
-}
 
 function sourceLinkedDegreeMannerModifiedVPFallback(core) {
   const { core: bareCore, particles } = withoutTrailingParticles(core);
@@ -2960,29 +2780,6 @@ function sourceLinkedDegreeMannerModifiedVPFallback(core) {
   });
 }
 
-function sourceLinkedPriorityMarkerClauseFallback(core) {
-  const { core: bareCore, particles } = withoutTrailingParticles(core);
-  const compact = withoutIgnorableSpaceText(bareCore);
-  if (compact.length < 3 || !nodeCanFillSlot(compact[0], "subject")) return null;
-  const markerIndex = compact.findIndex((node, index) => index > 1 && isToken(node, "先"));
-  if (markerIndex < 0 || markerIndex !== compact.length - 1) return null;
-  const action = categorySubspanFor(compact.slice(1, markerIndex), ["ProductiveVO", "TransitiveVP"]);
-  if (!action || flattenSurface(action) !== "打電話") return null;
-  if (particles.length !== 1 || !isToken(particles[0], "啦")) return null;
-  const children = [compact[0], action, priorityMarkerTokenClone(compact[markerIndex]), priorityParticleClone(particles[0])];
-  return construction("PriorityMarkerClause", "Priority先", children, {
-    note: "Source-linked postverbal 先 profile in 你打電話先啦.",
-    slots: cleanSlots(["priority_marker_clause", "sequence_priority_marker", "priority_marker", "subject", "vp", "action_vp", "predicate"]),
-    trace: traceInfo("generative_template", {
-      construction_type: "PriorityMarkerClause",
-      template: ["subject!", "action_vp!", "priority_marker!", "particle!"],
-      constraints: { surface_sequence: "你打電話先啦" },
-      assigned_slots: ["subject", "action_vp", "priority_marker", "particle"],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Retains the exact attested action + postverbal 先 + 啦 profile while excluding preverbal and deferral uses.",
-    }),
-  });
-}
 
 const {
   protectedOpaqueFormulaPassthrough,
@@ -3423,28 +3220,6 @@ const {
   withoutIgnorableSpaceText,
   withoutTrailingParticles,
 });
-function coordinatedSubjectModalPredicateClauseFallback(core) {
-  const { core: bareCore, particles } = withoutTrailingParticles(core);
-  const compact = withoutIgnorableSpaceText(bareCore);
-  if (compact.length < 5) return null;
-  const coord = coordinatedNPFromParts(compact.slice(0, 3));
-  if (!coord) return null;
-  const rest = compact.slice(3);
-  const modalVP = modalVPFromNodes(rest);
-  if (!modalVP || !nodeCanFillSlot(modalVP, "modal_vp")) return null;
-  const children = [coord, modalVP, ...particles];
-  return construction("CoordinatedSubjectModalPredicateClause", "CoordSubjModal", children, {
-    note: "v0.5.35 coordinated-subject modal clause: coordinated subject + existing ModalVP child.",
-    slots: templateDerivedSlots("CoordinatedSubjectModalPredicateClause", children),
-    trace: traceInfo("generative_template", {
-      construction_type: "CoordinatedSubjectModalPredicateClause",
-      template: ["subject!", "modal_vp!", "particle?"],
-      assigned_slots: ["subject", "modal_vp", ...particles.map(() => "particle")],
-      surfaces: children.map((node) => flattenSurface(node)),
-      reason: "Adds a subject-preserving wrapper for the reviewed coordinated-subject modal pattern while keeping the ModalVP internals unchanged.",
-    }),
-  });
-}
 
 
 
@@ -5979,7 +5754,7 @@ function wrapCore(core) {
 
   // Preference needs a top-level pass before broad NP category wrapping.
   // Otherwise 鍾意 + VP can be mis-wrapped as ModifiedNP because the VP exports noun/object slots from its object child.
-  const rawPreferenceSpan = templateConstructionFor(core, ["PreferenceVP"]);
+  const rawPreferenceSpan = rawPreferenceTemplateFallback(core);
   if (rawPreferenceSpan) return [rawPreferenceSpan];
 
   const negativeCognitionSpan = negativeCognitionFragmentFallback(core);
@@ -6162,9 +5937,8 @@ function wrapCore(core) {
   const experientialQuestionBoundary = experientialQuestionBoundaryFallback(core);
   if (experientialQuestionBoundary) return [experientialQuestionBoundary];
 
-  if (hasSurface(core, "想") && (hasSurface(core, "好") || hasSurface(core, "試吓"))) {
-    return [construction("DesiderativeVP", "WantVP", core, { note: "Desire/wanting construction, often 好想 + VP.", trace: traceInfo("legacy_surface_rule", { rule: "has 想 plus degree/VP", reason: "Surface modal fallback." }) })];
-  }
+  const desiderativeSpan = desiderativeVPWrapCoreFallback(core);
+  if (desiderativeSpan) return [desiderativeSpan];
 
   // Source-linked negative 算 evaluation. Keep the overt predicate and any subject/topic material visible.
   if (hasSurface(core, "唔") && hasSurface(core, "算") && hasSurface(core, "貴")) {
@@ -6202,15 +5976,8 @@ function wrapCore(core) {
   if (existentialWhQuestion) return [existentialWhQuestion];
 
   // Preference fallback: normally handled by the PreferenceVP template before broad NP category wrapping.
-  if (hasSurface(core, "鍾意")) {
-    return [construction("PreferenceVP", "Preference", core, {
-      note: "Preference fallback: preference predicate taking a VP/object complement.",
-      trace: traceInfo("construction_function", {
-        construction_type: "PreferenceVP",
-        reason: "Fallback only; generative PreferenceVP should normally catch this before ModifiedNP wrapping."
-      })
-    })];
-  }
+  const preferenceFallbackSpan = preferenceVPWrapCoreFallback(core);
+  if (preferenceFallbackSpan) return [preferenceFallbackSpan];
 
   // Temporal clause fallback: normally handled by the TemporalClause template.
   if (core.length >= 2 && firstToken(core[0]) && firstToken(core[0]).label === "when") {
@@ -6260,17 +6027,8 @@ function wrapCore(core) {
 
   // Modal + VP/predicate: NP? Modal Predicate.
   // v0.5.56: prefer governed generative ModalVP; retain the old slot heuristic only as a final fallback.
-  const modalIndex = core.findIndex(isModalToken);
-  if (modalIndex >= 0 && modalIndex < core.length - 1) {
-    const before = core.slice(0, modalIndex);
-    let modalSpan = modalVPFromNodes(core.slice(modalIndex));
-    if (!modalSpan) {
-      modalSpan = construction("ModalVP", "ModalVP", core.slice(modalIndex), { note: "Modal/desiderative construction wrapping following predicate.", trace: traceInfo("generative_or_heuristic_slot_rule", { rule: "modal token followed by predicate material", reason: "Fallback only; governed ModalVP should normally catch modal + VP material." }) });
-    }
-    const modalClause = modalPredicateClauseFromParts(before, modalSpan);
-    if (modalClause) return [modalClause];
-    return [...before, modalSpan];
-  }
+  const modalPredicateWrapSpan = modalPredicateWrapCoreFallback(core);
+  if (modalPredicateWrapSpan) return modalPredicateWrapSpan;
 
   return wrapPredicate(core);
 }


### PR DESCRIPTION
<!-- coordination-claim: #231 -->

Parent program: #161
Queue owner: #169
Intake issue: #194
Work claim: #231
Active worker: ChatGPT
Ownership revision: 1

Closes #194
Closes #231

## Outcome

Extract the existing modal predicate/clause composition and source-linked intention, preference, desiderative, priority-marker, and coordinated-subject modal detector families into focused dependency-injected modules without changing modal scope, complement boundaries, coordination, marker precedence, traces, learner roles, parser output, rendering, expectations, or runtime version.

## Final state

- exact head: `3aaebf2b32b5e42e13e8b172da93d259e96d9f39`;
- base: `main` at `f3957b275c604970182f19ab2413f366c570236d`;
- one clean commit ahead, zero behind;
- changed files: five;
- no documentation, fixture, expectation, version, workflow, temporary-tool, evidence, corpus, or survey changes remain.

## Changed files

- `src/parser/detectors/modality/modal-predicates.js` — modal predicate helpers, modal VP composition, coordinated-subject modal clauses, and clause wrappers;
- `src/parser/detectors/modality/intention-preference.js` — source-linked intention, preference, and desiderative detectors;
- `src/parser/detectors/discourse/priority.js` — priority-marker clause detection and composition;
- `src/plugin-entry.js` — dependency wiring while preserving existing invocation sites and order;
- `main.js` — deterministic generated deployment bundle.

## Validation

- validated artifact digest: `sha256:868fa175ffe7d47db762044ab40c6e867eaba576fdbf838955182f8104ad0d11`;
- deterministic runtime-build verification: PASS;
- regression output byte-for-byte parity: PASS;
- NP subsystem output byte-for-byte parity: PASS;
- construction output byte-for-byte parity: PASS;
- Glossika Week 16 runtime lexicon test: PASS;
- complete standard test suite: PASS;
- syntax checks for all extracted modules and `src/plugin-entry.js`: PASS;
- exact changed-path guard: PASS;
- generated validation snapshots restored/removed: PASS;
- runtime, package, and manifest versions remain `0.5.216`;
- exact-head Supported productive discovery workflow: PASS;
- exact-head Coordination claim workflow: PASS.

The existing duplicate-object-key and legacy HTML-comment build warnings were already present on the unchanged baseline and are outside this behavior-preserving extraction.

## Protected boundaries

- no new modal, intention, preference, desiderative, priority, or coordination grammar;
- no modal scope, complement boundary, coordination, marker precedence, trace, learner-role, or detector-order changes outside the named family helpers;
- no construction identity/status, evidence, corpus, survey, fixture, release, or version changes.

## Merge gate

Do not merge without explicit user approval for PR #232 at the unchanged exact head `3aaebf2b32b5e42e13e8b172da93d259e96d9f39`.