### PR TITLE
Require evidence-triggered, balanced research selection

### DIFF
--- a/docs/current/PROJECT-STATE.md
+++ b/docs/current/PROJECT-STATE.md
@@ -66,6 +66,12 @@ The canonical construction blacklist is [`../../data/parked-constructions.json`]
 
 New constructions, splits, broadenings, status changes, and runtime changes still require all applicable identity, evidence, boundary, documentation, testing, and review gates. Legacy note workflow fields are compatibility metadata only.
 
+Availability does not create a fixed research queue. Recent work on one construction or family gives its follow-up tasks neither automatic priority nor automatic exclusion.
+
+A substantive research issue must cite a concrete trigger from current parser behavior, primary sources, project corpora, eligible native judgments, learner/source material, or audited survey evidence. Discovery scores, empty metadata, retired wrappers, and broad family-gap reports can locate work but are not sufficient by themselves. The issue must state a falsifiable unresolved question, bounded evidence, competing analyses and negative boundaries, the decision it could inform, and an acceptable null outcome such as no new construction, lexical-only evidence, an instrument problem, or no runtime change.
+
+Implementation specifications, human artifact requests, corpus ingestion, work claims, and pull requests are execution records rather than independent linguistic research questions.
+
 ## Discovery state
 
 | Candidate state | Records |
@@ -123,13 +129,16 @@ Stable verification is `npm run verify`; full verification is `npm run verify:al
 ## Current work order
 
 1. Keep documentation, canonical data, status notes, runtime, survey metadata, corpus records, agent settings, claims, and generated reports consistent.
-2. Select the highest-benefit non-parked task after checking live work, evidence gaps, learner impact, ontology risk, dependencies, and implementation leverage.
-3. Continue identity adjudication from the 92 pending UUIDs when it outranks other work; batches are opportunities, not a mandatory queue.
-4. Complete pending HKCanCor inventories through deterministic extraction and separate expert review, using human local execution only when access requires it.
-5. Keep `YUE-JUDGMENT-PILOT-01` in collection until its stopping rule is met, then audit items and responses before revising a follow-up.
-6. Expand AB30 corpus diversity when that work outranks other available tasks.
-7. Implement status-path or runtime-label migrations only in explicitly scoped reviewed changes.
-8. Do not create duplicate current-state ledgers, verifier families, naming systems, or unscoped automatic writers.
+2. Select the highest-benefit non-parked task after checking live work, evidence gaps, learner impact, ontology risk, source and data availability, dependencies, implementation leverage, and recent topic concentration.
+3. Require each substantive research issue to identify an actual project trigger, a falsifiable unresolved linguistic question, bounded evidence, relevant counterevidence and ambiguity, and an acceptable null outcome.
+4. Treat topic diversity as a balancing factor: do not let the same few construction families repeatedly dominate when similarly valuable alternatives exist elsewhere.
+5. Continuing within the same family is allowed when its follow-up is genuinely the strongest next task; recent work gives a topic neither automatic priority nor automatic exclusion.
+6. Keep accepted implementation, runtime/design audits, human actions, corpus ingestion, claims, and pull requests separate from the substantive research portfolio.
+7. Continue identity adjudication from the 92 pending UUIDs when it outranks other work; batches are opportunities, not a mandatory queue.
+8. Complete useful HKCanCor inventories through deterministic extraction and separate expert review when they expose a bounded empirical question that outranks other available work, using human local execution only when access requires it.
+9. Keep `YUE-JUDGMENT-PILOT-01` in collection until its stopping rule is met, then audit item wording, eligibility, exclusions, quality, comments, interpretations, controls, and regional limitations before drawing conclusions or revising a follow-up.
+10. Implement status-path or runtime-label migrations only in explicitly scoped reviewed changes.
+11. Do not create duplicate current-state ledgers, verifier families, naming systems, fixed construction queues, or unscoped automatic writers.
 
 ## Historical-material rule
 


### PR DESCRIPTION
<!-- coordination-claim: #337 -->

Work claim: #337
Intake issue: #269

Closes #337

## Outcome and scope

Replace fixed or mechanically inherited research priority with an evidence-triggered selection rule. Research may continue within one family when justified, but substantive questions must arise from current parser behavior, sources, project corpora, eligible native judgments, learner material, or audited survey evidence.

## Coordination

- Work ID: `CS-WORK-0336`
- Claim mode: `shared`
- Integration role: `integrator`
- Active worker: `chatgpt`
- Ownership revision: `2`
- Live intake `active_pr`: `338`
- Branch: `agent/broaden-research-selection`
- Semantic regions: `docs/current/PROJECT-STATE.md` construction availability and current work order
- Pending changesets: none

## Exact change

- one file: `docs/current/PROJECT-STATE.md`;
- 16 additions, 7 deletions;
- no fixed construction queue or AB30-specific standing priority;
- require concrete empirical triggers, falsifiable questions, bounded evidence, counterevidence/ambiguity, an informed decision, and an acceptable null outcome;
- treat topic diversity as a balancing factor rather than mandatory rotation;
- keep implementation, runtime/design audits, human actions, corpus ingestion, claims, and PRs separate from substantive linguistic research;
- require item-level survey audit before survey-derived conclusions.

## Protected and unchanged

- construction identity and linguistic status;
- runtime behavior and executable fixtures;
- corpus candidate decisions and source files;
- panel evidence and the live survey instrument;
- held-out, release, deployment, and agent-availability state.

## Validation and independent review

- rebuilt from current `main` at `1e1d1b0c523e6d9a850e7d910b471d8bfea1e9cb`;
- exact head: `16c025346aebe7fc3120758fb9eff4b6dd16816a`;
- branch comparison: one commit ahead, zero behind;
- exact diff: one documentation file, 16 additions and 7 deletions;
- source-level review confirms factual counts and current corpus/survey state are unchanged;
- no pending changeset or generated validation artifact;
- local `npm run verify` is unavailable in the connected GitHub-only environment;
- GitHub checks are being read from the exact head before merge.

## One-time merge authorization

The repository owner explicitly directed ChatGPT on 2026-07-30 to override the per-PR merge contract for this recursive issue-processing task. ChatGPT must still independently review the exact head, require a coherent non-conflicting change, and check applicable available validation before merging.