### PR TITLE
Allow portfolio-routed issues to bind v2 work claims

### DIFF
--- a/docs/current/CODEX-ISSUE-WORKFLOW.md
+++ b/docs/current/CODEX-ISSUE-WORKFLOW.md
@@ -181,9 +181,15 @@ repository but must run on the user's local device:
 Local untracked `validation/current/` byproducts are not included unless the claim
 explicitly covers them.
 
-## 7. Unified intake ownership
+## 7. Intake ownership and portfolio routing
 
-Every current intake uses one `canto-span-task-intake-v2` block and distinguishes:
+The pull-request verifier accepts exactly one of two parent-issue routing modes.
+Mixed, missing, duplicate, malformed, or unsupported routing blocks fail closed.
+
+### Ownership-aware task intake
+
+A current operational intake normally uses one `canto-span-task-intake-v2` block and
+distinguishes:
 
 - `created_by`: who prepared the issue;
 - `pickup_target`: who must act next;
@@ -229,6 +235,28 @@ An initial ChatGPT intake may use:
 Use the checked-in schema rather than copying this example blindly. The selected
 pickup target and current workflow setting must agree.
 
+### Portfolio-routed parent issue
+
+A planning or decision issue may instead contain exactly one
+`canto-span-portfolio-routing-v2` block and no `task-intake` block. This mode avoids
+copying operational ownership metadata into every issue produced by the portfolio
+plan. It authorizes a pull request only when all of the following remain true:
+
+1. the parent issue is open and the routing block validates;
+2. the work claim is `canto-span-work-claim-v2`, active, unexpired, and names that
+   parent issue in `intake_issue`;
+3. the claim branch matches the pull-request head;
+4. the pull-request body states the same `Active worker` and `Ownership revision` as
+   the claim;
+5. every portfolio `write_lock` is retained by the claim;
+6. the claim acquires none of the portfolio `prohibited_parallel_writes`;
+7. changed-file coverage remains inside the claim; and
+8. the separate user merge gate remains in force.
+
+The portfolio block is planning authority plus direct claim binding. It is not a
+mutable ownership ledger and cannot perform takeover, reassignment, or handoff. Any
+such ownership transition must use the ownership-aware `task-intake-v2` path.
+
 Legacy intake and claim formats remain readable historical records. They must migrate
 to current ownership-aware formats before takeover, reassignment, or active binding.
 
@@ -248,10 +276,11 @@ agent setting. Removing or changing only one layer is insufficient.
 4. Re-fetch ownership before claim creation.
 5. Create the smallest adequate work claim and exact branch.
 6. Implement or produce findings within scope.
-7. Open one linked PR and bind `active_pr` to the assigned GitHub PR number.
+7. Open one linked PR and bind `active_pr` to the assigned GitHub PR number when the
+   parent uses task-intake ownership; repeat the claim worker and revision in every PR.
 8. Use draft state only while work or dependencies remain unresolved.
-9. Validate exact head, live ownership, overlap, changed-file coverage, and required
-   checks.
+9. Validate exact head, live routing mode, ownership or claim binding, overlap,
+   changed-file coverage, and required checks.
 10. Mark the coherent PR ready, notify the user, and stop.
 11. Merge only after explicit user approval for that PR and unchanged head.
 

--- a/tests/tooling/coordination/portfolio-routing.test.js
+++ b/tests/tooling/coordination/portfolio-routing.test.js
@@ -1,0 +1,145 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  extractPortfolioRouting,
+  intakeRoutingCounts,
+  validatePortfolioOwnershipBinding,
+  validatePortfolioRouting,
+} = require("../../../tools/coordination/portfolio-routing");
+const { resolveIntakeRouting } = require("../../../tools/coordination/check-pr");
+
+function validRouting(overrides = {}) {
+  return {
+    schema: "canto-span-portfolio-routing-v2",
+    track: "T2-identity",
+    kind: "identity-batch",
+    research_mode: "decision-support",
+    priority: "P2",
+    priority_reason: "The bounded identity package resolves a current registry gap.",
+    decision_question: "What permanent identity disposition is justified?",
+    dependencies: [],
+    informs: ["T5-evidence"],
+    read_scope: ["identity registry", "accepted neighboring decisions"],
+    write_locks: ["identity:example"],
+    prohibited_parallel_writes: ["runtime:example"],
+    acceptable_null_outcome: "The record remains retired with no successor UUID.",
+    completion_endpoint: "The permanent identity disposition and evidence home are recorded.",
+    ...overrides,
+  };
+}
+
+function fenced(label, value) {
+  return `\`\`\`${label}\n${JSON.stringify(value, null, 2)}\n\`\`\``;
+}
+
+function validClaim(overrides = {}) {
+  return {
+    schema: "canto-span-work-claim-v2",
+    intake_issue: 370,
+    active_worker: "chatgpt",
+    ownership_revision: 1,
+    branch: "agent/example",
+    write_locks: ["identity:example"],
+    ...overrides,
+  };
+}
+
+function validPr(overrides = {}) {
+  return {
+    number: 500,
+    body: "Active worker: chatgpt\nOwnership revision: 1",
+    head: { ref: "agent/example" },
+    ...overrides,
+  };
+}
+
+test("extracts exactly one portfolio-routing block", () => {
+  const routing = validRouting();
+  assert.deepEqual(extractPortfolioRouting(fenced("portfolio-routing", routing)), routing);
+});
+
+test("rejects missing and duplicate portfolio-routing blocks", () => {
+  assert.throws(() => extractPortfolioRouting("no block"), /exactly one/);
+  const body = `${fenced("portfolio-routing", validRouting())}\n${fenced("portfolio-routing", validRouting())}`;
+  assert.throws(() => extractPortfolioRouting(body), /exactly one/);
+});
+
+test("validates current portfolio-routing fields and enums", () => {
+  assert.deepEqual(validatePortfolioRouting(validRouting()), []);
+
+  const errors = validatePortfolioRouting(validRouting({
+    track: "identity",
+    priority: "urgent",
+    unsupported: true,
+    read_scope: ["identity registry", "identity registry"],
+  }));
+  assert.ok(errors.some((error) => error.includes("track must match")));
+  assert.ok(errors.some((error) => error.includes("priority must")));
+  assert.ok(errors.some((error) => error.includes("unsupported portfolio-routing field")));
+  assert.ok(errors.some((error) => error.includes("read_scope must contain unique")));
+});
+
+test("resolves exactly one supported intake mode", () => {
+  const portfolioBody = fenced("portfolio-routing", validRouting());
+  assert.equal(resolveIntakeRouting(portfolioBody).mode, "portfolio-routing");
+  assert.deepEqual(intakeRoutingCounts(portfolioBody), { taskIntake: 0, portfolioRouting: 1 });
+
+  const taskBody = fenced("task-intake", { schema: "canto-span-task-intake-v2" });
+  assert.equal(resolveIntakeRouting(taskBody).mode, "task-intake");
+
+  assert.throws(
+    () => resolveIntakeRouting(`${portfolioBody}\n${taskBody}`),
+    /exactly one supported routing block/,
+  );
+});
+
+test("portfolio routing accepts a coherent v2 claim binding", () => {
+  const errors = validatePortfolioOwnershipBinding(
+    validClaim(),
+    373,
+    validRouting(),
+    370,
+    validPr(),
+    { activeWorker: "chatgpt", ownershipRevision: 1 },
+  );
+  assert.deepEqual(errors, []);
+});
+
+test("portfolio routing rejects mismatched ownership, branch, and locks", () => {
+  const errors = validatePortfolioOwnershipBinding(
+    validClaim({
+      intake_issue: 999,
+      active_worker: "human",
+      ownership_revision: 2,
+      branch: "agent/other",
+      write_locks: ["runtime:example"],
+    }),
+    373,
+    validRouting(),
+    370,
+    validPr(),
+    { activeWorker: "chatgpt", ownershipRevision: 1 },
+  );
+
+  assert.ok(errors.some((error) => error.includes("claim intake_issue")));
+  assert.ok(errors.some((error) => error.includes("claim branch")));
+  assert.ok(errors.some((error) => error.includes("PR worker")));
+  assert.ok(errors.some((error) => error.includes("PR ownership revision")));
+  assert.ok(errors.some((error) => error.includes("does not preserve portfolio write lock")));
+  assert.ok(errors.some((error) => error.includes("acquires prohibited parallel write")));
+});
+
+test("portfolio routing requires a v2 claim", () => {
+  const errors = validatePortfolioOwnershipBinding(
+    validClaim({ schema: "canto-span-work-claim-v1" }),
+    373,
+    validRouting(),
+    370,
+    validPr(),
+    { activeWorker: "chatgpt", ownershipRevision: 1 },
+  );
+  assert.ok(errors.includes("portfolio routing requires a v2 work claim"));
+});

--- a/tests/tooling/coordination/portfolio-routing.test.js
+++ b/tests/tooling/coordination/portfolio-routing.test.js
@@ -61,10 +61,14 @@ test("extracts exactly one portfolio-routing block", () => {
   assert.deepEqual(extractPortfolioRouting(fenced("portfolio-routing", routing)), routing);
 });
 
-test("rejects missing and duplicate portfolio-routing blocks", () => {
+test("rejects missing, duplicate, and malformed portfolio-routing blocks", () => {
   assert.throws(() => extractPortfolioRouting("no block"), /exactly one/);
   const body = `${fenced("portfolio-routing", validRouting())}\n${fenced("portfolio-routing", validRouting())}`;
   assert.throws(() => extractPortfolioRouting(body), /exactly one/);
+  assert.throws(
+    () => extractPortfolioRouting("```portfolio-routing\n{not-json}\n```"),
+    /invalid portfolio-routing JSON/,
+  );
 });
 
 test("validates current portfolio-routing fields and enums", () => {

--- a/tools/coordination/check-pr.js
+++ b/tools/coordination/check-pr.js
@@ -13,6 +13,11 @@ const {
   extractTaskIntake,
   validateTaskMetadata,
 } = require("./codex-intake");
+const {
+  extractPortfolioRouting,
+  intakeRoutingCounts,
+  validatePortfolioOwnershipBinding,
+} = require("./portfolio-routing");
 
 const root = path.resolve(__dirname, "../..");
 const config = loadJson(path.join(root, "config/coordination-targets.json"));
@@ -126,6 +131,19 @@ function validateOwnershipBinding(claim, claimIssue, intake, intakeIssue, pr) {
   return errors;
 }
 
+function resolveIntakeRouting(issueBody) {
+  const counts = intakeRoutingCounts(issueBody);
+  if (counts.taskIntake === 1 && counts.portfolioRouting === 0) {
+    return { mode: "task-intake", metadata: extractTaskIntake(issueBody), counts };
+  }
+  if (counts.taskIntake === 0 && counts.portfolioRouting === 1) {
+    return { mode: "portfolio-routing", metadata: extractPortfolioRouting(issueBody), counts };
+  }
+  throw new Error(
+    `expected exactly one supported routing block; found task-intake=${counts.taskIntake}, portfolio-routing=${counts.portfolioRouting}`,
+  );
+}
+
 async function changedFiles(repository, prNumber, token) {
   const output = [];
   for (let page = 1; ; page += 1) {
@@ -174,14 +192,32 @@ async function main() {
   const intakeIssue = await github(`/repos/${repository}/issues/${intakeNumber}`, token);
   if (intakeIssue.pull_request) fail(`#${intakeNumber} is a pull request, not an intake issue`);
   if (intakeIssue.state !== "open") fail(`intake issue #${intakeNumber} is not open`);
-  let intake;
+
+  let intakeRouting;
   try {
-    intake = extractTaskIntake(intakeIssue.body);
+    intakeRouting = resolveIntakeRouting(intakeIssue.body);
   } catch (error) {
     fail(`intake issue #${intakeNumber} cannot be parsed`, error.message);
   }
-  const ownershipErrors = validateOwnershipBinding(claim, issueNumber, intake, intakeNumber, pr);
-  if (ownershipErrors.length) fail("live intake ownership does not authorize this pull request", ownershipErrors);
+
+  const ownershipErrors = intakeRouting.mode === "task-intake"
+    ? validateOwnershipBinding(claim, issueNumber, intakeRouting.metadata, intakeNumber, pr)
+    : validatePortfolioOwnershipBinding(
+      claim,
+      issueNumber,
+      intakeRouting.metadata,
+      intakeNumber,
+      pr,
+      prOwnershipFields(pr.body),
+    );
+  if (ownershipErrors.length) {
+    fail(
+      intakeRouting.mode === "task-intake"
+        ? "live intake ownership does not authorize this pull request"
+        : "portfolio routing does not authorize this pull request",
+      ownershipErrors,
+    );
+  }
 
   const files = await changedFiles(repository, pr.number, token);
   const coverage = validateChangedFiles(claim, files, config, { isDraft: Boolean(pr.draft) });
@@ -193,6 +229,7 @@ async function main() {
     pull_request: pr.number,
     work_claim_issue: issueNumber,
     intake_issue: intakeNumber,
+    intake_mode: intakeRouting.mode,
     work_id: claim.work_id,
     active_worker: claim.active_worker || null,
     ownership_revision: claim.ownership_revision || null,
@@ -215,5 +252,6 @@ module.exports = {
   intakeIssueNumber,
   legacyIntakeRequiresMigration,
   prOwnershipFields,
+  resolveIntakeRouting,
   validateOwnershipBinding,
 };

--- a/tools/coordination/portfolio-routing.js
+++ b/tools/coordination/portfolio-routing.js
@@ -1,0 +1,158 @@
+"use strict";
+
+const PORTFOLIO_SCHEMA = "canto-span-portfolio-routing-v2";
+const REQUIRED_FIELDS = [
+  "schema",
+  "track",
+  "kind",
+  "research_mode",
+  "priority",
+  "priority_reason",
+  "decision_question",
+  "dependencies",
+  "informs",
+  "read_scope",
+  "write_locks",
+  "prohibited_parallel_writes",
+  "acceptable_null_outcome",
+  "completion_endpoint",
+];
+const ALLOWED_FIELDS = new Set(REQUIRED_FIELDS);
+const WORKERS = new Set(["chatgpt", "codex", "human"]);
+
+function extractFencedBlocks(body, label) {
+  const pattern = new RegExp(`\\\`\\\`\\\`${label}[^\\n\\\`]*\\n([\\s\\S]*?)\\\`\\\`\\\``, "gi");
+  return [...String(body || "").matchAll(pattern)];
+}
+
+function intakeRoutingCounts(body) {
+  return {
+    taskIntake: extractFencedBlocks(body, "task-intake").length,
+    portfolioRouting: extractFencedBlocks(body, "portfolio-routing").length,
+  };
+}
+
+function extractPortfolioRouting(body) {
+  const matches = extractFencedBlocks(body, "portfolio-routing");
+  if (matches.length !== 1) {
+    throw new Error("expected exactly one fenced portfolio-routing JSON block");
+  }
+  try {
+    return JSON.parse(matches[0][1]);
+  } catch (error) {
+    throw new Error(`invalid portfolio-routing JSON: ${error.message}`);
+  }
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && Boolean(value.trim());
+}
+
+function validateReferenceArray(name, value) {
+  const errors = [];
+  if (!Array.isArray(value)) return [`${name} must be an array`];
+  const serialized = value.map((item) => JSON.stringify(item));
+  if (new Set(serialized).size !== serialized.length) errors.push(`${name} must contain unique items`);
+  for (const item of value) {
+    const valid = (Number.isInteger(item) && item > 0) || isNonEmptyString(item);
+    if (!valid) errors.push(`${name} items must be positive integers or non-empty strings`);
+  }
+  return errors;
+}
+
+function validateStringArray(name, value) {
+  const errors = [];
+  if (!Array.isArray(value)) return [`${name} must be an array`];
+  if (new Set(value).size !== value.length) errors.push(`${name} must contain unique items`);
+  if (value.some((item) => !isNonEmptyString(item))) {
+    errors.push(`${name} items must be non-empty strings`);
+  }
+  return errors;
+}
+
+function validatePortfolioRouting(routing) {
+  const errors = [];
+  if (!routing || typeof routing !== "object" || Array.isArray(routing)) {
+    return ["portfolio routing must be an object"];
+  }
+
+  const keys = Object.keys(routing);
+  for (const field of REQUIRED_FIELDS) {
+    if (!Object.hasOwn(routing, field)) errors.push(`${field} is required`);
+  }
+  for (const field of keys) {
+    if (!ALLOWED_FIELDS.has(field)) errors.push(`unsupported portfolio-routing field: ${field}`);
+  }
+
+  if (routing.schema !== PORTFOLIO_SCHEMA) errors.push(`schema must equal ${PORTFOLIO_SCHEMA}`);
+  if (!isNonEmptyString(routing.track) || !/^T[1-8]-[a-z0-9][a-z0-9-]*$/.test(routing.track)) {
+    errors.push("track must match T1- through T8- plus a lowercase hyphenated name");
+  }
+  if (!isNonEmptyString(routing.kind) || !/^[a-z][a-z0-9-]*$/.test(routing.kind)) {
+    errors.push("kind must be a lowercase identifier");
+  }
+  if (!(routing.research_mode === null
+      || (isNonEmptyString(routing.research_mode) && /^[a-z][a-z0-9-]*$/.test(routing.research_mode)))) {
+    errors.push("research_mode must be null or a lowercase identifier");
+  }
+  if (!new Set(["P0", "P1", "P2", "P3"]).has(routing.priority)) {
+    errors.push("priority must be P0, P1, P2, or P3");
+  }
+  for (const field of ["priority_reason", "acceptable_null_outcome", "completion_endpoint"]) {
+    if (!isNonEmptyString(routing[field])) errors.push(`${field} must be a non-empty string`);
+  }
+  if (!(routing.decision_question === null || isNonEmptyString(routing.decision_question))) {
+    errors.push("decision_question must be null or a non-empty string");
+  }
+
+  errors.push(...validateReferenceArray("dependencies", routing.dependencies));
+  errors.push(...validateReferenceArray("informs", routing.informs));
+  errors.push(...validateStringArray("read_scope", routing.read_scope));
+  errors.push(...validateStringArray("write_locks", routing.write_locks));
+  errors.push(...validateStringArray("prohibited_parallel_writes", routing.prohibited_parallel_writes));
+  return errors;
+}
+
+function validatePortfolioOwnershipBinding(claim, claimIssue, routing, intakeIssue, pr, prOwnership) {
+  const errors = validatePortfolioRouting(routing).map((error) => `portfolio: ${error}`);
+  if (claim.schema !== "canto-span-work-claim-v2") {
+    errors.push("portfolio routing requires a v2 work claim");
+    return errors;
+  }
+  if (claim.intake_issue !== intakeIssue) {
+    errors.push(`claim intake_issue ${claim.intake_issue} does not match PR intake issue ${intakeIssue}`);
+  }
+  if (!WORKERS.has(claim.active_worker)) errors.push("claim active_worker is unsupported");
+  if (!Number.isInteger(claim.ownership_revision) || claim.ownership_revision < 1) {
+    errors.push("claim ownership_revision must be a positive integer");
+  }
+  if (claim.branch !== pr.head.ref) {
+    errors.push(`claim branch ${claim.branch} does not match PR head ${pr.head.ref}`);
+  }
+  if (prOwnership.activeWorker !== claim.active_worker) {
+    errors.push(`PR worker ${prOwnership.activeWorker} does not match claim worker ${claim.active_worker}`);
+  }
+  if (prOwnership.ownershipRevision !== claim.ownership_revision) {
+    errors.push(
+      `PR ownership revision ${prOwnership.ownershipRevision} does not match claim revision ${claim.ownership_revision}`,
+    );
+  }
+
+  const claimLocks = new Set(Array.isArray(claim.write_locks) ? claim.write_locks : []);
+  for (const lock of routing.write_locks || []) {
+    if (!claimLocks.has(lock)) errors.push(`claim does not preserve portfolio write lock ${lock}`);
+  }
+  for (const prohibited of routing.prohibited_parallel_writes || []) {
+    if (claimLocks.has(prohibited)) errors.push(`claim acquires prohibited parallel write ${prohibited}`);
+  }
+  if (claimIssue == null || claimIssue < 1) errors.push("claim issue number is invalid");
+  return errors;
+}
+
+module.exports = {
+  PORTFOLIO_SCHEMA,
+  extractPortfolioRouting,
+  intakeRoutingCounts,
+  validatePortfolioOwnershipBinding,
+  validatePortfolioRouting,
+};

--- a/tools/coordination/portfolio-routing.js
+++ b/tools/coordination/portfolio-routing.js
@@ -21,7 +21,7 @@ const ALLOWED_FIELDS = new Set(REQUIRED_FIELDS);
 const WORKERS = new Set(["chatgpt", "codex", "human"]);
 
 function extractFencedBlocks(body, label) {
-  const pattern = new RegExp(`\\\`\\\`\\\`${label}[^\\n\\\`]*\\n([\\s\\S]*?)\\\`\\\`\\\``, "gi");
+  const pattern = new RegExp("```" + label + "[^\\n`]*\\n([\\s\\S]*?)```", "gi");
   return [...String(body || "").matchAll(pattern)];
 }
 


### PR DESCRIPTION
<!-- coordination-claim: #380 -->

Intake issue: #379
Work claim: #380
Active worker: chatgpt
Ownership revision: 1

## Change

- preserves the existing strict `task-intake` ownership path;
- accepts exactly one validated `portfolio-routing` block as an alternative parent issue mode;
- binds portfolio issues directly to an active v2 work claim, branch, worker, revision, and PR body;
- requires portfolio write locks to remain present in the claim and rejects prohibited lock acquisition;
- fails closed for missing, duplicate, mixed, malformed, unsupported, or mismatched routing metadata;
- keeps changed-file coverage and the user merge gate unchanged.

## Tests

Focused tests cover valid parsing and binding, duplicate or mixed routing blocks, malformed fields, worker/revision/branch mismatch, missing write locks, prohibited locks, and v1-claim rejection.

## Protected and unchanged

No runtime, linguistic, identity, corpus, survey, release, deployment, or merge-authorization behavior changes.

Closes #379
Closes #380