### PR TITLE
Re-enable Codex agent workflows

### DIFF
--- a/config/agent-workflow-settings.json
+++ b/config/agent-workflow-settings.json
@@ -1,7 +1,7 @@
 {
   "schema": "canto-span-agent-workflow-settings-v1",
   "codex": {
-    "enabled": false,
+    "enabled": true,
     "disabled_pickup_fallback": "chatgpt",
     "blocked_assignee_logins": [
       "codex",

--- a/docs/current/AGENT-WORKFLOW-SETTINGS.md
+++ b/docs/current/AGENT-WORKFLOW-SETTINGS.md
@@ -14,15 +14,42 @@ replace task routing, semantic work claims, evidence standards, or user merge re
 ## Current setting
 
 ```text
-codex.enabled: false
+codex.enabled: true
 ```
 
-Codex workflows are disabled because the user reported that Codex is out of tokens.
-The disabled-state fallback pickup target is `chatgpt`.
+Codex workflows are enabled because the user confirmed that Codex access is restored.
+The disabled-state fallback remains `chatgpt` and applies only if the toggle is changed
+back to `false` later.
+
+The allowed pickup targets are now exactly:
+
+```text
+codex
+chatgpt
+human
+```
+
+Availability does not assign work. A task still requires valid routing, an explicit
+pickup owner, a matching work claim, a branch, applicable checks, and the mandatory
+user merge-review stop.
+
+## Enabled-state rules
+
+While `codex.enabled` is `true`:
+
+1. new intake and later reassignment may use `codex`, `chatgpt`, or `human`, subject
+   to the normal routing and self-screening gates;
+2. Codex-named GitHub assignees are not blocked by the workflow-availability setting;
+3. enabling the toggle does not take over, reassign, reopen, or resume an existing
+   issue, claim, branch, or pull request;
+4. every transfer to Codex still requires a new valid ownership revision, matching
+   assignee state, overlap review, and a new or updated work claim;
+5. historical disabled-state reassignment notices remain historical and do not
+   transfer work back to Codex.
 
 ## Disabled-state rules
 
-While `codex.enabled` is `false`:
+If `codex.enabled` is changed to `false` again:
 
 1. a new intake issue may use only `pickup_target: chatgpt` or
    `pickup_target: human`;
@@ -38,23 +65,8 @@ While `codex.enabled` is `false`:
    than silently rewritten;
 8. closed historical issues remain unchanged.
 
-The allowed pickup targets are therefore exactly:
-
-```text
-chatgpt
-human
-```
-
 An issue assignment includes both the machine-readable pickup target and an actual
 GitHub issue assignee. Removing Codex from only one layer is insufficient.
-
-## Enabled-state rules
-
-When `codex.enabled` is changed to `true`, future intake and reassignment may again use
-`codex`, `chatgpt`, or `human`, subject to the normal routing and self-screening gates.
-Re-enabling Codex does not automatically take over, reassign, reopen, or resume any
-existing issue, claim, branch, or pull request. Every later transfer still requires a
-new valid ownership revision and overlap check.
 
 ## Enforcement
 
@@ -68,10 +80,11 @@ The setting is enforced through:
 - mandatory agent checks in `AGENTS.md` before issue creation, assignment, takeover,
   claim creation, branch creation, or resumed work.
 
-The issue-event workflow removes blocked Codex assignees and converts current v2 Codex
-pickup metadata to the configured fallback while disabled. The conversion is
+When disabled, the issue-event workflow removes blocked Codex assignees and converts
+current v2 Codex pickup metadata to the configured fallback. The conversion is
 idempotent: once the issue is assigned to ChatGPT or a human, another enforcement run
-does not increase its ownership revision again.
+does not increase its ownership revision again. When enabled, that disabled-state
+conversion is inactive.
 
 ## Changing the toggle
 

--- a/docs/current/PROJECT-STATE.md
+++ b/docs/current/PROJECT-STATE.md
@@ -24,9 +24,9 @@ This file is the sole present-tense project snapshot. Live GitHub intake and wor
 |---|---|
 | ChatGPT | Available |
 | Human action | Available |
-| Codex | Disabled |
+| Codex | Available |
 
-The canonical setting is [`../../config/agent-workflow-settings.json`](../../config/agent-workflow-settings.json). While Codex is disabled, new and reassigned intake issues may target only ChatGPT or human action. Codex may not remain the active pickup owner or an actual GitHub issue assignee. Re-enabling it later permits future routing only and does not transfer existing work.
+The canonical setting is [`../../config/agent-workflow-settings.json`](../../config/agent-workflow-settings.json). New intake and later reassignment may target Codex, ChatGPT, or human action, subject to normal routing, assignment, overlap, claim, verification, and review gates. Re-enabling Codex permits future routing only and does not transfer, reopen, resume, or reassign existing work.
 
 Agent availability is independent of construction availability, which is owned by `data/parked-constructions.json`.
 

--- a/tests/tooling/coordination/agent-workflow-settings.test.js
+++ b/tests/tooling/coordination/agent-workflow-settings.test.js
@@ -60,11 +60,11 @@ function intake(overrides = {}) {
   return `# Task\n\nCodex instructions.\n\n\`\`\`task-intake\n${JSON.stringify(metadata, null, 2)}\n\`\`\``;
 }
 
-test("checked-in toggle is valid and disabled", () => {
+test("checked-in toggle is valid and enabled", () => {
   const loaded = loadSettings();
   assert.deepEqual(validateSettings(loaded), []);
-  assert.equal(codexWorkflowsEnabled(loaded), false);
-  assert.deepEqual([...allowedPickupTargets(loaded)], ["chatgpt", "human"]);
+  assert.equal(codexWorkflowsEnabled(loaded), true);
+  assert.deepEqual([...allowedPickupTargets(loaded)], ["codex", "chatgpt", "human"]);
 });
 
 test("enabled setting permits all three pickup targets", () => {


### PR DESCRIPTION
<!-- coordination-claim: #397 -->

Intake issue: #396
Work claim: #397
Active worker: chatgpt
Ownership revision: 1

## Outcome

Re-enable Codex as an available pickup target through the repository-owned workflow setting.

## Changed scope

- `config/agent-workflow-settings.json`: set `codex.enabled` to `true`;
- `docs/current/AGENT-WORKFLOW-SETTINGS.md`: record the enabled state and its boundaries;
- `docs/current/PROJECT-STATE.md`: mark Codex available in the sole present-tense snapshot;
- `tests/tooling/coordination/agent-workflow-settings.test.js`: update the checked-in-state assertion.

## Behavioral boundary

This permits future intake and later explicit reassignment to Codex. It does not transfer, reopen, resume, assign, or revise any existing issue, claim, branch, or pull request.

## Protected and unchanged

Parser behavior, construction identity, linguistic status, corpus and survey data, runtime version, release state, current pickup ownership, existing claims, and merge authorization are unchanged.

## Validation

- focused checked-in workflow-setting assertion: passed;
- coordination system verification: passed;
- coordination test suite: 51/51 passed;
- live claim binding and changed-file coverage: passed;
- runtime source-first/core validation: passed.

Closes #396
Closes #397