### PR TITLE
Reserve bounded paired-clause relation identities

### DIFF
--- a/data/construction-identity-candidates.json
+++ b/data/construction-identity-candidates.json
@@ -1,6 +1,6 @@
 {
   "schema": "canto-span-construction-identity-candidates-v1",
-  "record_count": 1,
+  "record_count": 4,
   "records": [
     {
       "construction_uuid": "4e176fe2-a147-47c7-86c8-6778a379beb2",
@@ -10,6 +10,42 @@
       "profile_description": "A preverbal availability or opportunity relation uses affirmative 有得 or negative 冇得 before an overt predicate; the suppletive-polar surface 有冇得 asks which availability alternative holds. The profile excludes existential or possessive 有／冇 plus nominal complements, ordinary lexical V-唔-V, postverbal potential 得／唔到, arbitrary predicate omission, and fused or semi-lexical expressions whose meaning is not transparently availability.",
       "state": "candidate",
       "created_at": "2026-08-01",
+      "canonicalized_at": null,
+      "abandoned_at": null,
+      "construction_code": null
+    },
+    {
+      "construction_uuid": "a476c6c6-a0ba-4cf2-9021-13ad4c717d0f",
+      "canonical_name_at_creation": "ZiJiuZauSufficientConditionRelation",
+      "claim_layer": "language_construction",
+      "source_path": "grammar/research_pending/ZiJiuZauSufficientConditionRelation.md",
+      "profile_description": "An overt comma-delimited paired relation uses clause-initial 只要 to mark a sufficient condition and overt 就 in the following clause to mark its consequence. The profile requires licensed content in both members, preserves condition and consequence roles across the full pair, and excludes ordinary 如果 conditionals, 只有 necessary conditions, 除非 exception conditionals, 就算 concessives, lexical or focus 只 + 要, omitted-就 extensions, fragments, and discourse-spanning completions.",
+      "state": "candidate",
+      "created_at": "2026-08-02",
+      "canonicalized_at": null,
+      "abandoned_at": null,
+      "construction_code": null
+    },
+    {
+      "construction_uuid": "caae4649-29cd-4752-8e5d-48ab7d9503a4",
+      "canonical_name_at_creation": "JyuKeiBatJyuOrderedPreferenceRelation",
+      "claim_layer": "language_construction",
+      "source_path": "grammar/research_pending/JyuKeiBatJyuOrderedPreferenceRelation.md",
+      "profile_description": "An overt comma-delimited paired relation uses 與其 to introduce a disfavored option and 不如 to introduce a preferred option, preserving the ordering between two licensed members. The profile excludes lone suggestion 不如 B, ordinary comparison A 不如 B, 寧願 preference, empty members, optional 倒, marker omission, and broader constituent or discourse profiles pending separate evidence and implementation.",
+      "state": "candidate",
+      "created_at": "2026-08-02",
+      "canonicalized_at": null,
+      "abandoned_at": null,
+      "construction_code": null
+    },
+    {
+      "construction_uuid": "af85d495-5906-4fde-a5ba-ca39285a3281",
+      "canonical_name_at_creation": "ZiJauSinNecessaryConditionRelation",
+      "claim_layer": "language_construction",
+      "source_path": "grammar/research_pending/ZiJauSinNecessaryConditionRelation.md",
+      "profile_description": "An overt comma-delimited paired relation uses 只有 to mark a required clausal condition and 先, 先至, or 先可以 in the following clause to mark the consequence available only under that condition. The profile excludes participant or domain restriction without a clausal pair, bare condition-plus-先至, short 至, temporal 先至, existential or quantity 只有, 只要 sufficient conditions, 除非 exception conditionals, and empty members.",
+      "state": "candidate",
+      "created_at": "2026-08-02",
       "canonicalized_at": null,
       "abandoned_at": null,
       "construction_code": null

--- a/data/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-DECISIONS-R1.json
+++ b/data/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-DECISIONS-R1.json
@@ -1,0 +1,347 @@
+{
+  "schema": "canto-span-paired-clause-bounded-identity-decisions-v1",
+  "decided_on": "2026-08-02",
+  "parent_issue": 430,
+  "work_claim": 441,
+  "pull_request": null,
+  "scope": {
+    "research_units": [
+      "PRQ2-008",
+      "PRQ2-013",
+      "PRQ2-014"
+    ],
+    "runtime_parent": "ClauseRelationGraph",
+    "decision_layer": "language_construction_identity",
+    "runtime_change_authorized": false,
+    "status_change_authorized": false
+  },
+  "shared_decision": {
+    "three_new_uuids_required": true,
+    "one_shared_uuid_rejected": true,
+    "generic_graph_identity_rejected": true,
+    "short_codes_allocated": false,
+    "canonicalization_authorized_in_this_package": false,
+    "reason": "Each bounded pair contributes a distinct marker correlation, named member roles, and relation semantics that are lost under generic clause graph structure or neighboring broad identities. Sufficiency, ordered preference, and necessity are not interchangeable feature values of one established project identity, and no current UUID preserves all three relations losslessly.",
+    "canonicalization_dependency": "A later separately claimed source-first runtime package must create each current grammar note, executable construction test, runtime label and matcher, then canonicalize the corresponding reserved candidate through tools/allocate-construction-identity.js."
+  },
+  "decisions": [
+    {
+      "research_id": "PRQ2-008",
+      "new_uuid_required": true,
+      "candidate_uuid": "a476c6c6-a0ba-4cf2-9021-13ad4c717d0f",
+      "candidate_state": "candidate",
+      "construction_code": null,
+      "canonical_name_at_creation": "ZiJiuZauSufficientConditionRelation",
+      "claim_layer": "language_construction",
+      "family_name": "ConditionalClauseRelations",
+      "profile_name": "OvertZiJiuConditionZauConsequence",
+      "intended_source_path": "grammar/research_pending/ZiJiuZauSufficientConditionRelation.md",
+      "core_surface": "只要 + CONDITION，(SUBJECT) + 就 + CONSEQUENCE",
+      "semantic_contract": "The left member is presented as sufficient for the right-member consequence; the profile preserves an overt antecedent marker, overt consequence linker, and the relation between two licensed clause members.",
+      "span_contract": {
+        "start": "first overt token of the left 只要 marker sequence",
+        "end": "end of the maximal licensed right consequence clause before separately typed final discourse material",
+        "include": [
+          "只要 marker",
+          "left condition member",
+          "comma or equivalent overt pair boundary",
+          "right-clause subject when present",
+          "就 linker",
+          "right consequence member"
+        ],
+        "exclude": [
+          "material before 只要",
+          "final particle or discourse wrapper when separately typed",
+          "following independent discourse turn"
+        ]
+      },
+      "required_boundaries": [
+        "ordinary 如果 A，就 B",
+        "只有 A，先／先至 B necessary condition",
+        "除非 exception conditional",
+        "就算 concessive conditional",
+        "restrictive 只 plus lexical/modal 要",
+        "no-就 extensions",
+        "bare or fragmentary 只要",
+        "discourse-spanning completion",
+        "empty left or right member"
+      ],
+      "evidence_basis": [
+        {
+          "source_id": "SRC-YIP-MATTHEWS-2017-ZI2JIU3",
+          "role": "REFERENCE_GRAMMAR_CORE",
+          "scope": "explicit sufficient-condition analysis, condition-before-consequence order, overt 就 profile, and bounded no-就 attestation"
+        },
+        {
+          "source_id": "SRC-HONGKONGVISION-ZI2JIU3",
+          "role": "ATTESTATION_ONLY",
+          "scope": "modern examples and extension prompts only"
+        },
+        {
+          "source_id": "SRC-EDB-DRAMA-ZI2JIU3",
+          "role": "ATTESTATION_ONLY",
+          "scope": "independent paired attestation only"
+        },
+        {
+          "source_id": "CORPUS-HKCANCOR-PRQ2-008",
+          "role": "PRIMARY_CORPUS_ATTESTATION",
+          "scope": "occurrence and deferred fragment/discourse boundaries only"
+        },
+        {
+          "source_id": "RUNTIME-PRQ2-008-V0.5.213",
+          "role": "RUNTIME_OBSERVATION_ONLY",
+          "scope": "implementation collision and reachability only; zero linguistic-evidence weight"
+        }
+      ],
+      "existing_identity_dispositions": [
+        {
+          "construction_code": "AA14",
+          "canonical_name": "ClauseRelationGraph",
+          "disposition": "retain as parser representation only; it does not own sufficient-condition identity or evidence"
+        },
+        {
+          "construction_code": "AA29",
+          "canonical_name": "ConditionalClause",
+          "disposition": "may remain a broad neighboring or structural conditional analysis, but its unsupported general scope does not preserve the overt sufficient marker pair"
+        },
+        {
+          "construction_code": "AA28",
+          "canonical_name": "ConditionResult",
+          "disposition": "retired unresolved wrapper; cannot be revived as the new language identity"
+        }
+      ],
+      "later_runtime_sequence": [
+        "create canonical note and executable test",
+        "install the overt comma-delimited 只要 A，就 B profile only",
+        "preserve current internal sufficient_condition metadata as compatibility structure",
+        "canonicalize the reserved UUID and allocate the next code mechanically",
+        "defer no-就, fragment, and discourse extensions to separate evidence work"
+      ]
+    },
+    {
+      "research_id": "PRQ2-013",
+      "new_uuid_required": true,
+      "candidate_uuid": "caae4649-29cd-4752-8e5d-48ab7d9503a4",
+      "candidate_state": "candidate",
+      "construction_code": null,
+      "canonical_name_at_creation": "JyuKeiBatJyuOrderedPreferenceRelation",
+      "claim_layer": "language_construction",
+      "family_name": "AlternativePreferenceRelations",
+      "profile_name": "OvertJyuKeiDisfavoredBatJyuPreferred",
+      "intended_source_path": "grammar/research_pending/JyuKeiBatJyuOrderedPreferenceRelation.md",
+      "core_surface": "(SUBJECT) + 與其 + DISFAVORED OPTION，不如 + PREFERRED OPTION",
+      "semantic_contract": "The construction orders two overt alternatives by marking the first as rejected or disfavored and the second as preferred; suggestion or comparison readings of 不如 do not supply this two-member ordering.",
+      "span_contract": {
+        "start": "shared subject when it syntactically scopes over both alternatives; otherwise first overt token of 與其",
+        "end": "end of the maximal licensed preferred option before separately typed final discourse material",
+        "include": [
+          "optional shared subject when structurally common to both members",
+          "與其 marker",
+          "disfavored option member",
+          "comma or equivalent overt pair boundary",
+          "不如 marker",
+          "preferred option member"
+        ],
+        "exclude": [
+          "topic or frame outside the paired preference",
+          "final particle or discourse wrapper when separately typed",
+          "material after the preferred member belonging to another clause"
+        ]
+      },
+      "required_boundaries": [
+        "lone suggestion 不如 B",
+        "ordinary comparison A 不如 B",
+        "寧願 A，都唔 B or 都要 B",
+        "optional 倒 before 不如",
+        "marker omission",
+        "unlicensed NP or property symmetry",
+        "empty 與其 or 不如 member",
+        "lexical or coordinating 與"
+      ],
+      "evidence_basis": [
+        {
+          "source_id": "SRC-WORDSHK-JYU5KEI4",
+          "role": "VERIFIED_HONG_KONG_LEXICOGRAPHIC_RESOURCE",
+          "scope": "conjunction status, rejected first option, correlated 不如, and different-subject example"
+        },
+        {
+          "source_id": "SRC-JYUTDICTIONARY-JYU5KEI4",
+          "role": "VERIFIED_CANTONESE_LEXICOGRAPHIC_AGGREGATION",
+          "scope": "parallel predicate examples and optional 倒 attestation; 倒 remains deferred"
+        },
+        {
+          "source_id": "SRC-EDB-P6-JYU5KEI4",
+          "role": "VERIFIED_OFFICIAL_HONG_KONG_COURSE_MATERIAL",
+          "scope": "formal paired productivity and shared-subject placement with register limitation"
+        },
+        {
+          "source_id": "SRC-CANTODICT-BAT1JYU4",
+          "role": "VERIFIED_CANTONESE_LEXICOGRAPHIC_RESOURCE",
+          "scope": "suggestion-versus-comparison polysemy boundary"
+        },
+        {
+          "source_id": "RUNTIME-PRQ2-013-V0.5.213",
+          "role": "RUNTIME_OBSERVATION_ONLY",
+          "scope": "generic linking and Suggest collisions only; zero linguistic-evidence weight"
+        }
+      ],
+      "existing_identity_dispositions": [
+        {
+          "construction_code": "AA14",
+          "canonical_name": "ClauseRelationGraph",
+          "disposition": "retain as parser representation only; it cannot replace ordered preference identity"
+        },
+        {
+          "construction_code": "AB68",
+          "canonical_name": "SuggestionQuestion",
+          "disposition": "lone-suggestion neighbor only; it lacks the disfavored member and preference ordering"
+        },
+        {
+          "construction_code": "AB33",
+          "canonical_name": "ZungJiVPComplementClause",
+          "disposition": "lexical complement preference is structurally and semantically distinct from paired alternative ordering"
+        },
+        {
+          "construction_code": null,
+          "canonical_name": "PRQ2-035 committed preference",
+          "disposition": "separate research family because 寧願 with rejection or accepted-cost continuation has a different marker and polarity profile"
+        }
+      ],
+      "later_runtime_sequence": [
+        "create canonical note and executable test",
+        "install the overt comma-delimited 與其 A，不如 B profile only",
+        "preserve current ordered_preference runtime metadata as compatibility structure",
+        "canonicalize the reserved UUID and allocate the next code mechanically",
+        "keep optional 倒 and broader member categories deferred",
+        "maintain explicit suggestion, comparison, and 寧願 negative controls"
+      ]
+    },
+    {
+      "research_id": "PRQ2-014",
+      "new_uuid_required": true,
+      "candidate_uuid": "af85d495-5906-4fde-a5ba-ca39285a3281",
+      "candidate_state": "candidate",
+      "construction_code": null,
+      "canonical_name_at_creation": "ZiJauSinNecessaryConditionRelation",
+      "claim_layer": "language_construction",
+      "family_name": "ConditionalClauseRelations",
+      "profile_name": "OvertZiJauRequiredConditionSinConsequence",
+      "intended_source_path": "grammar/research_pending/ZiJauSinNecessaryConditionRelation.md",
+      "core_surface": "只有 + REQUIRED CONDITION，(SUBJECT) + 先／先至／先可以 + CONSEQUENCE",
+      "semantic_contract": "The left member states a required condition and the right linker presents the consequence as available only under that condition. The reserved identity is limited to the overt clausal pair and does not absorb participant restriction or temporal sequencing.",
+      "span_contract": {
+        "start": "first overt token of the left 只有 marker sequence",
+        "end": "end of the maximal licensed right consequence clause before separately typed final discourse material",
+        "include": [
+          "只有 marker",
+          "left required-condition member",
+          "comma or equivalent overt pair boundary",
+          "right-clause subject when present",
+          "先, 先至, or 先可以 linker",
+          "right consequence member"
+        ],
+        "exclude": [
+          "material before 只有",
+          "final particle or discourse wrapper when separately typed",
+          "following independent discourse turn"
+        ]
+      },
+      "required_boundaries": [
+        "participant or domain restriction without a clausal pair",
+        "locative restriction without paired clause structure",
+        "bare condition plus 先至 without overt 只有",
+        "short 至 condition",
+        "temporal-sequential 先至",
+        "existential or quantity 只有",
+        "只要 sufficient condition",
+        "除非 exception conditional",
+        "empty restrictor or consequence member"
+      ],
+      "evidence_basis": [
+        {
+          "source_id": "SRC-JYUTDICTIONARY-ZI2JAU5",
+          "role": "VERIFIED_CANTONESE_LEXICOGRAPHIC_AGGREGATION",
+          "scope": "necessary-condition marker correlation and participant, clausal, environmental, and locative profiles"
+        },
+        {
+          "source_id": "SRC-WORDSHK-ZI3-CONDITIONAL",
+          "role": "VERIFIED_HONG_KONG_LEXICOGRAPHIC_RESOURCE",
+          "scope": "conditional 至 as result available only under the preceding condition"
+        },
+        {
+          "source_id": "SRC-CANTODICT-SIN1ZI3",
+          "role": "VERIFIED_CANTONESE_LEXICOGRAPHIC_RESOURCE",
+          "scope": "先至 and shorter variants with temporal/conditional ambiguity boundaries"
+        },
+        {
+          "source_id": "CORPUS-HKCANCOR-PRQ2-014",
+          "role": "VERIFIED_PROJECT_EXTRACTED_ADULT_CORPUS_BOUNDARY",
+          "scope": "bare condition-plus-先至 boundary only, not core omission evidence"
+        },
+        {
+          "source_id": "RUNTIME-PRQ2-014-V0.5.213",
+          "role": "RUNTIME_OBSERVATION_ONLY",
+          "scope": "collision and reachability only; zero linguistic-evidence weight"
+        }
+      ],
+      "existing_identity_dispositions": [
+        {
+          "construction_code": "AA14",
+          "canonical_name": "ClauseRelationGraph",
+          "disposition": "retain as parser representation only; it cannot own necessary-condition identity or evidence"
+        },
+        {
+          "construction_code": "AA29",
+          "canonical_name": "ConditionalClause",
+          "disposition": "may remain a broad neighboring or structural conditional analysis, but it cannot preserve the overt necessary marker pair and inverse relation"
+        },
+        {
+          "construction_code": "AB34",
+          "canonical_name": "PostverbalSinPriorityClause",
+          "disposition": "distinct local postverbal priority profile; it does not encode a two-clause necessary condition"
+        },
+        {
+          "construction_code": "AA28",
+          "canonical_name": "ConditionResult",
+          "disposition": "retired unresolved wrapper; cannot be revived as the new language identity"
+        }
+      ],
+      "later_runtime_sequence": [
+        "create canonical note and executable test",
+        "install the overt comma-delimited 只有 A，先／先至／先可以 B clausal profile only",
+        "preserve current necessary_condition metadata as compatibility structure",
+        "canonicalize the reserved UUID and allocate the next code mechanically",
+        "keep participant restriction, bare condition, short 至, and temporal profiles deferred"
+      ]
+    }
+  ],
+  "cross_family_relations": [
+    {
+      "left": "PRQ2-008",
+      "right": "PRQ2-014",
+      "relation": "semantic_inverse_neighbors",
+      "constraint": "Shared conditional structure does not permit identity merger; sufficiency and necessity have distinct overt marker pairs and entailment direction."
+    },
+    {
+      "left": "PRQ2-013",
+      "right": "PRQ2-035",
+      "relation": "preference_neighbors",
+      "constraint": "Ordered alternative ranking and committed preference use different markers, polarity patterns, and continuation profiles."
+    },
+    {
+      "left": "all_three",
+      "right": "AA14 ClauseRelationGraph",
+      "relation": "transparent_parser_parent_only",
+      "constraint": "Generic graph, edge, and member-span records may host the language nodes but carry zero independent evidence and do not replace them."
+    }
+  ],
+  "protected_state": [
+    "permanent registry unchanged",
+    "short-code space unchanged through AB82",
+    "runtime source and generated bundle unchanged",
+    "executable construction fixtures unchanged",
+    "linguistic statuses unchanged",
+    "evidence grades and corpus classifications unchanged",
+    "survey, panel, held-out, version, release, deployment, and merge authority unchanged"
+  ]
+}

--- a/data/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-DECISIONS-R1.json
+++ b/data/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-DECISIONS-R1.json
@@ -3,7 +3,7 @@
   "decided_on": "2026-08-02",
   "parent_issue": 430,
   "work_claim": 441,
-  "pull_request": null,
+  "pull_request": 450,
   "scope": {
     "research_units": [
       "PRQ2-008",

--- a/docs/current/CONSTRUCTION-IDENTITY.md
+++ b/docs/current/CONSTRUCTION-IDENTITY.md
@@ -24,7 +24,7 @@ compatibility alias, not the durable key.
 - expert-adjudicated records: **93**;
 - pending expert adjudications: **88**;
 - accepted adjudication batches: **20**;
-- reserved identity candidates: **1**;
+- reserved identity candidates: **4**;
 - allocated codes: `AA01` through `AB82`.
 
 The canonical registry is `data/construction-identities.json`. The immutable lock
@@ -47,6 +47,19 @@ matcher before invoking the allocation tool. The permanent registry therefore
 remains at 181 records and codes remain allocated only through `AB82`.
 Candidate reservation establishes identity continuity only; it does not make the
 construction current, runtime-available, status-promoted, or promotion-eligible.
+
+The bounded paired-clause identity decision additionally reserves three candidates:
+
+- `a476c6c6-a0ba-4cf2-9021-13ad4c717d0f` — `ZiJiuZauSufficientConditionRelation` for overt `只要 A，就 B`;
+- `caae4649-29cd-4752-8e5d-48ab7d9503a4` — `JyuKeiBatJyuOrderedPreferenceRelation` for overt `與其 A，不如 B`;
+- `af85d495-5906-4fde-a5ba-ca39285a3281` — `ZiJauSinNecessaryConditionRelation` for overt clausal `只有 A，先／先至／先可以 B`.
+
+These candidates have no short codes, current notes, dedicated test files, or canonical
+runtime identities. Generic `ClauseRelationGraph` structure remains parser-only and carries
+zero independent linguistic-evidence weight. A later separately claimed runtime package
+must create the required artifacts and canonicalize each exact UUID through the allocation
+tool. The permanent registry therefore remains at 181 records and allocated codes remain
+`AA01` through `AB82`.
 
 ## UUID rules
 

--- a/docs/current/PROJECT-STATE.md
+++ b/docs/current/PROJECT-STATE.md
@@ -56,6 +56,7 @@ Current consequences include:
 - `AB53 ResourceInitialJungLaiFunctionClause` is canonical for the legacy runtime note `ResourceUseLaiFunctionRelation`;
 - `AA56 JauMarkedIndefiniteNPPredication` is canonical for the legacy runtime note `ExistentialPresentationalClause`; it is positive-only at the identity/specification layer, while the current locative-coda and negative runtime behavior remains unchanged pending a separate implementation;
 - candidate UUID `4e176fe2-a147-47c7-86c8-6778a379beb2` is reserved for `JauDakMouDakAvailabilityPredicate`; it has no short code or runtime note and must remain noncanonical until a later source-first implementation package creates the required note, test, label, and matcher;
+- candidate UUIDs `a476c6c6-a0ba-4cf2-9021-13ad4c717d0f`, `caae4649-29cd-4752-8e5d-48ab7d9503a4`, and `af85d495-5906-4fde-a5ba-ca39285a3281` are reserved respectively for the overt PRQ2-008 sufficient-condition, PRQ2-013 ordered-preference, and PRQ2-014 clausal necessary-condition relations; they have no short codes or current runtime identities and require a later separately claimed source-first implementation and canonicalization package;
 - Batch 18 internalized AB18 and AB21, retained AB19 and AB20 as retired, and narrowed AB22 to `FinalMe1BiasedPolarQuestionFrame`;
 - Batch 19 retains AB25, AB26, and AB27 as retired composite parser representations and rehomes their valid component evidence under separately typed possessive nominal, fragment, and transfer or dative profiles;
 - parser representations, umbrellas, and retired records do not compete for linguistic promotion or donate evidence automatically;
@@ -89,7 +90,7 @@ Implementation specifications, human artifact requests, corpus ingestion, work c
 
 Promotion-ready remains **0**.
 
-The paired-clause relation map reviews PRQ2-008–015 and PRQ2-033–035 as eleven separate families across 151 checked-in collision rows. Three bounded typed cores route to identity/composition decisions in #430, four source-ready unimplemented relations route to #431, and three evidence-constrained families remain in #432. The committed-preference runtime, probes, and generated bundle now use canonical PRQ2-035 provenance; PRQ2-015 remains research-only through #409. Generic clause graphs remain parser infrastructure, and the provenance correction changes metadata only, not matching behavior, identity, status, or evidence.
+The paired-clause relation map reviews PRQ2-008–015 and PRQ2-033–035 as eleven separate families across 151 checked-in collision rows. The three bounded typed cores in #430 now have separate reserved candidate UUIDs for overt sufficient condition, ordered preference, and clausal necessary condition; no short code, runtime identity, fixture, or status changed. Four source-ready unimplemented relations remain routed through #431, three evidence-constrained families remain in #432, and PRQ2-015 remains research-only through #409. Generic clause graphs remain parser infrastructure with zero independent linguistic-evidence weight.
 
 Discovery ranks expose gaps; they never promote, park, assign, or authorize work.
 

--- a/docs/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-SPECIFICATION-R1.md
+++ b/docs/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-SPECIFICATION-R1.md
@@ -1,8 +1,8 @@
 # Bounded paired-clause relation identity specification R1
 
-Date: 2026-08-02  
-Parent issue: #430  
-Work claim: #441  
+Date: 2026-08-02
+Parent issue: #430
+Work claim: #441
 Pull request: #450
 
 ## Decision

--- a/docs/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-SPECIFICATION-R1.md
+++ b/docs/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-SPECIFICATION-R1.md
@@ -3,7 +3,7 @@
 Date: 2026-08-02  
 Parent issue: #430  
 Work claim: #441  
-Pull request: pending
+Pull request: #450
 
 ## Decision
 

--- a/docs/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-SPECIFICATION-R1.md
+++ b/docs/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-SPECIFICATION-R1.md
@@ -1,0 +1,252 @@
+# Bounded paired-clause relation identity specification R1
+
+Date: 2026-08-02  
+Parent issue: #430  
+Work claim: #441  
+Pull request: pending
+
+## Decision
+
+The three implemented bounded relation cores require **three separate reserved
+language-construction UUIDs**. They are not instances of one new generic
+clause-linking identity, and they cannot inherit the UUIDs of the generic parser
+graph, broad `ConditionalClause`, suggestion, comparison, lexical preference, or
+postverbal priority records without losing their paired marker roles and relation
+semantics.
+
+| Research unit | Candidate UUID | Canonical name at creation | Family | Profile |
+|---|---|---|---|---|
+| PRQ2-008 | `a476c6c6-a0ba-4cf2-9021-13ad4c717d0f` | `ZiJiuZauSufficientConditionRelation` | `ConditionalClauseRelations` | `OvertZiJiuConditionZauConsequence` |
+| PRQ2-013 | `caae4649-29cd-4752-8e5d-48ab7d9503a4` | `JyuKeiBatJyuOrderedPreferenceRelation` | `AlternativePreferenceRelations` | `OvertJyuKeiDisfavoredBatJyuPreferred` |
+| PRQ2-014 | `af85d495-5906-4fde-a5ba-ca39285a3281` | `ZiJauSinNecessaryConditionRelation` | `ConditionalClauseRelations` | `OvertZiJauRequiredConditionSinConsequence` |
+
+All three records remain `candidate` with `construction_code: null`. This package
+allocates no short code, creates no current grammar note or executable construction
+test, and changes no matcher. A later separately claimed source-first runtime package
+must create those artifacts and invoke `tools/allocate-construction-identity.js` for
+each candidate.
+
+## Why three UUIDs are required
+
+`ClauseRelationGraph`, `ClauseRelationEdge`, and `ClauseRelationMemberSpan` represent
+parser organization. They can preserve a parent graph, typed edge, and member spans,
+but they do not independently assert that one member is sufficient for another, that
+one alternative is disfavored relative to another, or that one condition is necessary
+for a consequence. They retain zero independent linguistic-evidence weight.
+
+The existing broad `ConditionalClause` record is also insufficient. Its current scope
+is an unsupported generalization and it does not preserve the correlation between
+`只要` and `就`, the inverse correlation between `只有` and `先／先至／先可以`, or
+the direction of entailment. Reusing it would collapse two source-backed relations and
+make future narrowing depend on one overbroad UUID.
+
+The ordered-preference core likewise cannot be represented by lone `不如` suggestion,
+ordinary `A 不如 B` comparison, lexical `鍾意` complementation, or PRQ2-035
+`寧願` committed preference. Those profiles do not preserve the same two option roles,
+marker pair, or preference relation.
+
+## PRQ2-008 sufficient condition
+
+### Reserved identity
+
+```text
+只要 + CONDITION，
+(SUBJECT) + 就 + CONSEQUENCE
+```
+
+The full overt pair is the language node. The left member is sufficient for the
+right-member consequence. The candidate preserves:
+
+- the overt `只要` antecedent marker;
+- a licensed condition member;
+- an overt pair boundary;
+- a licensed consequence member;
+- overt right-clause `就` after any right-clause subject;
+- the sufficient-condition relation between the two members.
+
+Yip and Matthews provide direct reference-grammar support for the Cantonese
+sufficient-condition domain, condition-before-consequence order, overt `就`, modal and
+negative consequences, and at least one no-`就` example. The reserved candidate is
+nevertheless limited to the already implemented overt `只要 A，就 B` slice. The
+no-`就` source example establishes a research extension, not unrestricted optionality.
+
+### Span
+
+Start at the first overt token of `只要`. End at the end of the maximal independently
+licensed consequence clause. Include the marker pair and both members. Exclude material
+before `只要`, separately typed final discourse material, and any following discourse
+turn.
+
+### Boundaries
+
+Do not assign this identity to:
+
+- ordinary `如果 A，就 B` conditionals;
+- `只有 A，先／先至 B` necessary conditions;
+- `除非` exception/default conditionals;
+- `就算` concessive conditionals;
+- restrictive `只` plus lexical or modal `要`;
+- no-`就` extensions before separate implementation evidence;
+- fragments, discourse-spanning completions, or empty members.
+
+AA29 may remain a broad structural neighbor and AA14 may remain the parser parent. Neither
+replaces the reserved language identity or donates evidence.
+
+## PRQ2-013 ordered preference
+
+### Reserved identity
+
+```text
+(SUBJECT) + 與其 + DISFAVORED OPTION，
+            不如 + PREFERRED OPTION
+```
+
+The construction orders two overt alternatives. `與其` marks the first member as
+rejected or disfavored; `不如` marks the second as preferred. The relation is not
+recoverable from a generic graph plus an untyped `Suggest` child because that analysis
+loses the first option's role and the ordering between members.
+
+Words.hk directly defines the correlated pair and rejected first option. Jyut Dictionary
+attests parallel predicates and optional `倒`; Education Bureau material supports formal
+paired use across several activity types and shared-subject placement; CantoDict supports
+the suggestion/comparison polysemy boundary. Optional `倒` remains outside the reserved
+first runtime slice.
+
+### Span
+
+Where an overt subject structurally scopes over both alternatives, include it as shared
+pair material. Otherwise start at `與其`. End at the end of the maximal independently
+licensed preferred option. Include both markers, both option members, and the overt pair
+boundary; exclude outer topic/frame material and separately typed final discourse
+material.
+
+### Boundaries
+
+Do not assign this identity to:
+
+- lone suggestion `不如 B`;
+- ordinary comparison `A 不如 B`;
+- `寧願 A，都唔 B` or `寧願 A，都要 B`;
+- optional `倒` before a later package explicitly supports it;
+- marker omission or discourse completion;
+- unlicensed constituent symmetry or empty members;
+- lexical or coordinating uses of `與`.
+
+AB68 may remain the lone-suggestion neighbor, AB33 remains lexical preference
+complementation, and PRQ2-035 remains a separate committed-preference family.
+
+## PRQ2-014 necessary condition
+
+### Reserved identity
+
+```text
+只有 + REQUIRED CONDITION，
+(SUBJECT) + 先 / 先至 / 先可以 + CONSEQUENCE
+```
+
+The left member states a condition required for the right-member consequence. The overt
+right linker marks that the consequence is available only under that condition. This is
+the semantic inverse neighbor of the PRQ2-008 sufficient relation, not the same identity
+with a free feature substitution.
+
+The source package supports a broader necessary-condition marker family, including
+participant, environmental, locative, and conditional profiles, plus conditional `至` and
+bare condition-plus-`先至` boundaries. The reserved candidate is deliberately narrower:
+it covers only the already implemented overt comma-delimited **clausal pair**.
+
+### Span
+
+Start at the first overt token of `只有`. End at the end of the maximal independently
+licensed consequence clause. Include the left marker and required-condition member, the
+overt pair boundary, the right subject when present, the licensed `先／先至／先可以`
+linker, and the consequence member. Exclude material before `只有` and separately typed
+final discourse material.
+
+### Boundaries
+
+Do not assign this identity to:
+
+- participant, domain, or locative restriction without a clausal pair;
+- bare condition-plus-`先至` without overt `只有`;
+- short conditional `至` before separate specification;
+- temporal-sequential `先至`;
+- existential or quantity `只有`;
+- `只要` sufficient conditions or `除非` exception conditionals;
+- empty restrictor or consequence members.
+
+AB34 remains a postverbal priority profile, AA29 remains a broad conditional neighbor,
+and AA14 remains the parser parent. None owns the necessary-condition UUID.
+
+## Composition contract
+
+A later implementation may preserve generic graph structure around each language node,
+but it must expose the language identity independently. The graph may contain:
+
+- one typed language-relation node spanning the accepted pair;
+- two independently licensed member children;
+- marker/linker children or typed marker metadata;
+- generic graph, edge, and member-span parents for parser navigation.
+
+The parser representation must not become the language ontology. Conversely, the language
+node must not consume unrelated outer topics, quotations, particles, or following turns
+merely to obtain full-line coverage.
+
+## Runtime compatibility contract
+
+The existing internal subtypes are compatibility metadata, not permanent identities:
+
+| Research unit | Current internal metadata | Required later relation |
+|---|---|---|
+| PRQ2-008 | `sufficient_condition` | map to the reserved sufficient-condition UUID |
+| PRQ2-013 | `ordered_preference` | map to the reserved ordered-preference UUID |
+| PRQ2-014 | underlying `conditional` plus `necessary_condition` profile | map to the reserved necessary-condition UUID |
+
+This package does not change those runtime values. The later runtime package must preserve
+existing accepted reachability while adding UUID-resolved language identity and explicit
+negative boundaries.
+
+## Canonicalization sequence
+
+For each candidate, the later package must:
+
+1. create the intended `grammar/research_pending/` note with accepted evidence and
+   boundaries;
+2. create a dedicated executable construction-test file;
+3. add or map the runtime label and source-first matcher;
+4. canonicalize the exact reserved UUID through
+   `tools/allocate-construction-identity.js`;
+5. let the allocator assign the next unused short code mechanically;
+6. regenerate identity, lock, status, test-index, discovery, and deployment outputs;
+7. stop for review before merge.
+
+No package may preclaim `AB83`, `AB84`, `AB85`, or any other code. Allocation order is
+serialized at canonicalization time.
+
+## Later evidence gates
+
+The identity decision does not establish broad productivity. Before any linguistic-status
+promotion, role-neutral panel and held-out work must test at least:
+
+- sufficient versus necessary, ordinary hypothetical, exception, and concessive
+  conditionals;
+- overt right linker versus independently justified omission;
+- shared and different subjects;
+- negation, modality, particles, and member complexity;
+- ordered preference versus suggestion, comparison, and committed preference;
+- participant restriction versus clausal necessary condition;
+- temporal `先至` and lexical `只 + 要` controls;
+- unseen lexical and structural member classes not used to design the matcher.
+
+## Protected state and stop rule
+
+This package changes only the candidate ledger, one machine-readable coordinated decision,
+one human specification, and current identity/project documentation. It changes no
+permanent registry record, short code, runtime behavior, executable fixture, generated
+runtime bundle, linguistic-status placement, evidence grade, corpus classification,
+survey or panel state, held-out state, runtime version, release, deployment, or merge
+authority.
+
+The package is complete when the three UUIDs are collision-checked and reserved, every
+core and boundary has a terminal identity disposition, the later canonicalization order is
+explicit, repository verification passes, and no temporary publication file remains in
+the final diff.


### PR DESCRIPTION
Parent issue: #430
Work claim: #441
Active worker: chatgpt
Ownership revision: 1

## Outcome

Reserves three separate language-construction candidate UUIDs for the already implemented bounded paired-clause cores:

- PRQ2-008 overt `只要 A，就 B` sufficient condition → `a476c6c6-a0ba-4cf2-9021-13ad4c717d0f` / `ZiJiuZauSufficientConditionRelation`;
- PRQ2-013 overt `與其 A，不如 B` ordered preference → `caae4649-29cd-4752-8e5d-48ab7d9503a4` / `JyuKeiBatJyuOrderedPreferenceRelation`;
- PRQ2-014 overt clausal `只有 A，先／先至／先可以 B` necessary condition → `af85d495-5906-4fde-a5ba-ca39285a3281` / `ZiJauSinNecessaryConditionRelation`.

The coordinated decision rejects both one shared relation UUID and reuse of generic `ClauseRelationGraph`, broad `ConditionalClause`, suggestion, lexical preference, or postverbal priority identities. Those records may remain transparent parser parents or neighboring analyses but cannot preserve the three marker correlations, member roles, and relation semantics losslessly.

## Identity disposition

All three records remain reserved `candidate` entries with `construction_code: null`. The permanent registry remains at 181 records and allocated codes remain `AA01` through `AB82`.

A later separately claimed source-first runtime package must create each current grammar note, executable construction test, runtime label/mapping, and matcher before canonicalizing the exact UUID through `tools/allocate-construction-identity.js`. No future code is preclaimed here.

## Boundaries

- PRQ2-008 excludes ordinary `如果`, necessary `只有`, exception `除非`, concessive `就算`, lexical/focus `只 + 要`, no-`就` extensions, fragments, discourse completions, and empty members.
- PRQ2-013 excludes lone suggestion `不如 B`, comparison `A 不如 B`, `寧願` committed preference, optional `倒`, marker omission, and empty members.
- PRQ2-014 excludes participant/domain restriction without a clausal pair, bare condition-plus-`先至`, short `至`, temporal `先至`, existential/quantity `只有`, sufficient `只要`, exception `除非`, and empty members.

Generic graph, edge, and member-span records remain parser representations with zero independent linguistic-evidence weight.

## Final scope

Exactly five files:

- `data/construction-identity-candidates.json`;
- `data/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-DECISIONS-R1.json`;
- `docs/current/CONSTRUCTION-IDENTITY.md`;
- `docs/current/PROJECT-STATE.md`;
- `docs/research/PAIRED-CLAUSE-BOUNDED-IDENTITY-SPECIFICATION-R1.md`.

## Validation

Exact head: `ed77583f8d8856a925858a091ccf36cc4c127a7d`

- candidate-ledger and decision invariants: PASS;
- strict whitespace check: PASS;
- `node tools/verify-construction-identities.js`: PASS — 181 permanent records, 4 candidates, 3,750 checks, 0 failures;
- `npm run verify`: PASS — 7/7 core checks;
- `npm run verify:research`: PASS;
- project-state verification: PASS — 30 checked fields;
- documentation consistency: PASS;
- discovery freshness: PASS;
- exact-head Construction identity workflow: PASS;
- exact-head Research provenance workflow: PASS;
- review threads: none;
- final changed-file scope: exactly the five intended files.

## Protected state

No permanent registry record, short code, runtime behavior, generated bundle, executable fixture, linguistic status, evidence grade, corpus classification, survey, panel, held-out state, version, release, deployment, or merge authorization changes.

Closes #430
Closes #441