### PR TITLE
Repair native-panel lifecycle artifact enforcement

### DIFF
--- a/.github/workflows/full-diagnostic-verification.yml
+++ b/.github/workflows/full-diagnostic-verification.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "config/verification-profiles.json"
       - "tools/verify-current-state.js"
+      - "tests/tooling/verification/**"
       - "package.json"
       - "package-lock.json"
       - ".github/workflows/full-diagnostic-verification.yml"
@@ -12,6 +13,7 @@ on:
     paths:
       - "config/verification-profiles.json"
       - "tools/verify-current-state.js"
+      - "tests/tooling/verification/**"
       - "package.json"
       - "package-lock.json"
       - ".github/workflows/full-diagnostic-verification.yml"
@@ -31,6 +33,8 @@ jobs:
           package-manager-cache: false
       - name: Install build dependencies
         run: npm ci
+      - name: Test verification orchestration
+        run: npm run test:verification-orchestration
       - name: Run full diagnostic sweep
         continue-on-error: true
         run: npm run verify:all -- --keep-going --output /tmp/full-verification.json
@@ -38,19 +42,43 @@ jobs:
         run: |
           node <<'NODE'
           const fs = require('node:fs');
+          const manifest = JSON.parse(fs.readFileSync('config/verification-profiles.json', 'utf8'));
           const report = JSON.parse(fs.readFileSync('/tmp/full-verification.json', 'utf8'));
-          const expectedProfiles = ['core', 'research', 'runtime', 'release'];
+          const expectedProfiles = manifest.profile_requests.all;
+          const expectedIds = expectedProfiles.flatMap(
+            (profileName) => manifest.profiles[profileName].map((item) => item.id)
+          );
           const actualProfiles = report.included_profiles || [];
+          const actualIds = (report.results || []).map((item) => item.id);
+
           if (JSON.stringify(actualProfiles) !== JSON.stringify(expectedProfiles)) {
             throw new Error(`Unexpected included profiles: ${JSON.stringify(actualProfiles)}`);
           }
-          const ids = (report.results || []).map((item) => item.id);
-          if (new Set(ids).size !== ids.length) {
-            throw new Error(`Duplicate verification command IDs: ${JSON.stringify(ids)}`);
+          if (report.registered_command_count !== expectedIds.length) {
+            throw new Error(
+              `Registered command count mismatch: ${report.registered_command_count} != ${expectedIds.length}`
+            );
           }
-          for (const required of ['runtime-build', 'runtime-tests', 'generated-runtime']) {
-            if (!ids.includes(required)) throw new Error(`Missing runtime command: ${required}`);
+          if (report.configured_command_count !== expectedIds.length) {
+            throw new Error(
+              `Configured command count mismatch: ${report.configured_command_count} != ${expectedIds.length}`
+            );
           }
+          if (report.executed_command_count !== expectedIds.length) {
+            throw new Error(
+              `Executed command count mismatch: ${report.executed_command_count} != ${expectedIds.length}`
+            );
+          }
+          if (JSON.stringify(actualIds) !== JSON.stringify(expectedIds)) {
+            throw new Error(
+              `Verification commands were not executed exactly once in canonical order: ${JSON.stringify(actualIds)}`
+            );
+          }
+          const integrity = report.execution_integrity || {};
+          if ((integrity.duplicate_executions || []).length || (integrity.missing_executions || []).length) {
+            throw new Error(`Execution integrity failure: ${JSON.stringify(integrity)}`);
+          }
+
           const nonReleaseFailures = (report.results || []).filter(
             (item) => item.profile !== 'release' && item.status !== 'PASS'
           );
@@ -62,7 +90,7 @@ jobs:
           );
           console.log(JSON.stringify({
             included_profiles: actualProfiles,
-            command_count: ids.length,
+            command_count: actualIds.length,
             non_release_failures: 0,
             release_failures: releaseFailures.map((item) => item.id),
           }, null, 2));

--- a/.github/workflows/research-provenance.yml
+++ b/.github/workflows/research-provenance.yml
@@ -16,6 +16,8 @@ on:
       - "config/verification-profiles.json"
       - "tools/research-provenance-lib.js"
       - "tools/verify-research-provenance.js"
+      - "tools/verify-native-panel-lifecycle.js"
+      - "tests/tooling/native-panel/native-panel-lifecycle.test.js"
       - "package.json"
       - ".github/workflows/research-provenance.yml"
   pull_request:
@@ -33,6 +35,8 @@ on:
       - "config/verification-profiles.json"
       - "tools/research-provenance-lib.js"
       - "tools/verify-research-provenance.js"
+      - "tools/verify-native-panel-lifecycle.js"
+      - "tests/tooling/native-panel/native-panel-lifecycle.test.js"
       - "package.json"
       - ".github/workflows/research-provenance.yml"
   workflow_dispatch:
@@ -49,5 +53,7 @@ jobs:
         with:
           node-version: 24
           package-manager-cache: false
-      - name: Verify durable research provenance
+      - name: Test native-panel lifecycle verifier
+        run: node --test tests/tooling/native-panel/native-panel-lifecycle.test.js
+      - name: Verify durable research provenance and lifecycle state
         run: npm run verify:research

--- a/config/verification-profiles.json
+++ b/config/verification-profiles.json
@@ -1,5 +1,13 @@
 {
-  "schema": "canto-span-verification-profiles-v2",
+  "schema": "canto-span-verification-profiles-v3",
+  "profile_order": ["core", "research", "runtime", "release"],
+  "profile_requests": {
+    "core": ["core"],
+    "research": ["research"],
+    "runtime": ["runtime"],
+    "release": ["core", "release"],
+    "all": ["core", "research", "runtime", "release"]
+  },
   "profiles": {
     "core": [
       {
@@ -42,7 +50,7 @@
         "id": "documentation",
         "command": ["node", "tools/verify-documentation-consistency.js"],
         "reason": "Prevent broken current-document links and competing current authority.",
-        "run_when": "Current documentation, authority settings, or canonical state change."
+        "run_when": "Current documentation, authority settings, or canonical state changes."
       }
     ],
     "research": [
@@ -55,8 +63,8 @@
       {
         "id": "native-panel-lifecycle",
         "command": ["node", "tools/verify-native-panel-lifecycle.js"],
-        "reason": "Prevent a follow-up native-panel instrument or artifact from becoming locked, generated, deployable, or deployed before pilot closure and accepted item audit.",
-        "run_when": "Canonical pilot, item-audit, follow-up lifecycle, or tracked-artifact metadata changes."
+        "reason": "Prevent follow-up native-panel lifecycle, artifact-role, generated-form, and deployment evidence from bypassing pilot closure and accepted item audit.",
+        "run_when": "Canonical pilot, item-audit, follow-up lifecycle, artifact contract, generated namespace, or deployment namespace changes."
       }
     ],
     "runtime": [

--- a/config/verification-profiles.json
+++ b/config/verification-profiles.json
@@ -42,7 +42,7 @@
         "id": "documentation",
         "command": ["node", "tools/verify-documentation-consistency.js"],
         "reason": "Prevent broken current-document links and competing current authority.",
-        "run_when": "Current documentation, authority settings, or canonical state changes."
+        "run_when": "Current documentation, authority settings, or canonical state change."
       }
     ],
     "research": [
@@ -51,6 +51,12 @@
         "command": ["node", "tools/verify-research-provenance.js"],
         "reason": "Prevent missing, duplicate, malformed, or overclaimed research provenance records.",
         "run_when": "Research packages, source ledgers, evidence grades, or provenance configuration change."
+      },
+      {
+        "id": "native-panel-lifecycle",
+        "command": ["node", "tools/verify-native-panel-lifecycle.js"],
+        "reason": "Prevent a follow-up native-panel instrument or artifact from becoming locked, generated, deployable, or deployed before pilot closure and accepted item audit.",
+        "run_when": "Canonical pilot, item-audit, follow-up lifecycle, or tracked-artifact metadata changes."
       }
     ],
     "runtime": [

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test:regression": "node tests/run-regression.js",
     "test:np": "node tests/run-np-subsystem.js",
     "test:coordination": "node --test tests/tooling/coordination/*.test.js",
+    "test:verification-orchestration": "node --test tests/tooling/verification/verification-profiles.test.js",
+    "test:native-panel-lifecycle": "node --test tests/tooling/native-panel/native-panel-lifecycle.test.js",
     "identity:generate": "node tools/generate-construction-identities.js --write && node tools/build-construction-identity-lock.js --write",
     "identity:allocate": "node tools/allocate-construction-identity.js",
     "adjudication:apply": "node tools/apply-construction-adjudications.js --write && node tools/generate-construction-identities.js --write && node tools/generate-supported-productive-discovery.js --write",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "changes:apply": "node tools/coordination/change-set.js apply --write",
     "verify": "node tools/verify-current-state.js --profile core",
     "verify:research": "node tools/verify-current-state.js --profile research",
+    "verify:native-panel-lifecycle": "node tools/verify-native-panel-lifecycle.js",
     "verify:runtime": "node tools/verify-current-state.js --profile runtime",
     "verify:release": "node tools/verify-current-state.js --profile release",
     "verify:all": "node tools/verify-current-state.js --profile all",

--- a/review-packets/native-panel/active-v2/README.md
+++ b/review-packets/native-panel/active-v2/README.md
@@ -13,9 +13,9 @@ Canonical files:
 
 - `panel-policy.json` — thresholds, instrument requirements, batching, and lifecycle;
 - `panel-review-state.json` — current construction-specific panel evidence,
-  permanent identity tuples, and instrument-lifecycle references;
-- `followup-draft-v1-metadata.json` — non-deployable follow-up metadata using
-  permanent construction identities;
+  permanent identity tuples, pilot collection state, and item-audit state;
+- `followup-draft-v1-metadata.json` — follow-up identity, lifecycle, deployment
+  permission, and tracked-artifact state;
 - `followup-draft-v1-items.tsv` — canonical `G06–G09` and `F011–F018` item table;
 - `followup-draft-v1-item-crosswalk.tsv` — explicit mapping from superseded
   Codex-local `RUL-V1-*`, `PFV-V1-*`, and `FIL-V1-*` aliases;
@@ -43,10 +43,22 @@ but do not control the deployment gate.
 
 The deterministic lock permits `locked`, `generated`, or `deployed` only when
 pilot collection is `closed` and the item-level audit is `accepted`. It also
-rejects generated or deployable artifacts while the follow-up lifecycle remains
-`draft`. The current state is `active` / `not_started` / `draft`, and all tracked
-artifacts are non-deployable draft sources. Reported live responses that have not
-been exported, screened, and adjudicated are not accepted panel evidence.
+rejects generated, deployed, or deployable artifacts while the follow-up
+lifecycle remains `draft`, duplicate lifecycle declarations, cross-file state
+contradictions, and untracked follow-up sources. The current state is
+`active` / `not_started` / `draft`, and all tracked artifacts are non-deployable
+draft sources. Reported live responses that have not been exported, screened,
+and adjudicated are not accepted panel evidence.
+
+Run the lifecycle guard directly with:
+
+```bash
+npm run verify:native-panel-lifecycle
+```
+
+It also runs through `npm run verify:research`. The verifier reads lifecycle
+metadata only; it does not inspect respondent rows, comments, identifiers, or
+open-text responses and cannot transition survey state.
 
 The AB30 active note links the accepted decision ledger and its mechanical source
 ledger. Its five reviewed candidates (two genuine and three false positives)

--- a/review-packets/native-panel/active-v2/followup-draft-v1-metadata.json
+++ b/review-packets/native-panel/active-v2/followup-draft-v1-metadata.json
@@ -68,19 +68,28 @@
   "item_file": "review-packets/native-panel/active-v2/followup-draft-v1-items.tsv",
   "crosswalk_file": "review-packets/native-panel/active-v2/followup-draft-v1-item-crosswalk.tsv",
   "response_template_file": "review-packets/native-panel/active-v2/followup-draft-v1-response-template.tsv",
+  "artifact_contract": {
+    "scope_root": "review-packets/native-panel/active-v2",
+    "tracked_prefix": "followup-",
+    "generated_directory": "review-packets/native-panel/active-v2/generated",
+    "deployment_directory": "review-packets/native-panel/active-v2/deployment"
+  },
   "tracked_artifacts": [
     {
       "path": "review-packets/native-panel/active-v2/followup-draft-v1-items.tsv",
+      "role": "item_source",
       "artifact_state": "draft_source",
       "deployable": false
     },
     {
       "path": "review-packets/native-panel/active-v2/followup-draft-v1-item-crosswalk.tsv",
+      "role": "crosswalk_source",
       "artifact_state": "draft_source",
       "deployable": false
     },
     {
       "path": "review-packets/native-panel/active-v2/followup-draft-v1-response-template.tsv",
+      "role": "response_template_source",
       "artifact_state": "draft_source",
       "deployable": false
     }

--- a/tests/tooling/native-panel/native-panel-lifecycle.test.js
+++ b/tests/tooling/native-panel/native-panel-lifecycle.test.js
@@ -4,7 +4,10 @@ const assert = require("node:assert/strict");
 const path = require("node:path");
 const test = require("node:test");
 const {
+  ACTIVE_ROOT,
   FOLLOWUP_METADATA,
+  GENERATED_DIRECTORY,
+  DEPLOYMENT_DIRECTORY,
   validateNativePanelLifecycle,
   verifyNativePanelLifecycle,
 } = require("../../../tools/verify-native-panel-lifecycle");
@@ -19,13 +22,34 @@ function lifecycleFixtures() {
     instrument_status: "draft_followup",
     lifecycle_state: "draft",
     deployment_allowed: false,
-    item_file: "items.tsv",
-    crosswalk_file: "crosswalk.tsv",
-    response_template_file: "responses.tsv",
+    item_file: `${ACTIVE_ROOT}/followup-draft-v1-items.tsv`,
+    crosswalk_file: `${ACTIVE_ROOT}/followup-draft-v1-item-crosswalk.tsv`,
+    response_template_file: `${ACTIVE_ROOT}/followup-draft-v1-response-template.tsv`,
+    artifact_contract: {
+      scope_root: ACTIVE_ROOT,
+      tracked_prefix: "followup-",
+      generated_directory: GENERATED_DIRECTORY,
+      deployment_directory: DEPLOYMENT_DIRECTORY,
+    },
     tracked_artifacts: [
-      { path: "items.tsv", artifact_state: "draft_source", deployable: false },
-      { path: "crosswalk.tsv", artifact_state: "draft_source", deployable: false },
-      { path: "responses.tsv", artifact_state: "draft_source", deployable: false },
+      {
+        path: `${ACTIVE_ROOT}/followup-draft-v1-items.tsv`,
+        role: "item_source",
+        artifact_state: "draft_source",
+        deployable: false,
+      },
+      {
+        path: `${ACTIVE_ROOT}/followup-draft-v1-item-crosswalk.tsv`,
+        role: "crosswalk_source",
+        artifact_state: "draft_source",
+        deployable: false,
+      },
+      {
+        path: `${ACTIVE_ROOT}/followup-draft-v1-response-template.tsv`,
+        role: "response_template_source",
+        artifact_state: "draft_source",
+        deployable: false,
+      },
     ],
     current_live_instrument: {
       instrument_id: "YUE-JUDGMENT-PILOT-01",
@@ -73,17 +97,32 @@ function setLifecycle(fixture, pilotState, auditState, followupState) {
   metadata.lifecycle_state = followupState;
   metadata.instrument_status = followupStatuses[followupState];
   metadata.deployment_allowed = followupState === "deployed";
-  metadata.tracked_artifacts = metadata.tracked_artifacts.map((artifact) => ({
-    ...artifact,
-    artifact_state: "draft_source",
-    deployable: false,
-  }));
+  metadata.tracked_artifacts = metadata.tracked_artifacts.filter((artifact) =>
+    ["item_source", "crosswalk_source", "response_template_source"].includes(artifact.role)
+  );
   if (followupState === "generated") {
-    metadata.tracked_artifacts[0].artifact_state = "generated";
+    metadata.tracked_artifacts.push({
+      path: `${GENERATED_DIRECTORY}/followup-form.json`,
+      role: "generated_instrument",
+      artifact_state: "generated",
+      deployable: false,
+    });
   }
   if (followupState === "deployed") {
-    metadata.tracked_artifacts[0].artifact_state = "deployed";
-    metadata.tracked_artifacts[0].deployable = true;
+    metadata.tracked_artifacts.push(
+      {
+        path: `${GENERATED_DIRECTORY}/followup-form.json`,
+        role: "generated_instrument",
+        artifact_state: "deployed",
+        deployable: true,
+      },
+      {
+        path: `${DEPLOYMENT_DIRECTORY}/followup-deployment-receipt.json`,
+        role: "deployment_receipt",
+        artifact_state: "deployed",
+        deployable: false,
+      },
+    );
   }
 
   const pilot = state.instrument_lifecycle.pilot_collections[0];
@@ -100,19 +139,25 @@ function hasFailure(failures, invariant) {
   return failures.some((failure) => failure.invariant === invariant);
 }
 
+function discoveredFor(metadata) {
+  return metadata.tracked_artifacts.map((artifact) => artifact.path);
+}
+
 test("deployment lock covers all 24 pilot, audit, and follow-up combinations", () => {
   for (const pilotState of ["active", "closed"]) {
     for (const auditState of ["not_started", "in_progress", "accepted"]) {
       for (const followupState of ["draft", "locked", "generated", "deployed"]) {
         const fixture = lifecycleFixtures();
         setLifecycle(fixture, pilotState, auditState, followupState);
-        const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata);
-        const allowed = followupState === "draft" ||
-          (pilotState === "closed" && auditState === "accepted");
+        const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata, {
+          discovered_artifacts: discoveredFor(fixture.metadata),
+        });
+        const allowed = followupState === "draft"
+          || (pilotState === "closed" && auditState === "accepted");
         assert.equal(
           failures.length === 0,
           allowed,
-          `${pilotState}/${auditState}/${followupState}: ${JSON.stringify(failures)}`
+          `${pilotState}/${auditState}/${followupState}: ${JSON.stringify(failures)}`,
         );
       }
     }
@@ -121,7 +166,12 @@ test("deployment lock covers all 24 pilot, audit, and follow-up combinations", (
 
 test("current active, not-started, draft fixture passes", () => {
   const { metadata, state } = lifecycleFixtures();
-  assert.deepEqual(validateNativePanelLifecycle(state, metadata), []);
+  assert.deepEqual(
+    validateNativePanelLifecycle(state, metadata, {
+      discovered_artifacts: discoveredFor(metadata),
+    }),
+    [],
+  );
 });
 
 test("missing and duplicate lifecycle declarations fail", () => {
@@ -133,15 +183,15 @@ test("missing and duplicate lifecycle declarations fail", () => {
 
   const duplicate = lifecycleFixtures();
   duplicate.state.instrument_lifecycle.pilot_collections.push(
-    clone(duplicate.state.instrument_lifecycle.pilot_collections[0])
+    clone(duplicate.state.instrument_lifecycle.pilot_collections[0]),
   );
   assert.ok(hasFailure(
     validateNativePanelLifecycle(duplicate.state, duplicate.metadata),
-    "exactly_one_pilot_declaration"
+    "exactly_one_pilot_declaration",
   ));
 });
 
-test("unsupported states and cross-file contradictions fail precisely", () => {
+test("unsupported states and cross-file contradictions fail", () => {
   for (const mutate of [
     (fixture) => { fixture.state.instrument_lifecycle.pilot_collections[0].collection_state = "paused"; },
     (fixture) => { fixture.state.instrument_lifecycle.item_level_audit.state = "complete"; },
@@ -155,43 +205,118 @@ test("unsupported states and cross-file contradictions fail precisely", () => {
   }
 });
 
-test("draft lifecycle rejects generated, deployed, or deployable artifacts", () => {
-  for (const artifact of [
-    { artifact_state: "generated", deployable: false },
-    { artifact_state: "deployed", deployable: false },
-    { artifact_state: "draft_source", deployable: true },
-  ]) {
+test("deployed lifecycle cannot coexist with deployment_allowed=false", () => {
+  const fixture = lifecycleFixtures();
+  setLifecycle(fixture, "closed", "accepted", "deployed");
+  fixture.metadata.deployment_allowed = false;
+  fixture.state.instrument_lifecycle.followup_instrument.deployment_allowed = false;
+  const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata);
+  assert.ok(hasFailure(failures, "deployment_permission_matches_lifecycle"));
+});
+
+test("deployment permission cannot be true before deployed lifecycle", () => {
+  const fixture = lifecycleFixtures();
+  setLifecycle(fixture, "closed", "accepted", "generated");
+  fixture.metadata.deployment_allowed = true;
+  fixture.state.instrument_lifecycle.followup_instrument.deployment_allowed = true;
+  const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata);
+  assert.ok(hasFailure(failures, "deployment_permission_matches_lifecycle"));
+});
+
+test("source files cannot satisfy generated or deployed evidence", () => {
+  for (const followupState of ["generated", "deployed"]) {
     const fixture = lifecycleFixtures();
-    Object.assign(fixture.metadata.tracked_artifacts[0], artifact);
-    const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata);
-    assert.ok(
-      hasFailure(failures, "artifact_state_not_ahead_of_lifecycle") ||
-      hasFailure(failures, "draft_has_no_generated_or_deployable_artifact")
+    setLifecycle(fixture, "closed", "accepted", followupState);
+    fixture.metadata.tracked_artifacts = fixture.metadata.tracked_artifacts.filter((artifact) =>
+      !["generated_instrument", "deployment_receipt"].includes(artifact.role)
     );
+    fixture.metadata.tracked_artifacts[0].artifact_state = followupState;
+    fixture.metadata.tracked_artifacts[0].deployable = followupState === "deployed";
+    const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata);
+    assert.ok(hasFailure(
+      failures,
+      "source_role_cannot_supply_generated_or_deployed_evidence",
+    ));
+    assert.ok(hasFailure(
+      failures,
+      followupState === "generated" ? "generated_lifecycle_evidence" : "deployed_lifecycle_evidence",
+    ));
   }
 });
 
-test("artifact declarations must be unique, complete, and lifecycle-consistent", () => {
-  const duplicate = lifecycleFixtures();
-  duplicate.metadata.tracked_artifacts.push(clone(duplicate.metadata.tracked_artifacts[0]));
+test("generated instruments and deployment receipts use separate canonical roles and directories", () => {
+  const wrongGenerated = lifecycleFixtures();
+  setLifecycle(wrongGenerated, "closed", "accepted", "generated");
+  wrongGenerated.metadata.tracked_artifacts.find(
+    (artifact) => artifact.role === "generated_instrument",
+  ).path = `${ACTIVE_ROOT}/followup-form.json`;
   assert.ok(hasFailure(
-    validateNativePanelLifecycle(duplicate.state, duplicate.metadata),
-    "unique_tracked_artifact_declaration"
+    validateNativePanelLifecycle(wrongGenerated.state, wrongGenerated.metadata),
+    "generated_instrument_uses_canonical_directory",
   ));
 
-  const missing = lifecycleFixtures();
-  missing.metadata.tracked_artifacts.pop();
+  const wrongReceipt = lifecycleFixtures();
+  setLifecycle(wrongReceipt, "closed", "accepted", "deployed");
+  wrongReceipt.metadata.tracked_artifacts.find(
+    (artifact) => artifact.role === "deployment_receipt",
+  ).path = `${GENERATED_DIRECTORY}/followup-deployment-receipt.json`;
   assert.ok(hasFailure(
-    validateNativePanelLifecycle(missing.state, missing.metadata),
-    "all_followup_sources_are_tracked"
+    validateNativePanelLifecycle(wrongReceipt.state, wrongReceipt.metadata),
+    "deployment_receipt_uses_canonical_directory",
+  ));
+});
+
+test("deployed lifecycle requires both deployed instrument and deployment receipt", () => {
+  for (const missingRole of ["generated_instrument", "deployment_receipt"]) {
+    const fixture = lifecycleFixtures();
+    setLifecycle(fixture, "closed", "accepted", "deployed");
+    fixture.metadata.tracked_artifacts = fixture.metadata.tracked_artifacts.filter(
+      (artifact) => artifact.role !== missingRole,
+    );
+    const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata);
+    assert.ok(hasFailure(failures, "deployed_lifecycle_evidence"), missingRole);
+  }
+});
+
+test("untracked follow-up artifacts fail closed", () => {
+  const fixture = lifecycleFixtures();
+  const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata, {
+    discovered_artifacts: [
+      ...discoveredFor(fixture.metadata),
+      `${GENERATED_DIRECTORY}/followup-untracked-form.json`,
+    ],
+  });
+  assert.ok(hasFailure(failures, "untracked_followup_artifact"));
+});
+
+test("tracked artifacts absent from the namespace fail closed", () => {
+  const fixture = lifecycleFixtures();
+  const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata, {
+    discovered_artifacts: discoveredFor(fixture.metadata).slice(0, 2),
+  });
+  assert.ok(hasFailure(failures, "tracked_artifact_exists"));
+});
+
+test("artifact declarations require unique paths, unique source roles, and the canonical contract", () => {
+  const duplicatePath = lifecycleFixtures();
+  duplicatePath.metadata.tracked_artifacts.push(clone(duplicatePath.metadata.tracked_artifacts[0]));
+  assert.ok(hasFailure(
+    validateNativePanelLifecycle(duplicatePath.state, duplicatePath.metadata),
+    "unique_tracked_artifact_declaration",
   ));
 
-  const generatedWithoutArtifact = lifecycleFixtures();
-  setLifecycle(generatedWithoutArtifact, "closed", "accepted", "generated");
-  generatedWithoutArtifact.metadata.tracked_artifacts[0].artifact_state = "draft_source";
+  const duplicateRole = lifecycleFixtures();
+  duplicateRole.metadata.tracked_artifacts[1].role = "item_source";
   assert.ok(hasFailure(
-    validateNativePanelLifecycle(generatedWithoutArtifact.state, generatedWithoutArtifact.metadata),
-    "generated_state_has_generated_artifact"
+    validateNativePanelLifecycle(duplicateRole.state, duplicateRole.metadata),
+    "exactly_one_source_artifact_per_role",
+  ));
+
+  const badContract = lifecycleFixtures();
+  badContract.metadata.artifact_contract.generated_directory = `${ACTIVE_ROOT}/other`;
+  assert.ok(hasFailure(
+    validateNativePanelLifecycle(badContract.state, badContract.metadata),
+    "canonical_artifact_contract",
   ));
 });
 
@@ -202,7 +327,7 @@ test("unrelated prose does not become lifecycle authority", () => {
   assert.deepEqual(validateNativePanelLifecycle(fixture.state, fixture.metadata), []);
 });
 
-test("current repository lifecycle and tracked artifacts pass", () => {
+test("current repository lifecycle and closed artifact namespace pass", () => {
   const root = path.resolve(__dirname, "../../..");
   const result = verifyNativePanelLifecycle(root);
   assert.equal(result.status, "PASS", JSON.stringify(result.failures, null, 2));
@@ -210,4 +335,7 @@ test("current repository lifecycle and tracked artifacts pass", () => {
   assert.equal(result.audit_state, "not_started");
   assert.equal(result.followup_state, "draft");
   assert.equal(result.deployment_allowed, false);
+  assert.equal(result.tracked_artifacts, 3);
+  assert.equal(result.discovered_artifacts, 3);
+  assert.equal(result.artifact_digests.length, 3);
 });

--- a/tests/tooling/native-panel/native-panel-lifecycle.test.js
+++ b/tests/tooling/native-panel/native-panel-lifecycle.test.js
@@ -1,0 +1,213 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  FOLLOWUP_METADATA,
+  validateNativePanelLifecycle,
+  verifyNativePanelLifecycle,
+} = require("../../../tools/verify-native-panel-lifecycle");
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function lifecycleFixtures() {
+  const metadata = {
+    instrument_id: "YUE-JUDGMENT-FOLLOWUP-01-DRAFT",
+    instrument_status: "draft_followup",
+    lifecycle_state: "draft",
+    deployment_allowed: false,
+    item_file: "items.tsv",
+    crosswalk_file: "crosswalk.tsv",
+    response_template_file: "responses.tsv",
+    tracked_artifacts: [
+      { path: "items.tsv", artifact_state: "draft_source", deployable: false },
+      { path: "crosswalk.tsv", artifact_state: "draft_source", deployable: false },
+      { path: "responses.tsv", artifact_state: "draft_source", deployable: false },
+    ],
+    current_live_instrument: {
+      instrument_id: "YUE-JUDGMENT-PILOT-01",
+      status: "collection_in_progress",
+      collection_state: "active",
+      closure_rule: "Do not deploy this follow-up until the live instrument closes and its item audit is incorporated.",
+    },
+  };
+  const state = {
+    constructions: [],
+    instrument_lifecycle: {
+      metadata_file: FOLLOWUP_METADATA,
+      pilot_collections: [{
+        instrument_id: metadata.current_live_instrument.instrument_id,
+        collection_state: metadata.current_live_instrument.collection_state,
+        compatibility_status: metadata.current_live_instrument.status,
+        closure_rule: metadata.current_live_instrument.closure_rule,
+      }],
+      item_level_audit: {
+        pilot_instrument_id: metadata.current_live_instrument.instrument_id,
+        state: "not_started",
+      },
+      followup_instrument: {
+        instrument_id: metadata.instrument_id,
+        lifecycle_state: metadata.lifecycle_state,
+        compatibility_status: metadata.instrument_status,
+        deployment_allowed: metadata.deployment_allowed,
+      },
+    },
+  };
+  return { metadata, state };
+}
+
+function setLifecycle(fixture, pilotState, auditState, followupState) {
+  const pilotStatuses = { active: "collection_in_progress", closed: "collection_closed" };
+  const followupStatuses = {
+    draft: "draft_followup",
+    locked: "instrument_locked",
+    generated: "form_generated",
+    deployed: "deployed",
+  };
+  const { metadata, state } = fixture;
+  metadata.current_live_instrument.collection_state = pilotState;
+  metadata.current_live_instrument.status = pilotStatuses[pilotState];
+  metadata.lifecycle_state = followupState;
+  metadata.instrument_status = followupStatuses[followupState];
+  metadata.deployment_allowed = followupState === "deployed";
+  metadata.tracked_artifacts = metadata.tracked_artifacts.map((artifact) => ({
+    ...artifact,
+    artifact_state: "draft_source",
+    deployable: false,
+  }));
+  if (followupState === "generated") {
+    metadata.tracked_artifacts[0].artifact_state = "generated";
+  }
+  if (followupState === "deployed") {
+    metadata.tracked_artifacts[0].artifact_state = "deployed";
+    metadata.tracked_artifacts[0].deployable = true;
+  }
+
+  const pilot = state.instrument_lifecycle.pilot_collections[0];
+  pilot.collection_state = pilotState;
+  pilot.compatibility_status = pilotStatuses[pilotState];
+  state.instrument_lifecycle.item_level_audit.state = auditState;
+  const followup = state.instrument_lifecycle.followup_instrument;
+  followup.lifecycle_state = followupState;
+  followup.compatibility_status = followupStatuses[followupState];
+  followup.deployment_allowed = metadata.deployment_allowed;
+}
+
+function hasFailure(failures, invariant) {
+  return failures.some((failure) => failure.invariant === invariant);
+}
+
+test("deployment lock covers all 24 pilot, audit, and follow-up combinations", () => {
+  for (const pilotState of ["active", "closed"]) {
+    for (const auditState of ["not_started", "in_progress", "accepted"]) {
+      for (const followupState of ["draft", "locked", "generated", "deployed"]) {
+        const fixture = lifecycleFixtures();
+        setLifecycle(fixture, pilotState, auditState, followupState);
+        const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata);
+        const allowed = followupState === "draft" ||
+          (pilotState === "closed" && auditState === "accepted");
+        assert.equal(
+          failures.length === 0,
+          allowed,
+          `${pilotState}/${auditState}/${followupState}: ${JSON.stringify(failures)}`
+        );
+      }
+    }
+  }
+});
+
+test("current active, not-started, draft fixture passes", () => {
+  const { metadata, state } = lifecycleFixtures();
+  assert.deepEqual(validateNativePanelLifecycle(state, metadata), []);
+});
+
+test("missing and duplicate lifecycle declarations fail", () => {
+  for (const field of ["pilot_collections", "item_level_audit", "followup_instrument"]) {
+    const fixture = lifecycleFixtures();
+    delete fixture.state.instrument_lifecycle[field];
+    assert.notEqual(validateNativePanelLifecycle(fixture.state, fixture.metadata).length, 0, field);
+  }
+
+  const duplicate = lifecycleFixtures();
+  duplicate.state.instrument_lifecycle.pilot_collections.push(
+    clone(duplicate.state.instrument_lifecycle.pilot_collections[0])
+  );
+  assert.ok(hasFailure(
+    validateNativePanelLifecycle(duplicate.state, duplicate.metadata),
+    "exactly_one_pilot_declaration"
+  ));
+});
+
+test("unsupported states and cross-file contradictions fail precisely", () => {
+  for (const mutate of [
+    (fixture) => { fixture.state.instrument_lifecycle.pilot_collections[0].collection_state = "paused"; },
+    (fixture) => { fixture.state.instrument_lifecycle.item_level_audit.state = "complete"; },
+    (fixture) => { fixture.state.instrument_lifecycle.followup_instrument.lifecycle_state = "ready"; },
+    (fixture) => { fixture.metadata.current_live_instrument.instrument_id = "OLD-PILOT"; },
+    (fixture) => { fixture.state.instrument_lifecycle.followup_instrument.compatibility_status = "pilot_ready"; },
+  ]) {
+    const fixture = lifecycleFixtures();
+    mutate(fixture);
+    assert.notEqual(validateNativePanelLifecycle(fixture.state, fixture.metadata).length, 0);
+  }
+});
+
+test("draft lifecycle rejects generated, deployed, or deployable artifacts", () => {
+  for (const artifact of [
+    { artifact_state: "generated", deployable: false },
+    { artifact_state: "deployed", deployable: false },
+    { artifact_state: "draft_source", deployable: true },
+  ]) {
+    const fixture = lifecycleFixtures();
+    Object.assign(fixture.metadata.tracked_artifacts[0], artifact);
+    const failures = validateNativePanelLifecycle(fixture.state, fixture.metadata);
+    assert.ok(
+      hasFailure(failures, "artifact_state_not_ahead_of_lifecycle") ||
+      hasFailure(failures, "draft_has_no_generated_or_deployable_artifact")
+    );
+  }
+});
+
+test("artifact declarations must be unique, complete, and lifecycle-consistent", () => {
+  const duplicate = lifecycleFixtures();
+  duplicate.metadata.tracked_artifacts.push(clone(duplicate.metadata.tracked_artifacts[0]));
+  assert.ok(hasFailure(
+    validateNativePanelLifecycle(duplicate.state, duplicate.metadata),
+    "unique_tracked_artifact_declaration"
+  ));
+
+  const missing = lifecycleFixtures();
+  missing.metadata.tracked_artifacts.pop();
+  assert.ok(hasFailure(
+    validateNativePanelLifecycle(missing.state, missing.metadata),
+    "all_followup_sources_are_tracked"
+  ));
+
+  const generatedWithoutArtifact = lifecycleFixtures();
+  setLifecycle(generatedWithoutArtifact, "closed", "accepted", "generated");
+  generatedWithoutArtifact.metadata.tracked_artifacts[0].artifact_state = "draft_source";
+  assert.ok(hasFailure(
+    validateNativePanelLifecycle(generatedWithoutArtifact.state, generatedWithoutArtifact.metadata),
+    "generated_state_has_generated_artifact"
+  ));
+});
+
+test("unrelated prose does not become lifecycle authority", () => {
+  const fixture = lifecycleFixtures();
+  fixture.state.expert_prose = "The pilot might close after a future audit.";
+  fixture.metadata.notes = "Generated and deployed are words here, not state declarations.";
+  assert.deepEqual(validateNativePanelLifecycle(fixture.state, fixture.metadata), []);
+});
+
+test("current repository lifecycle and tracked artifacts pass", () => {
+  const root = path.resolve(__dirname, "../../..");
+  const result = verifyNativePanelLifecycle(root);
+  assert.equal(result.status, "PASS", JSON.stringify(result.failures, null, 2));
+  assert.equal(result.pilot_state, "active");
+  assert.equal(result.audit_state, "not_started");
+  assert.equal(result.followup_state, "draft");
+  assert.equal(result.deployment_allowed, false);
+});

--- a/tests/tooling/verification/verification-profiles.test.js
+++ b/tests/tooling/verification/verification-profiles.test.js
@@ -1,0 +1,180 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const root = path.resolve(__dirname, "../../..");
+const runner = path.join(root, "tools", "verify-current-state.js");
+const canonicalManifest = JSON.parse(
+  fs.readFileSync(path.join(root, "config", "verification-profiles.json"), "utf8"),
+);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function withManifest(manifest, callback) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "canto-span-verification-"));
+  const manifestPath = path.join(directory, "profiles.json");
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  try {
+    return callback({ directory, manifestPath });
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function runManifest(manifest, args = ["--profile", "all", "--validate-only"], env = {}) {
+  return withManifest(manifest, ({ manifestPath, directory }) => {
+    const result = spawnSync(
+      process.execPath,
+      [runner, ...args, "--manifest", manifestPath],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+      },
+    );
+    return { ...result, directory };
+  });
+}
+
+function assertConfigFailure(manifest, pattern, args) {
+  const result = runManifest(manifest, args);
+  assert.equal(result.status, 2, result.stdout || result.stderr);
+  assert.match(result.stderr, pattern);
+}
+
+test("canonical verification manifest validates", () => {
+  const result = runManifest(canonicalManifest);
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.deepEqual(report.included_profiles, canonicalManifest.profile_order);
+  const expectedCount = canonicalManifest.profile_order.reduce(
+    (count, profileName) => count + canonicalManifest.profiles[profileName].length,
+    0,
+  );
+  assert.equal(report.registered_command_count, expectedCount);
+  assert.equal(report.configured_command_count, expectedCount);
+  assert.equal(report.executed_command_count, 0);
+});
+
+test("duplicate command IDs fail closed", () => {
+  const manifest = clone(canonicalManifest);
+  manifest.profiles.research[0].id = manifest.profiles.core[0].id;
+  assertConfigFailure(manifest, /Duplicate verification command ID/);
+});
+
+test("duplicate command payloads fail closed even with different IDs", () => {
+  const manifest = clone(canonicalManifest);
+  manifest.profiles.research[0].command = [...manifest.profiles.core[0].command];
+  assertConfigFailure(manifest, /Duplicate verification command/);
+});
+
+test("canonical profile names cannot be redefined", () => {
+  const manifest = clone(canonicalManifest);
+  manifest.profile_order = ["core", "research", "release"];
+  delete manifest.profiles.runtime;
+  delete manifest.profile_requests.runtime;
+  manifest.profile_requests.all = ["core", "research", "release"];
+  assertConfigFailure(manifest, /profile_order must exactly equal/);
+});
+
+test("missing canonical profiles fail closed", () => {
+  const manifest = clone(canonicalManifest);
+  delete manifest.profiles.release;
+  assertConfigFailure(manifest, /profiles keys must exactly match/);
+});
+
+test("extra canonical profiles fail closed", () => {
+  const manifest = clone(canonicalManifest);
+  manifest.profiles.unknown = clone(manifest.profiles.research);
+  assertConfigFailure(manifest, /profiles keys must exactly match/);
+});
+
+test("empty canonical profiles fail closed", () => {
+  const manifest = clone(canonicalManifest);
+  manifest.profiles.research = [];
+  assertConfigFailure(manifest, /profiles\.research must be a non-empty array/);
+});
+
+test("non-canonical all selection fails closed", () => {
+  const manifest = clone(canonicalManifest);
+  manifest.profile_requests.all = ["core", "research", "release"];
+  assertConfigFailure(manifest, /profile_requests\.all must exactly equal profile_order/);
+});
+
+test("empty profile selections fail closed", () => {
+  const manifest = clone(canonicalManifest);
+  manifest.profile_requests.research = [];
+  assertConfigFailure(manifest, /profile_requests\.research must be a non-empty array/);
+});
+
+test("missing profile selections fail closed", () => {
+  const manifest = clone(canonicalManifest);
+  delete manifest.profile_requests.research;
+  assertConfigFailure(manifest, /profile_requests keys must exactly match/);
+});
+
+test("unknown requested profiles fail closed", () => {
+  assertConfigFailure(
+    canonicalManifest,
+    /Unknown verification profile request: unknown/,
+    ["--profile", "unknown", "--validate-only"],
+  );
+});
+
+test("all profile executes every registered command exactly once", () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "canto-span-execution-"));
+  const logPath = path.join(directory, "executions.log");
+  const manifest = {
+    schema: "canto-span-verification-profiles-v3",
+    profile_order: ["core", "research", "runtime", "release"],
+    profile_requests: {
+      core: ["core"],
+      research: ["research"],
+      runtime: ["runtime"],
+      release: ["core", "release"],
+      all: ["core", "research", "runtime", "release"],
+    },
+    profiles: {},
+  };
+  for (const profileName of manifest.profile_order) {
+    manifest.profiles[profileName] = [{
+      id: `${profileName}-probe`,
+      command: [
+        process.execPath,
+        "-e",
+        `require('node:fs').appendFileSync(process.env.CANTO_SPAN_VERIFY_TEST_LOG, '${profileName}\\n')`,
+      ],
+      reason: `Exercise ${profileName} execution integrity.`,
+      run_when: "The verification orchestrator changes.",
+    }];
+  }
+
+  try {
+    const result = runManifest(
+      manifest,
+      ["--profile", "all", "--keep-going"],
+      { CANTO_SPAN_VERIFY_TEST_LOG: logPath },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.configured_command_count, 4);
+    assert.equal(report.executed_command_count, 4);
+    assert.deepEqual(report.execution_integrity, {
+      duplicate_executions: [],
+      missing_executions: [],
+    });
+    assert.deepEqual(
+      fs.readFileSync(logPath, "utf8").trim().split("\n"),
+      manifest.profile_order,
+    );
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/tools/verify-current-state.js
+++ b/tools/verify-current-state.js
@@ -6,69 +6,205 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
 const root = path.resolve(__dirname, "..");
-const manifest = JSON.parse(
-  fs.readFileSync(path.join(root, "config", "verification-profiles.json"), "utf8"),
-);
-const profileIndex = process.argv.indexOf("--profile");
-const requested = profileIndex >= 0 ? process.argv[profileIndex + 1] : "core";
-const outputIndex = process.argv.indexOf("--output");
-const outputPath = outputIndex >= 0
-  ? path.resolve(process.cwd(), process.argv[outputIndex + 1] || "")
-  : null;
-const keepGoing = process.argv.includes("--keep-going");
-const valid = new Set(["core", "research", "runtime", "release", "all"]);
+const CANONICAL_PROFILE_ORDER = Object.freeze(["core", "research", "runtime", "release"]);
 
-if (!valid.has(requested)) {
-  console.error(`Unknown verification profile: ${requested}`);
-  process.exit(2);
-}
-if (outputIndex >= 0 && !process.argv[outputIndex + 1]) {
-  console.error("--output requires a file path");
-  process.exit(2);
-}
-if (manifest.schema !== "canto-span-verification-profiles-v2") {
-  console.error(`Unsupported verification profile schema: ${manifest.schema}`);
-  process.exit(2);
+function optionValue(flag, fallback = null) {
+  const indexes = process.argv
+    .map((value, index) => (value === flag ? index : -1))
+    .filter((index) => index >= 0);
+  if (indexes.length > 1) {
+    throw new Error(`${flag} may be supplied at most once`);
+  }
+  if (!indexes.length) return fallback;
+  const value = process.argv[indexes[0] + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
 }
 
-const selectedNames = requested === "all"
-  ? ["core", "research", "runtime", "release"]
-  : requested === "release"
-    ? ["core", "release"]
-    : [requested];
-const commands = [];
-const seen = new Set();
-const configurationErrors = [];
-
-for (const name of selectedNames) {
-  for (const item of manifest.profiles[name] || []) {
-    const validItem = item
-      && typeof item.id === "string"
-      && item.id.length > 0
-      && Array.isArray(item.command)
-      && item.command.length > 0
-      && item.command.every((part) => typeof part === "string" && part.length > 0)
-      && typeof item.reason === "string"
-      && item.reason.trim().length > 0
-      && typeof item.run_when === "string"
-      && item.run_when.trim().length > 0;
-    if (!validItem) {
-      configurationErrors.push({ profile: name, id: item?.id || null });
-      continue;
-    }
-    if (seen.has(item.id)) continue;
-    seen.add(item.id);
-    commands.push({ ...item, profile: name });
+function assertStringArray(value, label) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${label} must be a non-empty array`);
+  }
+  if (!value.every((item) => typeof item === "string" && item.trim().length > 0)) {
+    throw new Error(`${label} must contain only non-empty strings`);
+  }
+  if (new Set(value).size !== value.length) {
+    throw new Error(`${label} must not contain duplicates`);
   }
 }
 
-if (configurationErrors.length) {
-  console.error(JSON.stringify({
-    status: "FAIL",
-    reason: "Every permanent verification command requires id, command, reason, and run_when.",
-    configuration_errors: configurationErrors,
-  }, null, 2));
+function assertExactKeys(actualObject, expectedKeys, label) {
+  if (!actualObject || typeof actualObject !== "object" || Array.isArray(actualObject)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const actualKeys = Object.keys(actualObject);
+  if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
+    throw new Error(
+      `${label} keys must exactly match ${JSON.stringify(expectedKeys)}; got ${JSON.stringify(actualKeys)}`,
+    );
+  }
+}
+
+function validateManifest(manifest) {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error("Verification profile manifest must be an object");
+  }
+  if (manifest.schema !== "canto-span-verification-profiles-v3") {
+    throw new Error(`Unsupported verification profile schema: ${manifest.schema}`);
+  }
+
+  assertStringArray(manifest.profile_order, "profile_order");
+  if (JSON.stringify(manifest.profile_order) !== JSON.stringify(CANONICAL_PROFILE_ORDER)) {
+    throw new Error(
+      `profile_order must exactly equal ${JSON.stringify(CANONICAL_PROFILE_ORDER)}`,
+    );
+  }
+  assertExactKeys(manifest.profiles, manifest.profile_order, "profiles");
+
+  const requestKeys = [...manifest.profile_order, "all"];
+  assertExactKeys(manifest.profile_requests, requestKeys, "profile_requests");
+
+  for (const requestName of requestKeys) {
+    const selected = manifest.profile_requests[requestName];
+    assertStringArray(selected, `profile_requests.${requestName}`);
+    for (const profileName of selected) {
+      if (!manifest.profile_order.includes(profileName)) {
+        throw new Error(`profile_requests.${requestName} references unknown profile: ${profileName}`);
+      }
+    }
+    if (requestName === "all") {
+      if (JSON.stringify(selected) !== JSON.stringify(manifest.profile_order)) {
+        throw new Error("profile_requests.all must exactly equal profile_order");
+      }
+    } else if (!selected.includes(requestName)) {
+      throw new Error(`profile_requests.${requestName} must include its own profile`);
+    }
+  }
+
+  const ids = new Set();
+  const commandKeys = new Map();
+  let registeredCommandCount = 0;
+
+  for (const profileName of manifest.profile_order) {
+    const items = manifest.profiles[profileName];
+    if (!Array.isArray(items) || items.length === 0) {
+      throw new Error(`profiles.${profileName} must be a non-empty array`);
+    }
+    for (const [index, item] of items.entries()) {
+      const label = `profiles.${profileName}[${index}]`;
+      const validItem = item
+        && typeof item === "object"
+        && typeof item.id === "string"
+        && item.id.trim().length > 0
+        && Array.isArray(item.command)
+        && item.command.length > 0
+        && item.command.every((part) => typeof part === "string" && part.length > 0)
+        && typeof item.reason === "string"
+        && item.reason.trim().length > 0
+        && typeof item.run_when === "string"
+        && item.run_when.trim().length > 0;
+      if (!validItem) {
+        throw new Error(`${label} requires non-empty id, command, reason, and run_when fields`);
+      }
+      if (ids.has(item.id)) {
+        throw new Error(`Duplicate verification command ID: ${item.id}`);
+      }
+      ids.add(item.id);
+
+      const commandKey = JSON.stringify(item.command);
+      if (commandKeys.has(commandKey)) {
+        throw new Error(
+          `Duplicate verification command for IDs ${commandKeys.get(commandKey)} and ${item.id}`,
+        );
+      }
+      commandKeys.set(commandKey, item.id);
+      registeredCommandCount += 1;
+    }
+  }
+
+  return { requestKeys, registeredCommandCount };
+}
+
+function writeOutput(outputPath, output) {
+  if (!outputPath) return;
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`);
+}
+
+let requested;
+let outputPath;
+let manifestPath;
+try {
+  requested = optionValue("--profile", "core");
+  const outputValue = optionValue("--output", null);
+  outputPath = outputValue ? path.resolve(process.cwd(), outputValue) : null;
+  const manifestValue = optionValue(
+    "--manifest",
+    path.join(root, "config", "verification-profiles.json"),
+  );
+  manifestPath = path.resolve(process.cwd(), manifestValue);
+} catch (error) {
+  console.error(error.message);
   process.exit(2);
+}
+
+const keepGoing = process.argv.includes("--keep-going");
+const validateOnly = process.argv.includes("--validate-only");
+
+let manifest;
+let manifestValidation;
+try {
+  manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  manifestValidation = validateManifest(manifest);
+  if (!manifestValidation.requestKeys.includes(requested)) {
+    throw new Error(`Unknown verification profile request: ${requested}`);
+  }
+} catch (error) {
+  const output = {
+    schema: "canto-span-verification-summary-v3",
+    requested_profile: requested || null,
+    manifest: path.relative(root, manifestPath || "") || ".",
+    status: "FAIL",
+    reason: error.message,
+  };
+  writeOutput(outputPath, output);
+  console.error(JSON.stringify(output, null, 2));
+  process.exit(2);
+}
+
+const selectedNames = manifest.profile_requests[requested];
+const commands = selectedNames.flatMap((profileName) =>
+  manifest.profiles[profileName].map((item) => ({ ...item, profile: profileName }))
+);
+const selectedIds = commands.map((item) => item.id);
+if (new Set(selectedIds).size !== selectedIds.length) {
+  console.error("Selected verification commands must have unique IDs");
+  process.exit(2);
+}
+
+const runtime = JSON.parse(
+  fs.readFileSync(path.join(root, "manifest.json"), "utf8"),
+).version;
+
+if (validateOnly) {
+  const output = {
+    schema: "canto-span-verification-summary-v3",
+    runtime_version: runtime,
+    requested_profile: requested,
+    included_profiles: selectedNames,
+    manifest_profile_order: manifest.profile_order,
+    validation_only: true,
+    registered_command_count: manifestValidation.registeredCommandCount,
+    configured_command_count: commands.length,
+    executed_command_count: 0,
+    status: "PASS",
+    results: [],
+  };
+  writeOutput(outputPath, output);
+  console.log(JSON.stringify(output, null, 2));
+  process.exit(0);
 }
 
 const results = [];
@@ -96,26 +232,41 @@ for (const item of commands) {
   if (failed && !keepGoing) break;
 }
 
-const runtime = JSON.parse(
-  fs.readFileSync(path.join(root, "manifest.json"), "utf8"),
-).version;
+const executionCounts = new Map();
+for (const result of results) {
+  executionCounts.set(result.id, (executionCounts.get(result.id) || 0) + 1);
+}
+const duplicateExecutions = [...executionCounts.entries()]
+  .filter(([, count]) => count !== 1)
+  .map(([id, count]) => ({ id, count }));
+const missingExecutions = requested === "all" && keepGoing
+  ? selectedIds.filter((id) => !executionCounts.has(id))
+  : [];
+if (duplicateExecutions.length || missingExecutions.length) {
+  failed = true;
+}
+
 const output = {
-  schema: "canto-span-verification-summary-v2",
+  schema: "canto-span-verification-summary-v3",
   runtime_version: runtime,
   requested_profile: requested,
   included_profiles: selectedNames,
+  manifest_profile_order: manifest.profile_order,
   fail_fast: !keepGoing,
+  validation_only: false,
+  registered_command_count: manifestValidation.registeredCommandCount,
   configured_command_count: commands.length,
   executed_command_count: results.length,
+  execution_integrity: {
+    duplicate_executions: duplicateExecutions,
+    missing_executions: missingExecutions,
+  },
   passed: results.filter((item) => item.status === "PASS").length,
   failed: results.filter((item) => item.status === "FAIL").length,
   status: failed ? "FAIL" : "PASS",
   results,
 };
 
-if (outputPath) {
-  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-  fs.writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`);
-}
+writeOutput(outputPath, output);
 console.log(JSON.stringify(output, null, 2));
 if (failed) process.exit(1);

--- a/tools/verify-native-panel-lifecycle.js
+++ b/tools/verify-native-panel-lifecycle.js
@@ -1,18 +1,34 @@
 #!/usr/bin/env node
 "use strict";
 
+const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 
 const DEFAULT_ROOT = path.resolve(__dirname, "..");
-const PANEL_STATE = "review-packets/native-panel/active-v2/panel-review-state.json";
-const FOLLOWUP_METADATA = "review-packets/native-panel/active-v2/followup-draft-v1-metadata.json";
+const ACTIVE_ROOT = "review-packets/native-panel/active-v2";
+const PANEL_STATE = `${ACTIVE_ROOT}/panel-review-state.json`;
+const FOLLOWUP_METADATA = `${ACTIVE_ROOT}/followup-draft-v1-metadata.json`;
+const GENERATED_DIRECTORY = `${ACTIVE_ROOT}/generated`;
+const DEPLOYMENT_DIRECTORY = `${ACTIVE_ROOT}/deployment`;
 
 const PILOT_STATES = new Set(["active", "closed"]);
 const AUDIT_STATES = new Set(["not_started", "in_progress", "accepted"]);
 const FOLLOWUP_STATES = new Set(["draft", "locked", "generated", "deployed"]);
 const RESTRICTED_FOLLOWUP_STATES = new Set(["locked", "generated", "deployed"]);
 const ARTIFACT_STATES = new Set(["draft_source", "generated", "deployed"]);
+const ARTIFACT_ROLES = new Set([
+  "item_source",
+  "crosswalk_source",
+  "response_template_source",
+  "generated_instrument",
+  "deployment_receipt",
+]);
+const SOURCE_ROLES = new Set([
+  "item_source",
+  "crosswalk_source",
+  "response_template_source",
+]);
 const PILOT_COMPATIBILITY = {
   active: "collection_in_progress",
   closed: "collection_closed",
@@ -23,14 +39,67 @@ const FOLLOWUP_COMPATIBILITY = {
   generated: "form_generated",
   deployed: "deployed",
 };
-const FOLLOWUP_RANK = { draft: 0, locked: 1, generated: 2, deployed: 3 };
-const ARTIFACT_RANK = { draft_source: 0, generated: 2, deployed: 3 };
+const SOURCE_ROLE_PATH_FIELDS = {
+  item_source: "item_file",
+  crosswalk_source: "crosswalk_file",
+  response_template_source: "response_template_file",
+};
 
 function readJson(root, relativePath) {
   return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8"));
 }
 
-function validateNativePanelLifecycle(state, metadata) {
+function normalizeRepoPath(value) {
+  return typeof value === "string" ? value.split(path.sep).join("/") : value;
+}
+
+function isWithin(candidate, directory) {
+  return candidate === directory || candidate.startsWith(`${directory}/`);
+}
+
+function walkRegularFiles(root, relativeDirectory) {
+  const absoluteDirectory = path.join(root, relativeDirectory);
+  if (!fs.existsSync(absoluteDirectory)) return [];
+  const files = [];
+  const stack = [absoluteDirectory];
+  while (stack.length) {
+    const current = stack.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const absolutePath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(absolutePath);
+      } else if (entry.isFile() || entry.isSymbolicLink()) {
+        files.push(normalizeRepoPath(path.relative(root, absolutePath)));
+      }
+    }
+  }
+  return files.sort();
+}
+
+function discoverFollowupArtifacts(root, metadata) {
+  const contract = metadata && metadata.artifact_contract;
+  const scopeRoot = contract && contract.scope_root === ACTIVE_ROOT
+    ? contract.scope_root
+    : ACTIVE_ROOT;
+  const trackedPrefix = contract && contract.tracked_prefix === "followup-"
+    ? contract.tracked_prefix
+    : "followup-";
+  const controlFiles = new Set([FOLLOWUP_METADATA]);
+  return walkRegularFiles(root, scopeRoot)
+    .filter((relativePath) => {
+      if (controlFiles.has(relativePath)) return false;
+      if (isWithin(relativePath, GENERATED_DIRECTORY) || isWithin(relativePath, DEPLOYMENT_DIRECTORY)) {
+        return true;
+      }
+      return path.posix.basename(relativePath).startsWith(trackedPrefix);
+    });
+}
+
+function sha256File(absolutePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(absolutePath)).digest("hex");
+}
+
+function validateNativePanelLifecycle(state, metadata, options = {}) {
   const failures = [];
   const canonicalFiles = {
     pilot_and_audit: PANEL_STATE,
@@ -48,22 +117,25 @@ function validateNativePanelLifecycle(state, metadata) {
     });
   };
 
-  if (!state || typeof state !== "object") {
+  if (!state || typeof state !== "object" || Array.isArray(state)) {
     addFailure("panel_state_required", "panel review state must be an object");
     return failures;
   }
-  if (!metadata || typeof metadata !== "object") {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
     addFailure("followup_metadata_required", "follow-up metadata must be an object");
     return failures;
   }
 
   const lifecycle = state.instrument_lifecycle;
-  if (!lifecycle || typeof lifecycle !== "object") {
+  if (!lifecycle || typeof lifecycle !== "object" || Array.isArray(lifecycle)) {
     addFailure("required_lifecycle_fields", "instrument_lifecycle is missing");
     return failures;
   }
   if (lifecycle.metadata_file !== FOLLOWUP_METADATA) {
-    addFailure("canonical_followup_metadata_link", "instrument_lifecycle.metadata_file does not name the canonical follow-up metadata file");
+    addFailure(
+      "canonical_followup_metadata_link",
+      "instrument_lifecycle.metadata_file does not name the canonical follow-up metadata file",
+    );
   }
 
   const pilots = lifecycle.pilot_collections;
@@ -72,7 +144,7 @@ function validateNativePanelLifecycle(state, metadata) {
       "exactly_one_pilot_declaration",
       Array.isArray(pilots)
         ? `found ${pilots.length} pilot declarations`
-        : "pilot_collections must be an array containing exactly one declaration"
+        : "pilot_collections must be an array containing exactly one declaration",
     );
   }
   const pilot = Array.isArray(pilots) && pilots.length === 1 ? pilots[0] : {};
@@ -89,13 +161,25 @@ function validateNativePanelLifecycle(state, metadata) {
   };
 
   if (!PILOT_STATES.has(values.pilot_state)) {
-    addFailure("controlled_pilot_collection_state", `unsupported pilot state ${JSON.stringify(values.pilot_state)}`, values);
+    addFailure(
+      "controlled_pilot_collection_state",
+      `unsupported pilot state ${JSON.stringify(values.pilot_state)}`,
+      values,
+    );
   }
   if (!AUDIT_STATES.has(values.audit_state)) {
-    addFailure("controlled_item_audit_state", `unsupported audit state ${JSON.stringify(values.audit_state)}`, values);
+    addFailure(
+      "controlled_item_audit_state",
+      `unsupported audit state ${JSON.stringify(values.audit_state)}`,
+      values,
+    );
   }
   if (!FOLLOWUP_STATES.has(values.followup_state)) {
-    addFailure("controlled_followup_lifecycle_state", `unsupported follow-up state ${JSON.stringify(values.followup_state)}`, values);
+    addFailure(
+      "controlled_followup_lifecycle_state",
+      `unsupported follow-up state ${JSON.stringify(values.followup_state)}`,
+      values,
+    );
   }
 
   const metadataPilot = metadata.current_live_instrument && typeof metadata.current_live_instrument === "object"
@@ -103,15 +187,29 @@ function validateNativePanelLifecycle(state, metadata) {
     : {};
   for (const field of ["instrument_id", "collection_state", "closure_rule"]) {
     if (pilot[field] !== metadataPilot[field]) {
-      addFailure("single_pilot_declaration_consistency", `pilot ${field} does not match follow-up metadata`, values);
+      addFailure(
+        "single_pilot_declaration_consistency",
+        `pilot ${field} does not match follow-up metadata`,
+        values,
+      );
     }
   }
-  if (pilot.compatibility_status !== PILOT_COMPATIBILITY[values.pilot_state] ||
-      metadataPilot.status !== pilot.compatibility_status) {
-    addFailure("pilot_compatibility_status_consistency", "pilot compatibility status does not match collection state", values);
+  if (
+    pilot.compatibility_status !== PILOT_COMPATIBILITY[values.pilot_state]
+    || metadataPilot.status !== pilot.compatibility_status
+  ) {
+    addFailure(
+      "pilot_compatibility_status_consistency",
+      "pilot compatibility status does not match collection state",
+      values,
+    );
   }
   if (!lifecycle.item_level_audit || audit.pilot_instrument_id !== pilot.instrument_id) {
-    addFailure("item_audit_targets_current_pilot", "item-level audit is missing or targets a different pilot", values);
+    addFailure(
+      "item_audit_targets_current_pilot",
+      "item-level audit is missing or targets a different pilot",
+      values,
+    );
   }
 
   const expectedFollowup = {
@@ -122,11 +220,19 @@ function validateNativePanelLifecycle(state, metadata) {
   };
   for (const field of Object.keys(expectedFollowup)) {
     if (followup[field] !== expectedFollowup[field]) {
-      addFailure("followup_declaration_consistency", `follow-up ${field} does not match canonical metadata`, values);
+      addFailure(
+        "followup_declaration_consistency",
+        `follow-up ${field} does not match canonical metadata`,
+        values,
+      );
     }
   }
   if (followup.compatibility_status !== FOLLOWUP_COMPATIBILITY[values.followup_state]) {
-    addFailure("followup_compatibility_status_consistency", "follow-up compatibility status does not match lifecycle state", values);
+    addFailure(
+      "followup_compatibility_status_consistency",
+      "follow-up compatibility status does not match lifecycle state",
+      values,
+    );
   }
 
   const prerequisitesSatisfied = values.pilot_state === "closed" && values.audit_state === "accepted";
@@ -134,41 +240,133 @@ function validateNativePanelLifecycle(state, metadata) {
     addFailure(
       "followup_deployment_lock",
       "locked, generated, or deployed follow-up requires pilot=closed and audit=accepted",
-      values
+      values,
     );
   }
-  if (values.followup_state === "draft" && followup.deployment_allowed !== false) {
-    addFailure("draft_is_non_deployable", "draft follow-up must set deployment_allowed=false", values);
+
+  const deploymentExpected = values.followup_state === "deployed";
+  if (followup.deployment_allowed !== deploymentExpected || metadata.deployment_allowed !== deploymentExpected) {
+    addFailure(
+      "deployment_permission_matches_lifecycle",
+      "deployment_allowed must be true exactly when lifecycle_state=deployed",
+      values,
+    );
   }
-  if (followup.deployment_allowed === true && !prerequisitesSatisfied) {
-    addFailure("deployment_permission_prerequisites", "deployment_allowed requires pilot=closed and audit=accepted", values);
+
+  const contract = metadata.artifact_contract;
+  const expectedContract = {
+    scope_root: ACTIVE_ROOT,
+    tracked_prefix: "followup-",
+    generated_directory: GENERATED_DIRECTORY,
+    deployment_directory: DEPLOYMENT_DIRECTORY,
+  };
+  if (!contract || typeof contract !== "object" || Array.isArray(contract)) {
+    addFailure("artifact_contract_required", "artifact_contract is missing", values);
+  } else {
+    for (const [field, expected] of Object.entries(expectedContract)) {
+      if (contract[field] !== expected) {
+        addFailure(
+          "canonical_artifact_contract",
+          `artifact_contract.${field} must equal ${expected}`,
+          values,
+        );
+      }
+    }
   }
 
   const artifacts = metadata.tracked_artifacts;
+  const byPath = new Map();
+  const byRole = new Map();
   if (!Array.isArray(artifacts)) {
     addFailure("tracked_artifacts_required", "tracked_artifacts must be an array", values);
   } else {
-    const byPath = new Map();
     for (const artifact of artifacts) {
-      const artifactPath = artifact && artifact.path;
-      const prior = byPath.get(artifactPath) || [];
-      prior.push(artifact);
-      byPath.set(artifactPath, prior);
+      const artifactPath = artifact && normalizeRepoPath(artifact.path);
+      const role = artifact && artifact.role;
+      const priorPath = byPath.get(artifactPath) || [];
+      priorPath.push(artifact);
+      byPath.set(artifactPath, priorPath);
+      const priorRole = byRole.get(role) || [];
+      priorRole.push(artifact);
+      byRole.set(role, priorRole);
 
-      if (!artifact || typeof artifact.path !== "string" || artifact.path.length === 0 ||
-          !ARTIFACT_STATES.has(artifact.artifact_state) || typeof artifact.deployable !== "boolean") {
-        addFailure("valid_tracked_artifact", "artifact requires path, controlled artifact_state, and deployable boolean", values, artifact || {});
+      if (
+        !artifact
+        || typeof artifactPath !== "string"
+        || artifactPath.length === 0
+        || !ARTIFACT_ROLES.has(role)
+        || !ARTIFACT_STATES.has(artifact.artifact_state)
+        || typeof artifact.deployable !== "boolean"
+      ) {
+        addFailure(
+          "valid_tracked_artifact",
+          "artifact requires path, controlled role, controlled artifact_state, and deployable boolean",
+          values,
+          artifact || {},
+        );
         continue;
       }
-      if (FOLLOWUP_RANK[values.followup_state] !== undefined &&
-          ARTIFACT_RANK[artifact.artifact_state] > FOLLOWUP_RANK[values.followup_state]) {
-        addFailure("artifact_state_not_ahead_of_lifecycle", "tracked artifact state is ahead of follow-up lifecycle", values, artifact);
-      }
-      if (values.followup_state === "draft" && artifact.deployable) {
-        addFailure("draft_has_no_generated_or_deployable_artifact", "draft lifecycle cannot contain a deployable artifact", values, artifact);
-      }
-      if (artifact.deployable && !prerequisitesSatisfied) {
-        addFailure("deployable_artifact_prerequisites", "deployable artifact requires pilot=closed and audit=accepted", values, artifact);
+
+      if (SOURCE_ROLES.has(role)) {
+        const expectedPath = metadata[SOURCE_ROLE_PATH_FIELDS[role]];
+        if (artifactPath !== expectedPath) {
+          addFailure(
+            "source_role_binds_canonical_path",
+            `${role} must bind ${expectedPath}`,
+            values,
+            artifact,
+          );
+        }
+        if (artifact.artifact_state !== "draft_source" || artifact.deployable !== false) {
+          addFailure(
+            "source_role_cannot_supply_generated_or_deployed_evidence",
+            `${role} must remain non-deployable draft_source evidence`,
+            values,
+            artifact,
+          );
+        }
+      } else if (role === "generated_instrument") {
+        if (!isWithin(artifactPath, GENERATED_DIRECTORY)) {
+          addFailure(
+            "generated_instrument_uses_canonical_directory",
+            `generated instrument must be under ${GENERATED_DIRECTORY}`,
+            values,
+            artifact,
+          );
+        }
+        if (!["generated", "deployed"].includes(artifact.artifact_state)) {
+          addFailure(
+            "generated_instrument_has_generated_state",
+            "generated instrument must have generated or deployed artifact_state",
+            values,
+            artifact,
+          );
+        }
+        if (artifact.deployable !== deploymentExpected) {
+          addFailure(
+            "generated_instrument_deployability_matches_lifecycle",
+            "generated instrument is deployable exactly in deployed lifecycle",
+            values,
+            artifact,
+          );
+        }
+      } else if (role === "deployment_receipt") {
+        if (!isWithin(artifactPath, DEPLOYMENT_DIRECTORY)) {
+          addFailure(
+            "deployment_receipt_uses_canonical_directory",
+            `deployment receipt must be under ${DEPLOYMENT_DIRECTORY}`,
+            values,
+            artifact,
+          );
+        }
+        if (artifact.artifact_state !== "deployed" || artifact.deployable !== false) {
+          addFailure(
+            "deployment_receipt_has_deployed_evidence_state",
+            "deployment receipt must be non-deployable deployed evidence",
+            values,
+            artifact,
+          );
+        }
       }
     }
 
@@ -178,22 +376,77 @@ function validateNativePanelLifecycle(state, metadata) {
           "unique_tracked_artifact_declaration",
           `${artifactPath || "<missing path>"} has ${declarations.length} declarations`,
           values,
-          { path: artifactPath || null }
+          { path: artifactPath || null },
         );
       }
     }
-    for (const requiredPath of [metadata.item_file, metadata.crosswalk_file, metadata.response_template_file]) {
-      if (typeof requiredPath !== "string" || (byPath.get(requiredPath) || []).length !== 1) {
-        addFailure("all_followup_sources_are_tracked", "required follow-up source lacks exactly one tracked-artifact declaration", values, { path: requiredPath || null });
+
+    for (const role of SOURCE_ROLES) {
+      if ((byRole.get(role) || []).length !== 1) {
+        addFailure(
+          "exactly_one_source_artifact_per_role",
+          `${role} requires exactly one tracked artifact`,
+          values,
+          { role },
+        );
       }
     }
-    if (values.followup_state === "generated" &&
-        !artifacts.some((artifact) => artifact && ["generated", "deployed"].includes(artifact.artifact_state))) {
-      addFailure("generated_state_has_generated_artifact", "generated lifecycle has no generated artifact", values);
+
+    const generatedArtifacts = byRole.get("generated_instrument") || [];
+    const deploymentReceipts = byRole.get("deployment_receipt") || [];
+    if (["draft", "locked"].includes(values.followup_state)) {
+      if (generatedArtifacts.length || deploymentReceipts.length) {
+        addFailure(
+          "pre_generation_lifecycle_has_no_generated_or_deployment_artifacts",
+          "draft and locked lifecycle states cannot contain generated instruments or deployment receipts",
+          values,
+        );
+      }
+    } else if (values.followup_state === "generated") {
+      if (generatedArtifacts.length < 1 || deploymentReceipts.length !== 0) {
+        addFailure(
+          "generated_lifecycle_evidence",
+          "generated lifecycle requires a generated instrument and no deployment receipt",
+          values,
+        );
+      }
+    } else if (values.followup_state === "deployed") {
+      if (generatedArtifacts.length < 1 || deploymentReceipts.length < 1) {
+        addFailure(
+          "deployed_lifecycle_evidence",
+          "deployed lifecycle requires both a deployed generated instrument and a deployment receipt",
+          values,
+        );
+      }
     }
-    if (values.followup_state === "deployed" &&
-        !artifacts.some((artifact) => artifact && artifact.artifact_state === "deployed")) {
-      addFailure("deployed_state_has_deployed_artifact", "deployed lifecycle has no deployed artifact", values);
+  }
+
+  if (Array.isArray(options.discovered_artifacts) && Array.isArray(artifacts)) {
+    const trackedPaths = new Set(
+      artifacts
+        .filter((artifact) => artifact && typeof artifact.path === "string")
+        .map((artifact) => normalizeRepoPath(artifact.path)),
+    );
+    const discovered = new Set(options.discovered_artifacts.map(normalizeRepoPath));
+    for (const artifactPath of discovered) {
+      if (!trackedPaths.has(artifactPath)) {
+        addFailure(
+          "untracked_followup_artifact",
+          `follow-up namespace contains an untracked artifact: ${artifactPath}`,
+          values,
+          { path: artifactPath },
+        );
+      }
+    }
+    for (const artifactPath of trackedPaths) {
+      if (!discovered.has(artifactPath)) {
+        addFailure(
+          "tracked_artifact_exists",
+          `tracked artifact does not exist in the follow-up namespace: ${artifactPath}`,
+          values,
+          { path: artifactPath },
+        );
+      }
     }
   }
 
@@ -203,7 +456,8 @@ function validateNativePanelLifecycle(state, metadata) {
 function verifyNativePanelLifecycle(root = DEFAULT_ROOT) {
   const state = readJson(root, PANEL_STATE);
   const metadata = readJson(root, FOLLOWUP_METADATA);
-  const failures = validateNativePanelLifecycle(state, metadata);
+  const discoveredArtifacts = discoverFollowupArtifacts(root, metadata);
+  const failures = validateNativePanelLifecycle(state, metadata, { discovered_artifacts: discoveredArtifacts });
   const lifecycle = state.instrument_lifecycle || {};
   const pilot = Array.isArray(lifecycle.pilot_collections) && lifecycle.pilot_collections.length === 1
     ? lifecycle.pilot_collections[0]
@@ -211,10 +465,15 @@ function verifyNativePanelLifecycle(root = DEFAULT_ROOT) {
   const audit = lifecycle.item_level_audit || {};
   const followup = lifecycle.followup_instrument || {};
 
+  const artifactDigests = [];
   for (const artifact of metadata.tracked_artifacts || []) {
-    if (!artifact.path || !fs.existsSync(path.join(root, artifact.path))) {
+    if (!artifact || typeof artifact.path !== "string") continue;
+    const absolutePath = path.join(root, artifact.path);
+    if (!fs.existsSync(absolutePath)) continue;
+    const stat = fs.lstatSync(absolutePath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
       failures.push({
-        invariant: "tracked_artifact_exists",
+        invariant: "tracked_artifact_is_regular_file",
         pilot_state: pilot.collection_state ?? null,
         audit_state: audit.state ?? null,
         followup_state: followup.lifecycle_state ?? null,
@@ -223,18 +482,26 @@ function verifyNativePanelLifecycle(root = DEFAULT_ROOT) {
           pilot_and_audit: PANEL_STATE,
           followup_and_artifacts: FOLLOWUP_METADATA,
         },
-        detail: `tracked artifact does not exist: ${artifact.path || "<missing path>"}`,
+        detail: `tracked artifact must be a regular non-symlink file: ${artifact.path}`,
       });
+      continue;
     }
+    artifactDigests.push({
+      path: artifact.path,
+      role: artifact.role,
+      sha256: sha256File(absolutePath),
+    });
   }
 
   return {
-    schema: "canto-span-native-panel-lifecycle-verification-v1",
+    schema: "canto-span-native-panel-lifecycle-verification-v2",
     pilot_state: pilot.collection_state ?? null,
     audit_state: audit.state ?? null,
     followup_state: followup.lifecycle_state ?? null,
     deployment_allowed: followup.deployment_allowed ?? null,
     tracked_artifacts: Array.isArray(metadata.tracked_artifacts) ? metadata.tracked_artifacts.length : null,
+    discovered_artifacts: discoveredArtifacts.length,
+    artifact_digests: artifactDigests,
     failed: failures.length,
     status: failures.length === 0 ? "PASS" : "FAIL",
     failures,
@@ -248,8 +515,12 @@ if (require.main === module) {
 }
 
 module.exports = {
+  ACTIVE_ROOT,
   PANEL_STATE,
   FOLLOWUP_METADATA,
+  GENERATED_DIRECTORY,
+  DEPLOYMENT_DIRECTORY,
+  discoverFollowupArtifacts,
   validateNativePanelLifecycle,
   verifyNativePanelLifecycle,
 };

--- a/tools/verify-native-panel-lifecycle.js
+++ b/tools/verify-native-panel-lifecycle.js
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const DEFAULT_ROOT = path.resolve(__dirname, "..");
+const PANEL_STATE = "review-packets/native-panel/active-v2/panel-review-state.json";
+const FOLLOWUP_METADATA = "review-packets/native-panel/active-v2/followup-draft-v1-metadata.json";
+
+const PILOT_STATES = new Set(["active", "closed"]);
+const AUDIT_STATES = new Set(["not_started", "in_progress", "accepted"]);
+const FOLLOWUP_STATES = new Set(["draft", "locked", "generated", "deployed"]);
+const RESTRICTED_FOLLOWUP_STATES = new Set(["locked", "generated", "deployed"]);
+const ARTIFACT_STATES = new Set(["draft_source", "generated", "deployed"]);
+const PILOT_COMPATIBILITY = {
+  active: "collection_in_progress",
+  closed: "collection_closed",
+};
+const FOLLOWUP_COMPATIBILITY = {
+  draft: "draft_followup",
+  locked: "instrument_locked",
+  generated: "form_generated",
+  deployed: "deployed",
+};
+const FOLLOWUP_RANK = { draft: 0, locked: 1, generated: 2, deployed: 3 };
+const ARTIFACT_RANK = { draft_source: 0, generated: 2, deployed: 3 };
+
+function readJson(root, relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8"));
+}
+
+function validateNativePanelLifecycle(state, metadata) {
+  const failures = [];
+  const canonicalFiles = {
+    pilot_and_audit: PANEL_STATE,
+    followup_and_artifacts: FOLLOWUP_METADATA,
+  };
+  const addFailure = (invariant, detail, values = {}, artifact = null) => {
+    failures.push({
+      invariant,
+      pilot_state: values.pilot_state ?? null,
+      audit_state: values.audit_state ?? null,
+      followup_state: values.followup_state ?? null,
+      ...(artifact ? { artifact } : {}),
+      canonical_files: canonicalFiles,
+      detail,
+    });
+  };
+
+  if (!state || typeof state !== "object") {
+    addFailure("panel_state_required", "panel review state must be an object");
+    return failures;
+  }
+  if (!metadata || typeof metadata !== "object") {
+    addFailure("followup_metadata_required", "follow-up metadata must be an object");
+    return failures;
+  }
+
+  const lifecycle = state.instrument_lifecycle;
+  if (!lifecycle || typeof lifecycle !== "object") {
+    addFailure("required_lifecycle_fields", "instrument_lifecycle is missing");
+    return failures;
+  }
+  if (lifecycle.metadata_file !== FOLLOWUP_METADATA) {
+    addFailure("canonical_followup_metadata_link", "instrument_lifecycle.metadata_file does not name the canonical follow-up metadata file");
+  }
+
+  const pilots = lifecycle.pilot_collections;
+  if (!Array.isArray(pilots) || pilots.length !== 1) {
+    addFailure(
+      "exactly_one_pilot_declaration",
+      Array.isArray(pilots)
+        ? `found ${pilots.length} pilot declarations`
+        : "pilot_collections must be an array containing exactly one declaration"
+    );
+  }
+  const pilot = Array.isArray(pilots) && pilots.length === 1 ? pilots[0] : {};
+  const audit = lifecycle.item_level_audit && typeof lifecycle.item_level_audit === "object"
+    ? lifecycle.item_level_audit
+    : {};
+  const followup = lifecycle.followup_instrument && typeof lifecycle.followup_instrument === "object"
+    ? lifecycle.followup_instrument
+    : {};
+  const values = {
+    pilot_state: pilot.collection_state,
+    audit_state: audit.state,
+    followup_state: followup.lifecycle_state,
+  };
+
+  if (!PILOT_STATES.has(values.pilot_state)) {
+    addFailure("controlled_pilot_collection_state", `unsupported pilot state ${JSON.stringify(values.pilot_state)}`, values);
+  }
+  if (!AUDIT_STATES.has(values.audit_state)) {
+    addFailure("controlled_item_audit_state", `unsupported audit state ${JSON.stringify(values.audit_state)}`, values);
+  }
+  if (!FOLLOWUP_STATES.has(values.followup_state)) {
+    addFailure("controlled_followup_lifecycle_state", `unsupported follow-up state ${JSON.stringify(values.followup_state)}`, values);
+  }
+
+  const metadataPilot = metadata.current_live_instrument && typeof metadata.current_live_instrument === "object"
+    ? metadata.current_live_instrument
+    : {};
+  for (const field of ["instrument_id", "collection_state", "closure_rule"]) {
+    if (pilot[field] !== metadataPilot[field]) {
+      addFailure("single_pilot_declaration_consistency", `pilot ${field} does not match follow-up metadata`, values);
+    }
+  }
+  if (pilot.compatibility_status !== PILOT_COMPATIBILITY[values.pilot_state] ||
+      metadataPilot.status !== pilot.compatibility_status) {
+    addFailure("pilot_compatibility_status_consistency", "pilot compatibility status does not match collection state", values);
+  }
+  if (!lifecycle.item_level_audit || audit.pilot_instrument_id !== pilot.instrument_id) {
+    addFailure("item_audit_targets_current_pilot", "item-level audit is missing or targets a different pilot", values);
+  }
+
+  const expectedFollowup = {
+    instrument_id: metadata.instrument_id,
+    lifecycle_state: metadata.lifecycle_state,
+    compatibility_status: metadata.instrument_status,
+    deployment_allowed: metadata.deployment_allowed,
+  };
+  for (const field of Object.keys(expectedFollowup)) {
+    if (followup[field] !== expectedFollowup[field]) {
+      addFailure("followup_declaration_consistency", `follow-up ${field} does not match canonical metadata`, values);
+    }
+  }
+  if (followup.compatibility_status !== FOLLOWUP_COMPATIBILITY[values.followup_state]) {
+    addFailure("followup_compatibility_status_consistency", "follow-up compatibility status does not match lifecycle state", values);
+  }
+
+  const prerequisitesSatisfied = values.pilot_state === "closed" && values.audit_state === "accepted";
+  if (RESTRICTED_FOLLOWUP_STATES.has(values.followup_state) && !prerequisitesSatisfied) {
+    addFailure(
+      "followup_deployment_lock",
+      "locked, generated, or deployed follow-up requires pilot=closed and audit=accepted",
+      values
+    );
+  }
+  if (values.followup_state === "draft" && followup.deployment_allowed !== false) {
+    addFailure("draft_is_non_deployable", "draft follow-up must set deployment_allowed=false", values);
+  }
+  if (followup.deployment_allowed === true && !prerequisitesSatisfied) {
+    addFailure("deployment_permission_prerequisites", "deployment_allowed requires pilot=closed and audit=accepted", values);
+  }
+
+  const artifacts = metadata.tracked_artifacts;
+  if (!Array.isArray(artifacts)) {
+    addFailure("tracked_artifacts_required", "tracked_artifacts must be an array", values);
+  } else {
+    const byPath = new Map();
+    for (const artifact of artifacts) {
+      const artifactPath = artifact && artifact.path;
+      const prior = byPath.get(artifactPath) || [];
+      prior.push(artifact);
+      byPath.set(artifactPath, prior);
+
+      if (!artifact || typeof artifact.path !== "string" || artifact.path.length === 0 ||
+          !ARTIFACT_STATES.has(artifact.artifact_state) || typeof artifact.deployable !== "boolean") {
+        addFailure("valid_tracked_artifact", "artifact requires path, controlled artifact_state, and deployable boolean", values, artifact || {});
+        continue;
+      }
+      if (FOLLOWUP_RANK[values.followup_state] !== undefined &&
+          ARTIFACT_RANK[artifact.artifact_state] > FOLLOWUP_RANK[values.followup_state]) {
+        addFailure("artifact_state_not_ahead_of_lifecycle", "tracked artifact state is ahead of follow-up lifecycle", values, artifact);
+      }
+      if (values.followup_state === "draft" && artifact.deployable) {
+        addFailure("draft_has_no_generated_or_deployable_artifact", "draft lifecycle cannot contain a deployable artifact", values, artifact);
+      }
+      if (artifact.deployable && !prerequisitesSatisfied) {
+        addFailure("deployable_artifact_prerequisites", "deployable artifact requires pilot=closed and audit=accepted", values, artifact);
+      }
+    }
+
+    for (const [artifactPath, declarations] of byPath) {
+      if (!artifactPath || declarations.length !== 1) {
+        addFailure(
+          "unique_tracked_artifact_declaration",
+          `${artifactPath || "<missing path>"} has ${declarations.length} declarations`,
+          values,
+          { path: artifactPath || null }
+        );
+      }
+    }
+    for (const requiredPath of [metadata.item_file, metadata.crosswalk_file, metadata.response_template_file]) {
+      if (typeof requiredPath !== "string" || (byPath.get(requiredPath) || []).length !== 1) {
+        addFailure("all_followup_sources_are_tracked", "required follow-up source lacks exactly one tracked-artifact declaration", values, { path: requiredPath || null });
+      }
+    }
+    if (values.followup_state === "generated" &&
+        !artifacts.some((artifact) => artifact && ["generated", "deployed"].includes(artifact.artifact_state))) {
+      addFailure("generated_state_has_generated_artifact", "generated lifecycle has no generated artifact", values);
+    }
+    if (values.followup_state === "deployed" &&
+        !artifacts.some((artifact) => artifact && artifact.artifact_state === "deployed")) {
+      addFailure("deployed_state_has_deployed_artifact", "deployed lifecycle has no deployed artifact", values);
+    }
+  }
+
+  return failures;
+}
+
+function verifyNativePanelLifecycle(root = DEFAULT_ROOT) {
+  const state = readJson(root, PANEL_STATE);
+  const metadata = readJson(root, FOLLOWUP_METADATA);
+  const failures = validateNativePanelLifecycle(state, metadata);
+  const lifecycle = state.instrument_lifecycle || {};
+  const pilot = Array.isArray(lifecycle.pilot_collections) && lifecycle.pilot_collections.length === 1
+    ? lifecycle.pilot_collections[0]
+    : {};
+  const audit = lifecycle.item_level_audit || {};
+  const followup = lifecycle.followup_instrument || {};
+
+  for (const artifact of metadata.tracked_artifacts || []) {
+    if (!artifact.path || !fs.existsSync(path.join(root, artifact.path))) {
+      failures.push({
+        invariant: "tracked_artifact_exists",
+        pilot_state: pilot.collection_state ?? null,
+        audit_state: audit.state ?? null,
+        followup_state: followup.lifecycle_state ?? null,
+        artifact,
+        canonical_files: {
+          pilot_and_audit: PANEL_STATE,
+          followup_and_artifacts: FOLLOWUP_METADATA,
+        },
+        detail: `tracked artifact does not exist: ${artifact.path || "<missing path>"}`,
+      });
+    }
+  }
+
+  return {
+    schema: "canto-span-native-panel-lifecycle-verification-v1",
+    pilot_state: pilot.collection_state ?? null,
+    audit_state: audit.state ?? null,
+    followup_state: followup.lifecycle_state ?? null,
+    deployment_allowed: followup.deployment_allowed ?? null,
+    tracked_artifacts: Array.isArray(metadata.tracked_artifacts) ? metadata.tracked_artifacts.length : null,
+    failed: failures.length,
+    status: failures.length === 0 ? "PASS" : "FAIL",
+    failures,
+  };
+}
+
+if (require.main === module) {
+  const result = verifyNativePanelLifecycle();
+  console.log(JSON.stringify(result, null, 2));
+  if (result.status !== "PASS") process.exit(1);
+}
+
+module.exports = {
+  PANEL_STATE,
+  FOLLOWUP_METADATA,
+  validateNativePanelLifecycle,
+  verifyNativePanelLifecycle,
+};


### PR DESCRIPTION
Parent issue: #43
Repair program: #460
Work claim: #463
Supersedes accidentally auto-closed unmerged PR #464
Dependency: #462 at reviewed head `60083fcb98397bb03a37b15f18499bb18691ad84`
Active worker: chatgpt
Ownership revision: 3

## Work in progress

Rebuilds the native-panel lifecycle lock on the repaired #462 verification contract and closes the artifact-enforcement blockers found during review of #464:

- closed follow-up artifact namespace;
- role-bound source, generated-instrument, and deployment-receipt evidence;
- exact deployment-permission/lifecycle equivalence;
- mutation coverage for untracked artifacts, source-file relabelling, missing role evidence, duplicate roles, and deployed-with-permission-false.

Current canonical state remains `active / not_started / draft / deployment_allowed=false`. No participant, survey, parser, evidence, status, release, deployment, or merge state is authorized to change.

Do not merge without explicit user approval after exact-head review.