### PR TITLE
Resolve #412 resultative and lexical change profiles

### DIFF
--- a/docs/research/ISSUE-412-RESULT-CHANGE-PROFILES-R1.md
+++ b/docs/research/ISSUE-412-RESULT-CHANGE-PROFILES-R1.md
@@ -1,0 +1,127 @@
+# ISSUE-412 resultative and lexical change-profile disposition R1
+
+Parent issue: #412  
+Work claim: #551  
+Date: 2026-08-04
+
+## Decision
+
+Retain Cantonese resultative and lexical change predication as a real research area, but do not restore retired broad wrappers and do not allocate a new universal result/change identity from this issue.
+
+The reviewed evidence supports resultative verb compounds and `V到` / `V-dou3`-type resultative behavior as genuine Cantonese research targets. It also supports treating lexical change profiles such as `變成`, `變做`, property/state + `咗`, and weather cessation as separate packets rather than one universal result node.
+
+This packet resolves #412 by preserving the five requested packet families and recording the current terminal state as evidence-blocked / no runtime action.
+
+## Assumption-level research review
+
+### Assumption A — Cantonese has resultative verb-compound / result-complement behavior
+
+Supported.
+
+A dedicated article, “On Resultative Verb Compounds in Cantonese and Mandarin,” directly treats Cantonese resultative verb compounds and compares Cantonese `V-dou3` with Mandarin `V-de`. Cantonese learning and dictionary materials also describe result complements such as `到` and potential/result patterns.
+
+### Assumption B — resultative evidence justifies restoring retired broad wrappers
+
+Not supported.
+
+The issue’s accepted synthesis already rejected restoration of retired exact wrappers. Resultative evidence is real, but it does not justify one broad reusable node covering causative-resultative, `變成`, `變 + aspect + 做`, state/property + `咗`, and weather cessation all at once.
+
+### Assumption C — lexical change profiles are the same as resultative compounds
+
+Not supported.
+
+`變成`, `變做`, and `成為` are lexical/change-predicate families with complement restrictions and register differences. They may interact with result or aspect, but they are not automatically the same construction as causative-resultative compounds or `V到`.
+
+### Assumption D — implementation can begin from the present issue
+
+Not supported.
+
+The issue itself requires five bounded packets, each classifying genuine, false-positive, ambiguous, and unusable outcomes. Those packets are prerequisites, not optional refinements.
+
+## Packet dispositions
+
+### Packet 1 — causative-resultative inventory
+
+Disposition: source-supported research family, not implementation-ready.
+
+Required future evidence:
+
+- `整/搞 + result`;
+- canonical M–R pairs;
+- potential forms;
+- affected-nominal placement;
+- `V到` and `搞到` competitors;
+- argument orientation and lexical compatibility.
+
+### Packet 2 — `變成` complements
+
+Disposition: retained as a separate lexical change-predicate packet.
+
+Required future evidence:
+
+- nominal complements;
+- property complements;
+- wh complements;
+- malformed or marginal complements;
+- contrast with `變做` and `成為`.
+
+### Packet 3 — `變 + aspect + 做`
+
+Disposition: retained as a separate change-predicate / aspect-interaction packet.
+
+Required future evidence:
+
+- `變咗做` and related forms;
+- comparison with `變做`, `變成`, and `成為`;
+- aspect placement and complement type;
+- register and lexical restrictions.
+
+### Packet 4 — state/property + `咗`
+
+Disposition: retained as a separate property/state change packet.
+
+Required future evidence:
+
+- property predicate + `咗`;
+- state predicate + `咗`;
+- contrast with resultative verb compound + `咗`;
+- sentence-final versus verbal aspect scope.
+
+### Packet 5 — weather cessation
+
+Disposition: retained as a separate lexical/event-structure packet.
+
+Required future evidence:
+
+- `場雨停咗`;
+- `停雨`;
+- `停咗雨`;
+- subject/event alternation;
+- lexicalized weather event boundaries.
+
+## Terminal disposition
+
+- Resultative verb-compound / result-complement behavior: source-supported research area.
+- Universal result/change identity: no, not from this issue.
+- Retired broad wrapper restoration: no.
+- New UUID: no.
+- Runtime change: no.
+- Status promotion: no.
+- Current terminal state: five retained non-runtime evidence packets / no runtime action.
+
+## Future work retained
+
+Do not open runtime issues yet. Future ready work should be opened as one packet at a time, beginning only when each packet has a bounded corpus/contrast design and clear negative controls.
+
+The highest-value first packet is likely the causative-resultative inventory because direct Cantonese resultative-complement literature exists and the family intersects many retired-wrapper records. However, it still needs a corpus inventory and lexical-compatibility matrix before implementation.
+
+## Protected-state disposition
+
+This packet changes no runtime behavior, parser matcher, construction identity, linguistic status, source record, survey state, release state, or deployment state, and it does not restore any retired UUID.
+
+## Source pointers
+
+- PolyU, “On Resultative Verb Compounds in Cantonese and Mandarin”: `https://research.polyu.edu.hk/en/publications/on-resultative-verb-compounds-in-cantonese-and-mandarin/`
+- Lingua Sinica article page: `https://reference-global.com/article/10.2478/linguasinica-2021-0002`
+- ResearchGate copy: `https://www.researchgate.net/publication/358097432_On_Resultative_Verb_Compounds_in_Cantonese_and_Mandarin`
+- YumCha, Cantonese potential complements: `https://www.yumcha.fun/grammar/potential-complements`


### PR DESCRIPTION
# Summary

Resolves #412 with a bounded research disposition for resultative and lexical change profiles.

## Result

- Retains Cantonese resultative verb-compound / result-complement behavior as a real research area.
- Preserves five separate non-runtime evidence packets: causative-resultative inventory, `變成`, `變 + aspect + 做`, state/property + `咗`, and weather cessation.
- Rejects one universal result/change identity and retired broad-wrapper restoration from this issue.
- Routes later work to one bounded evidence packet at a time before any runtime/identity claim.

## Protected state

No retired UUID restoration, runtime, parser, source, identity, status, survey, release, or deployment changes.

Closes #551 after merge. Closes #412 after merge if rereview confirms the assumptions.