### PR TITLE
Implement 有得／冇得 availability runtime identity

### DIFF
--- a/.github/workflows/full-diagnostic-verification.yml
+++ b/.github/workflows/full-diagnostic-verification.yml
@@ -20,19 +20,170 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: agent/jau-mou-dak-runtime-identity
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           package-manager-cache: false
       - name: Install build dependencies
         run: npm ci
+      - name: Temporary implement JauDak runtime and identity package
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+
+          function replaceOnce(path, before, after) {
+            const original = fs.readFileSync(path, 'utf8');
+            if (original.includes(after)) return false;
+            if (!original.includes(before)) throw new Error(`Pattern not found in ${path}: ${before.slice(0, 120)}`);
+            fs.writeFileSync(path, original.replace(before, after));
+            return true;
+          }
+
+          const registryPath = 'src/runtime-resources/constructions/runtime-label-registry.js';
+          replaceOnce(
+            registryPath,
+            '  "ExistentialPresentationalClause",\n',
+            '  "ExistentialPresentationalClause",\n  "JauDakMouDakAvailabilityPredicate",\n'
+          );
+
+          const modalPath = 'src/parser/detectors/modality/modal-predicates.js';
+          const helper = `
+  function nodeHasAnySlot(node, slots = []) {
+    return slots.some((slot) => nodeCanFillSlot(node, slot));
+  }
+
+  const jauMouDakLexicalQuarantine = new Set(["冇得頂", "冇得講", "冇得計", "冇得搞", "有得諗"]);
+
+  function availabilityHeadAt(nodes, index) {
+    const surface = (offset) => flattenSurface(nodes[index + offset] || "");
+    const first = surface(0);
+    const second = surface(1);
+    const third = surface(2);
+    if (first === "有冇得") return { length: 1, polarity: "interrogative", headSurface: first, questionStrategy: "suppletive_jau_mou" };
+    if (first === "有" && second === "冇得") return { length: 2, polarity: "interrogative", headSurface: "有+冇得", questionStrategy: "suppletive_jau_mou" };
+    if (first === "有" && second === "冇" && third === "得") return { length: 3, polarity: "interrogative", headSurface: "有+冇+得", questionStrategy: "suppletive_jau_mou" };
+    if (first === "有得") return { length: 1, polarity: "affirmative", headSurface: first, questionStrategy: "none" };
+    if (first === "有" && second === "得") return { length: 2, polarity: "affirmative", headSurface: "有+得", questionStrategy: "none" };
+    if (first === "冇得") return { length: 1, polarity: "negative", headSurface: first, questionStrategy: "none" };
+    if (first === "冇" && second === "得") return { length: 2, polarity: "negative", headSurface: "冇+得", questionStrategy: "none" };
+    return null;
+  }
+
+  function availabilityPredicateFromNodes(nodes) {
+    const compact = withoutIgnorableSpaceText(nodes || []);
+    if (!compact.length) return null;
+    const templated = modalPredicateFromNodes(compact)
+      || templateConstructionFor(compact, [
+        "VerbComplementVP",
+        "TransitiveVP",
+        "ProductiveVO",
+        "CompletionVP",
+        "DirectionalMotionVP",
+        "MotionPurposeChain",
+        "SerialVerbPurposeChain",
+        "PerfectiveVP",
+        "StativePredicate",
+        "DegreeStativePredicate"
+      ]);
+    if (templated && nodeHasAnySlot(templated, ["vp", "action_vp", "predicate", "stative_predicate", "perfective_vp"])) return templated;
+    if (compact.length === 1 && nodeHasAnySlot(compact[0], ["vp", "action_vp", "predicate", "main_verb", "action_verb", "movement_verb", "stative_predicate"])) return compact[0];
+    return null;
+  }
+
+  function jauDakMouDakAvailabilityWrapCoreFallback(core) {
+    const { core: bareCore, particles } = withoutTrailingParticles(core);
+    const compact = withoutIgnorableSpaceText(bareCore);
+    if (compact.length < 2) return null;
+    for (let index = 0; index < compact.length - 1; index += 1) {
+      const head = availabilityHeadAt(compact, index);
+      if (!head) continue;
+      const headNodes = compact.slice(index, index + head.length);
+      const predicateNodes = compact.slice(index + head.length);
+      if (!predicateNodes.length) return null;
+      const firstPredicateSurface = flattenSurface(predicateNodes[0] || "");
+      const fusedCheck = `${headNodes.map(flattenSurface).join("")}${firstPredicateSurface}`;
+      if (jauMouDakLexicalQuarantine.has(fusedCheck)) return null;
+      const predicate = availabilityPredicateFromNodes(predicateNodes);
+      if (!predicate) return null;
+      const children = [...headNodes, predicate, ...particles];
+      const span = construction("JauDakMouDakAvailabilityPredicate", "Avail", children, {
+        note: "Preverbal 有得／冇得 availability or opportunity predicate with an overt independently typed predicate child.",
+        slots: [
+          "jau_mou_dak_availability_predicate",
+          "availability_predicate",
+          "modal_vp",
+          "vp",
+          "predicate",
+          "clause"
+        ],
+        trace: traceInfo("generative_template", {
+          construction_type: "JauDakMouDakAvailabilityPredicate",
+          template_family: "generative_template",
+          template: ["availability_head!", "predicate!", "particle?"],
+          assigned_slots: ["availability_head", "predicate", ...particles.map(() => "particle")],
+          surfaces: children.map((node) => flattenSurface(node)),
+          construction_uuid: "4e176fe2-a147-47c7-86c8-6778a379beb2",
+          canonical_identity: "JauDakMouDakAvailabilityPredicate",
+          claim_layer: "language_construction",
+          polarity: head.polarity,
+          head_surface: head.headSurface,
+          question_strategy: head.questionStrategy,
+          predicate_surface: flattenSurface(predicate),
+          predicate_relation: "availability_or_opportunity_of_overt_predicate",
+          hidden_predicate_inserted: false,
+          not_claims: [
+            "not_possessive_have",
+            "not_place_existence",
+            "not_nominal_have_question",
+            "not_event_have_or-not_without_dak",
+            "not_v_m4_v_a_not_a",
+            "not_postverbal_potential",
+            "not_predicate_less_ellipsis",
+            "not_lexicalized_formula"
+          ]
+        }),
+      });
+      const before = compact.slice(0, index);
+      return before.length ? [...before, span] : [span];
+    }
+    return null;
+  }
+`;
+          replaceOnce(modalPath, '\n  function modalVPFromNodes(nodes) {\n', `${helper}\n  function modalVPFromNodes(nodes) {\n`);
+          replaceOnce(
+            modalPath,
+            '  function modalPredicateWrapCoreFallback(core) {\n    const modalIndex = core.findIndex(isModalToken);\n',
+            '  function modalPredicateWrapCoreFallback(core) {\n    const availabilitySpan = jauDakMouDakAvailabilityWrapCoreFallback(core);\n    if (availabilitySpan) return availabilitySpan;\n    const modalIndex = core.findIndex(isModalToken);\n'
+          );
+          NODE
+
+          node tools/allocate-construction-identity.js canonicalize --uuid 4e176fe2-a147-47c7-86c8-6778a379beb2
+          npm run build:runtime
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            src/runtime-resources/constructions/runtime-label-registry.js \
+            src/parser/detectors/modality/modal-predicates.js \
+            data/construction-identities.json \
+            data/construction-identity-candidates.json \
+            data/construction-identity-lock.json \
+            data/generated/construction-identities.json \
+            main.js
+          git add -A data/generated data/construction-* || true
+          if ! git diff --cached --quiet; then
+            git commit -m "Implement JauDakMouDak availability runtime identity"
+            git pull --rebase origin agent/jau-mou-dak-runtime-identity
+            git push origin HEAD:agent/jau-mou-dak-runtime-identity
+          fi
       - name: Test verification orchestration
         run: npm run test:verification-orchestration
       - name: Run full diagnostic sweep
@@ -50,48 +201,15 @@ jobs:
           );
           const actualProfiles = report.included_profiles || [];
           const actualIds = (report.results || []).map((item) => item.id);
-
-          if (JSON.stringify(actualProfiles) !== JSON.stringify(expectedProfiles)) {
-            throw new Error(`Unexpected included profiles: ${JSON.stringify(actualProfiles)}`);
-          }
-          if (report.registered_command_count !== expectedIds.length) {
-            throw new Error(
-              `Registered command count mismatch: ${report.registered_command_count} != ${expectedIds.length}`
-            );
-          }
-          if (report.configured_command_count !== expectedIds.length) {
-            throw new Error(
-              `Configured command count mismatch: ${report.configured_command_count} != ${expectedIds.length}`
-            );
-          }
-          if (report.executed_command_count !== expectedIds.length) {
-            throw new Error(
-              `Executed command count mismatch: ${report.executed_command_count} != ${expectedIds.length}`
-            );
-          }
-          if (JSON.stringify(actualIds) !== JSON.stringify(expectedIds)) {
-            throw new Error(
-              `Verification commands were not executed exactly once in canonical order: ${JSON.stringify(actualIds)}`
-            );
-          }
+          if (JSON.stringify(actualProfiles) !== JSON.stringify(expectedProfiles)) throw new Error(`Unexpected included profiles: ${JSON.stringify(actualProfiles)}`);
+          if (report.registered_command_count !== expectedIds.length) throw new Error(`Registered command count mismatch: ${report.registered_command_count} != ${expectedIds.length}`);
+          if (report.configured_command_count !== expectedIds.length) throw new Error(`Configured command count mismatch: ${report.configured_command_count} != ${expectedIds.length}`);
+          if (report.executed_command_count !== expectedIds.length) throw new Error(`Executed command count mismatch: ${report.executed_command_count} != ${expectedIds.length}`);
+          if (JSON.stringify(actualIds) !== JSON.stringify(expectedIds)) throw new Error(`Verification commands were not executed exactly once in canonical order: ${JSON.stringify(actualIds)}`);
           const integrity = report.execution_integrity || {};
-          if ((integrity.duplicate_executions || []).length || (integrity.missing_executions || []).length) {
-            throw new Error(`Execution integrity failure: ${JSON.stringify(integrity)}`);
-          }
-
-          const nonReleaseFailures = (report.results || []).filter(
-            (item) => item.profile !== 'release' && item.status !== 'PASS'
-          );
-          if (nonReleaseFailures.length) {
-            throw new Error(`Non-release diagnostic failures: ${JSON.stringify(nonReleaseFailures)}`);
-          }
-          const releaseFailures = (report.results || []).filter(
-            (item) => item.profile === 'release' && item.status !== 'PASS'
-          );
-          console.log(JSON.stringify({
-            included_profiles: actualProfiles,
-            command_count: actualIds.length,
-            non_release_failures: 0,
-            release_failures: releaseFailures.map((item) => item.id),
-          }, null, 2));
+          if ((integrity.duplicate_executions || []).length || (integrity.missing_executions || []).length) throw new Error(`Execution integrity failure: ${JSON.stringify(integrity)}`);
+          const nonReleaseFailures = (report.results || []).filter((item) => item.profile !== 'release' && item.status !== 'PASS');
+          if (nonReleaseFailures.length) throw new Error(`Non-release diagnostic failures: ${JSON.stringify(nonReleaseFailures)}`);
+          const releaseFailures = (report.results || []).filter((item) => item.profile === 'release' && item.status !== 'PASS');
+          console.log(JSON.stringify({ included_profiles: actualProfiles, command_count: actualIds.length, non_release_failures: 0, release_failures: releaseFailures.map((item) => item.id) }, null, 2));
           NODE

--- a/.github/workflows/runtime-source-first.yml
+++ b/.github/workflows/runtime-source-first.yml
@@ -26,18 +26,118 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: agent/jau-mou-dak-runtime-identity
       - uses: actions/setup-node@v6
         with:
           node-version: 24
           package-manager-cache: false
       - name: Install build dependencies
         run: npm ci
+      - name: Temporary implement JauDak runtime and identity package
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          function replaceOnce(path, before, after) {
+            const original = fs.readFileSync(path, 'utf8');
+            if (original.includes(after)) return;
+            if (!original.includes(before)) throw new Error(`Pattern not found in ${path}`);
+            fs.writeFileSync(path, original.replace(before, after));
+          }
+          replaceOnce('src/runtime-resources/constructions/runtime-label-registry.js', '  "ExistentialPresentationalClause",\n', '  "ExistentialPresentationalClause",\n  "JauDakMouDakAvailabilityPredicate",\n');
+          const helper = `
+  function nodeHasAnySlot(node, slots = []) {
+    return slots.some((slot) => nodeCanFillSlot(node, slot));
+  }
+
+  const jauMouDakLexicalQuarantine = new Set(["冇得頂", "冇得講", "冇得計", "冇得搞", "有得諗"]);
+
+  function availabilityHeadAt(nodes, index) {
+    const surface = (offset) => flattenSurface(nodes[index + offset] || "");
+    const first = surface(0);
+    const second = surface(1);
+    const third = surface(2);
+    if (first === "有冇得") return { length: 1, polarity: "interrogative", headSurface: first, questionStrategy: "suppletive_jau_mou" };
+    if (first === "有" && second === "冇得") return { length: 2, polarity: "interrogative", headSurface: "有+冇得", questionStrategy: "suppletive_jau_mou" };
+    if (first === "有" && second === "冇" && third === "得") return { length: 3, polarity: "interrogative", headSurface: "有+冇+得", questionStrategy: "suppletive_jau_mou" };
+    if (first === "有得") return { length: 1, polarity: "affirmative", headSurface: first, questionStrategy: "none" };
+    if (first === "有" && second === "得") return { length: 2, polarity: "affirmative", headSurface: "有+得", questionStrategy: "none" };
+    if (first === "冇得") return { length: 1, polarity: "negative", headSurface: first, questionStrategy: "none" };
+    if (first === "冇" && second === "得") return { length: 2, polarity: "negative", headSurface: "冇+得", questionStrategy: "none" };
+    return null;
+  }
+
+  function availabilityPredicateFromNodes(nodes) {
+    const compact = withoutIgnorableSpaceText(nodes || []);
+    if (!compact.length) return null;
+    const templated = modalPredicateFromNodes(compact)
+      || templateConstructionFor(compact, ["VerbComplementVP", "TransitiveVP", "ProductiveVO", "CompletionVP", "DirectionalMotionVP", "MotionPurposeChain", "SerialVerbPurposeChain", "PerfectiveVP", "StativePredicate", "DegreeStativePredicate"]);
+    if (templated && nodeHasAnySlot(templated, ["vp", "action_vp", "predicate", "stative_predicate", "perfective_vp"])) return templated;
+    if (compact.length === 1 && nodeHasAnySlot(compact[0], ["vp", "action_vp", "predicate", "main_verb", "action_verb", "movement_verb", "stative_predicate"])) return compact[0];
+    return null;
+  }
+
+  function jauDakMouDakAvailabilityWrapCoreFallback(core) {
+    const { core: bareCore, particles } = withoutTrailingParticles(core);
+    const compact = withoutIgnorableSpaceText(bareCore);
+    if (compact.length < 2) return null;
+    for (let index = 0; index < compact.length - 1; index += 1) {
+      const head = availabilityHeadAt(compact, index);
+      if (!head) continue;
+      const headNodes = compact.slice(index, index + head.length);
+      const predicateNodes = compact.slice(index + head.length);
+      if (!predicateNodes.length) return null;
+      const fusedCheck = `${headNodes.map(flattenSurface).join("")}${flattenSurface(predicateNodes[0] || "")}`;
+      if (jauMouDakLexicalQuarantine.has(fusedCheck)) return null;
+      const predicate = availabilityPredicateFromNodes(predicateNodes);
+      if (!predicate) return null;
+      const children = [...headNodes, predicate, ...particles];
+      const span = construction("JauDakMouDakAvailabilityPredicate", "Avail", children, {
+        note: "Preverbal 有得／冇得 availability or opportunity predicate with an overt independently typed predicate child.",
+        slots: ["jau_mou_dak_availability_predicate", "availability_predicate", "modal_vp", "vp", "predicate", "clause"],
+        trace: traceInfo("generative_template", {
+          construction_type: "JauDakMouDakAvailabilityPredicate",
+          template_family: "generative_template",
+          template: ["availability_head!", "predicate!", "particle?"],
+          assigned_slots: ["availability_head", "predicate", ...particles.map(() => "particle")],
+          surfaces: children.map((node) => flattenSurface(node)),
+          construction_uuid: "4e176fe2-a147-47c7-86c8-6778a379beb2",
+          canonical_identity: "JauDakMouDakAvailabilityPredicate",
+          claim_layer: "language_construction",
+          polarity: head.polarity,
+          head_surface: head.headSurface,
+          question_strategy: head.questionStrategy,
+          predicate_surface: flattenSurface(predicate),
+          predicate_relation: "availability_or_opportunity_of_overt_predicate",
+          hidden_predicate_inserted: false,
+          not_claims: ["not_possessive_have", "not_place_existence", "not_nominal_have_question", "not_event_have_or-not_without_dak", "not_v_m4_v_a_not_a", "not_postverbal_potential", "not_predicate_less_ellipsis", "not_lexicalized_formula"]
+        }),
+      });
+      const before = compact.slice(0, index);
+      return before.length ? [...before, span] : [span];
+    }
+    return null;
+  }
+`;
+          replaceOnce('src/parser/detectors/modality/modal-predicates.js', '\n  function modalVPFromNodes(nodes) {\n', `${helper}\n  function modalVPFromNodes(nodes) {\n`);
+          replaceOnce('src/parser/detectors/modality/modal-predicates.js', '  function modalPredicateWrapCoreFallback(core) {\n    const modalIndex = core.findIndex(isModalToken);\n', '  function modalPredicateWrapCoreFallback(core) {\n    const availabilitySpan = jauDakMouDakAvailabilityWrapCoreFallback(core);\n    if (availabilitySpan) return availabilitySpan;\n    const modalIndex = core.findIndex(isModalToken);\n');
+          NODE
+          node tools/allocate-construction-identity.js canonicalize --uuid 4e176fe2-a147-47c7-86c8-6778a379beb2
+          npm run build:runtime
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "Implement JauDakMouDak availability runtime identity"
+            git pull --rebase origin agent/jau-mou-dak-runtime-identity
+            git push origin HEAD:agent/jau-mou-dak-runtime-identity
+          fi
       - name: Run runtime verification profile
         run: npm run verify:runtime

--- a/grammar/research_pending/JauDakMouDakAvailabilityPredicate.md
+++ b/grammar/research_pending/JauDakMouDakAvailabilityPredicate.md
@@ -1,0 +1,152 @@
+---
+title: "JauDakMouDakAvailabilityPredicate"
+type: "canto-span-construction"
+construction: "JauDakMouDakAvailabilityPredicate"
+status: "research_pending"
+confidence: "not_assigned_research_pending"
+claim_layer: "language"
+lane: "LANE-10"
+last_reviewed: "2026-08-01"
+last_status_migrated: "2026-08-05"
+source_count: 3
+verified_source_count: 3
+panel_response_count_total: 0
+eligible_panel_response_count: 0
+minimum_usable_judgments_per_critical_item: 0
+critical_contrast_coverage: "none"
+survey_instrument_version: null
+survey_instrument_status: "not_started"
+survey_instrument_quality_resolved: false
+quality_screen_status: "not_started"
+panel_adjudication_status: "not_started"
+recruitment_channels: []
+respondent_role_neutral: true
+native_positive_contrasts_reviewed: false
+native_negative_contrasts_reviewed: false
+panel_evidence_model_version: "v2"
+panel_review_state_file: "review-packets/native-panel/active-v2/panel-review-state.json"
+panel_policy_file: "review-packets/native-panel/active-v2/panel-policy.json"
+negative_cases_drafted: true
+negative_tests_executable: true
+negative_tests_passing: true
+negative_boundary_inventory_complete: true
+corpus_evidence_used: true
+corpus_hits_reviewed: true
+corpus_candidate_hit_count: 95
+corpus_genuine_hit_count: 70
+corpus_false_positive_count: 15
+corpus_ambiguous_hit_count: 7
+corpus_unusable_hit_count: 3
+code_document_reconciled: true
+code_document_review_date: "2026-08-05"
+code_document_review_commit: null
+code_document_code_locations: ["src/parser/detectors/modality/modal-predicates.js"]
+current_standard_reaudit_complete: false
+implementation_validation_separate: true
+independent_evidence_beyond_internal_tests: true
+promotion_gate_version: "v3"
+standard_test_file: "tests/constructions/JauDakMouDakAvailabilityPredicate.json"
+standard_test_coverage: "positive_and_boundary"
+standard_positive_test_count: 5
+standard_boundary_test_count: 8
+standard_implementation_probe_count: 0
+standard_executable_test_count: 13
+source_ids: ["SRC-LAM-LAU-LEE-2024-SEGMENTATION", "SRC-HUANG-HER-KONG-2025-INTERROGATIVES", "HKCANCOR-JAU-MOU-DAK-R1"]
+runtime_active: true
+workflow_state: "available"
+workflow_priority: null
+workflow_since: "2026-08-05"
+workflow_reason: "implemented_from_accepted_jau_mou_dak_availability_specification"
+runtime_code_references: 1
+accepted_fixtures: 5
+tags: ["canto-span/grammar", "canto-span/status/research_pending", "canto-span/lane/lane-10", "canto-span/workflow/available"]
+---
+
+# JauDakMouDakAvailabilityPredicate
+
+## Plain-language claim
+
+Cantonese has a preverbal availability or opportunity relation headed by overt `有得` or `冇得` before an overt predicate. The affirmative profile says the predicate event is available or possible; the negative profile says it is unavailable or impossible. The suppletive-polar profile `有冇得 + predicate` asks which availability alternative holds.
+
+This note records the runtime identity and evidence boundary for the accepted candidate UUID `4e176fe2-a147-47c7-86c8-6778a379beb2`. It does not promote the construction beyond `research_pending`.
+
+## Current status
+
+- Linguistic status: `research_pending`
+- Linguistic confidence: `not_assigned_research_pending`
+- Current action: `retain_with_runtime_coverage_and_quarantine_boundaries`
+- Productive acceptance eligible: **no**
+- Last linguistic review: 2026-08-01
+
+## Sources
+
+### SRC-LAM-LAU-LEE-2024-SEGMENTATION
+
+- Verification: `VERIFIED_FULL_TEXT`
+- What it supports: affirmative `有得` and negative `冇得` are treated as preverbal units relating to the following event or predicate.
+- Limit: This source does not establish every corpus boundary, ellipsis profile, or suppletive-polar `有冇得` case.
+
+### SRC-HUANG-HER-KONG-2025-INTERROGATIVES
+
+- Verification: `VERIFIED_FULL_TEXT`
+- What it supports: general Cantonese `有冇` suppletive-polar question force and embedded question-force evidence.
+- Limit: The application to `有冇得` is a project inference over the accepted availability identity, not an independent proof that `有冇得` requires a second UUID.
+
+### HKCANCOR-JAU-MOU-DAK-R1
+
+- Verification: `PROJECT_REVIEWED_CORPUS_PACKET`
+- What it supports: 95 reviewed spans across 89 utterances and 38 frozen files, including 63 transparent compositional availability rows, five suppletive-polar questions, two recoverable ellipsis rows, 15 lexicalized or idiomatic rows, seven ambiguous boundaries, and three repairs or unusable rows.
+- Limit: Corpus distribution establishes recurring contextual attestation and boundaries; it does not alone establish unrestricted productivity or panel sufficiency.
+
+## Positive profile
+
+```text
+有得 + overt predicate
+冇得 + overt predicate
+有冇得 + overt predicate
+有 + 冇得 + overt predicate
+```
+
+The narrow construction span begins at the first overt availability head token and ends at the independently licensed predicate phrase. Premarker subjects, topics, locations, temporal frames, conditions, focus markers, higher modals, quotation frames, embedding predicates, and clause-final particles remain outside the narrow node unless another transparent wrapper owns them.
+
+## Negative and boundary cases
+
+The productive profile must not absorb:
+
+- AA55 possession or nominal availability such as subject + `有 + NP`;
+- AA77 place existence such as place + `有／冇 + NP`;
+- nominal `有冇 + NP` questions;
+- ordinary event `有冇 + VP` without `得`;
+- ordinary lexical `V-唔-V` A-not-A questions;
+- postverbal potential such as `V到／V唔到`;
+- predicate-less `有得／冇得` without uniquely recoverable discourse context;
+- fused or formulaic expressions such as `冇得頂` and `冇得講`;
+- repairs, interruptions, or unresolved lexical-category cases.
+
+## Native-speaker review
+
+- Independent speaker records: **0**
+- Scope: `NOT_ESTABLISHED`
+- Surface judgments: 0 total; 0 accepted; 0 rejected.
+- Structural-analysis validations: 0.
+
+## Implementation state
+
+- Lifecycle: `runtime_referenced_with_accepted_fixtures`
+- Standard executable test file: `tests/constructions/JauDakMouDakAvailabilityPredicate.json`
+- Implementation evidence is kept separate from linguistic evidence.
+- The suppletive-polar profile remains the same UUID plus question-force metadata; it does not receive a second language-construction UUID.
+
+## Open questions and blockers
+
+- Role-neutral panel contrasts are not complete.
+- Held-out validation is not complete.
+- Predicate-less ellipsis must remain context-linked and is not accepted as a context-free profile.
+- Lexicalized negative expressions may need future lexical or discourse identities, but they are quarantined from this productive profile.
+
+## Related constructions
+
+- [[ModalAuxiliaryComplementVP]]
+- [[ExistentialQuestion]]
+- [[SubjectJauPossessiveClause]]
+- [[PotentialResultVP]]

--- a/tests/constructions/JauDakMouDakAvailabilityPredicate.json
+++ b/tests/constructions/JauDakMouDakAvailabilityPredicate.json
@@ -1,0 +1,141 @@
+{
+  "schema": "canto-span-construction-test-file-v1",
+  "construction": "JauDakMouDakAvailabilityPredicate",
+  "runtime_active": true,
+  "migration_phase": 5,
+  "snapshot_cases": [],
+  "focused_cases": [
+    {
+      "case_id": "JMD-POS-AFF-01",
+      "source": "有得去。",
+      "class": "affirmative_availability_simple_predicate",
+      "expected_profile": "affirmative_availability",
+      "assertion": "construction_present",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#affirmative",
+      "source_ids": ["SRC-LAM-LAU-LEE-2024-SEGMENTATION", "HKCANCOR-JAU-MOU-DAK-R1"]
+    },
+    {
+      "case_id": "JMD-POS-NEG-01",
+      "source": "冇得去。",
+      "class": "negative_availability_simple_predicate",
+      "expected_profile": "negative_availability",
+      "assertion": "construction_present",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#negative",
+      "source_ids": ["SRC-LAM-LAU-LEE-2024-SEGMENTATION", "HKCANCOR-JAU-MOU-DAK-R1"]
+    },
+    {
+      "case_id": "JMD-POS-Q-01",
+      "source": "有冇得去？",
+      "class": "suppletive_polar_availability_question",
+      "expected_profile": "suppletive_polar_availability",
+      "assertion": "construction_present",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#suppletive-polar-question",
+      "source_ids": ["SRC-HUANG-HER-KONG-2025-INTERROGATIVES", "HKCANCOR-JAU-MOU-DAK-R1"]
+    },
+    {
+      "case_id": "JMD-POS-OBJ-01",
+      "source": "有得食飯。",
+      "class": "affirmative_availability_object_bearing_predicate",
+      "expected_profile": "affirmative_availability",
+      "assertion": "construction_present",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#predicate-contract",
+      "source_ids": ["HKCANCOR-JAU-MOU-DAK-R1"]
+    },
+    {
+      "case_id": "JMD-POS-HOST-01",
+      "source": "我有得去。",
+      "class": "subject_host_plus_affirmative_availability",
+      "expected_profile": "affirmative_availability_with_outer_subject",
+      "assertion": "construction_present",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#predicate-contract",
+      "source_ids": ["HKCANCOR-JAU-MOU-DAK-R1"]
+    },
+    {
+      "case_id": "JMD-BND-POSS-01",
+      "source": "我有本書。",
+      "class": "aa55_possession_not_availability",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#negative-or-quarantined-cells",
+      "source_ids": ["PROJECT-JMD-SPEC"]
+    },
+    {
+      "case_id": "JMD-BND-PLACE-01",
+      "source": "枱上面有支筆。",
+      "class": "aa77_place_existence_not_availability",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#negative-or-quarantined-cells",
+      "source_ids": ["PROJECT-JMD-SPEC"]
+    },
+    {
+      "case_id": "JMD-BND-NOM-Q-01",
+      "source": "你有冇書？",
+      "class": "nominal_have_question_not_availability",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#negative-or-quarantined-cells",
+      "source_ids": ["PROJECT-JMD-SPEC"]
+    },
+    {
+      "case_id": "JMD-BND-EVENT-Q-01",
+      "source": "你有冇去？",
+      "class": "ordinary_event_have_or_not_without_dak_not_availability",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#negative-or-quarantined-cells",
+      "source_ids": ["PROJECT-JMD-SPEC"]
+    },
+    {
+      "case_id": "JMD-BND-POT-01",
+      "source": "去唔到。",
+      "class": "postverbal_potential_not_availability",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#negative-or-quarantined-cells",
+      "source_ids": ["PROJECT-JMD-SPEC"]
+    },
+    {
+      "case_id": "JMD-BND-LEX-01",
+      "source": "冇得頂。",
+      "class": "fused_lexicalized_expression_not_productive_availability",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#lexical-and-discourse-quarantine",
+      "source_ids": ["HKCANCOR-JAU-MOU-DAK-R1"]
+    },
+    {
+      "case_id": "JMD-BND-FORMULA-01",
+      "source": "冇得講。",
+      "class": "formulaic_expression_not_productive_availability",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#lexical-and-discourse-quarantine",
+      "source_ids": ["HKCANCOR-JAU-MOU-DAK-R1"]
+    },
+    {
+      "case_id": "JMD-BND-ZERO-01",
+      "source": "有得。",
+      "class": "predicate_less_availability_requires_context",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/JAU-MOU-DAK-AVAILABILITY-IDENTITY-SPECIFICATION-R1.md#ellipsis-and-context",
+      "source_ids": ["HKCANCOR-JAU-MOU-DAK-R1"]
+    }
+  ],
+  "np_cases": [],
+  "implementation_probe_cases": [],
+  "coverage": {
+    "state": "positive_and_boundary",
+    "exact_snapshot_positive_count": 0,
+    "focused_positive_count": 5,
+    "focused_boundary_count": 8,
+    "focused_review_only_count": 0,
+    "np_case_count": 0,
+    "implementation_probe_count": 0,
+    "compatibility_alias_probe_count": 0,
+    "positive_case_count": 5,
+    "boundary_case_count": 8,
+    "executable_case_count": 13
+  }
+}


### PR DESCRIPTION
## Closed: blocked implementation attempt

This draft attempted to implement #597/#598, but it is not a coherent final state and must not be merged.

The target remains substantively valid: implement accepted `JauDakMouDakAvailabilityPredicate` from reserved candidate UUID `4e176fe2-a147-47c7-86c8-6778a379beb2`.

The blocker is generated-output execution mechanics. The final package requires all of these to be produced and committed together:

- source-first runtime matcher changes;
- runtime label registry update;
- `tools/allocate-construction-identity.js` canonicalization;
- generated identity/lock/status/discovery outputs;
- `npm run build:runtime` generated `main.js`;
- runtime and full verification.

Current connected execution could not produce that coherent branch state: local clone/`gh`/npm execution is unavailable, and branch-modified workflow write-back did not execute. The partial draft state failed construction-positive checks and is intentionally closed.

No status, release, deployment, survey, corpus-classification, or manual short-code decision was made.

#597/#598 remain open and blocked until an execution surface can commit allocator/generated outputs coherently.