### PR TITLE
Research reduplicated manner profiles and AA84 boundaries

### DIFF
--- a/docs/research/ISSUE-611-REDUPLICATED-MANNER-PROFILES-R1.md
+++ b/docs/research/ISSUE-611-REDUPLICATED-MANNER-PROFILES-R1.md
@@ -1,0 +1,172 @@
+# ISSUE-611 reduplicated-manner profile disposition R1
+
+Parent issue: #611  
+Work claim: #612  
+Date: 2026-08-05
+
+## Decision
+
+Retain AA84 `GamMarkedReduplicatedMannerVP` narrowly for an overt marked manner relation:
+
+```text
+reduplicated manner expression + overt 咁／噉 + overt independently typed VP
+```
+
+Do not let the AA84 identity or evidence automatically cover bare `慢慢 + VP`, every repeated adjective/stative surface, `AA地`, bare AABB adverbs, verb reduplication, or speech repetition.
+
+The legacy runtime label `MannerAdverbialVP` currently merges a defensible overt path with an unsupported generic bare fallback. That runtime–research mismatch should be repaired in a later separately claimed implementation without changing AA84's UUID or linguistic status.
+
+## Profile dispositions
+
+| Profile | Disposition | Reason |
+|---|---|---|
+| reduplicated manner expression + overt `咁／噉` + typed VP | `RETAIN_AS_AA84_CORE` | Independently attested in scholarly and pedagogical sources with event predicates, aspect-marked predicates, and object-bearing VPs. |
+| exactly `AA + 咁／噉 + VP` | `SUPPORTED_SUBTYPE_NOT_COMPLETE_FORMULA` | `慢慢噉` is directly attested, but other sources show `AA地咁`, `大大力咁`, and `細細聲咁`; raw equality of two stative tokens is not the invariant. |
+| `AA地 + VP` | `SUPPORTED_NEIGHBORING_ADVERBIAL_PROFILE` | Directly documented, but lacks overt `咁／噉` and also collides with attenuative property uses of `AA地`. It should not inherit AA84 automatically. |
+| `AA地咁／噉 + VP` | `SUPPORTED_MARKED_VARIANT_REQUIRING_TYPED_MODIFIER` | Direct examples support the surface; a later implementation may treat `AA地` as the modifier constituent inside the overt marked relation. |
+| bare `慢慢 + VP` | `SUPPORTED_LEXICAL_ADVERBIAL_OUTSIDE_AA84` | Modern lexical evidence directly attests it, but does not establish a productive rule over arbitrary repeated statives. |
+| other bare `AA + VP` | `UNRESOLVED_NOT_PRODUCTIVE_BY_DEFAULT` | No source set establishes unrestricted lexical or predicate compatibility. Tone, prosody, lexicalization, and register remain unresolved. |
+| bare AABB adverb + VP | `SUPPORTED_DISTINCT_REDUPLICATION_PROFILE` | Reference grammar examples are direct, but AABB morphology is distinct from the runtime's AA pair and should not be collapsed into AA84. |
+| reduplicated adjective predication or `AA地` attenuation | `SEPARATE_PROPERTY_PREDICATION` | The reduplicated material describes a property or degree rather than manner of an event. |
+| verb reduplication | `SEPARATE_ACTION_ASPECT_OR_ITERATION` | Repeated verbs are not automatically adjective-derived manner expressions. |
+| time/frequency, sound-symbolic, planning, emphasis, or repair repetition | `SEPARATE_OR_CONTEXT_DEPENDENT` | Surface repetition alone does not establish morphological manner reduplication. |
+| single `A + 咁／噉 + VP` | `OUTSIDE_AA84_UNLESS_SEPARATELY_LICENSED` | `咁／噉` is a broader adverbial marker; AA84 specifically preserves a reduplicated marked modifier profile. |
+
+## Current runtime comparison
+
+Canonical source inspected:
+
+- `src/parser/detectors/manner/adjustment.js`
+
+### Overt path
+
+The current detector requires:
+
+- optional outer subject based on a length heuristic;
+- two adjacent nodes with identical surface strings;
+- both nodes independently able to fill `stative_predicate`;
+- optional overt `咁／噉`;
+- one following action or VP node after wrapping.
+
+The overt branch is directionally aligned with AA84 because it preserves `咁／噉` and a following predicate. However, it is simultaneously too narrow and too surface-driven:
+
+- it cannot represent modifier constituents such as `傻傻哋`, `大大力`, or `細細聲` as typed wholes;
+- it treats string equality plus stative slots as proof of reduplication;
+- it does not encode tone/prosody or lexical constraints;
+- its optional-subject decision is based on node count rather than transparent outer composition;
+- it applies construction patterns to all remaining material and therefore requires careful boundary tests for time, coverb, coordination, and clause material.
+
+### Bare path
+
+When no `咁／噉` is present, the same detector accepts exactly two identical stative nodes followed by one action/VP node and emits the same `MannerAdverbialVP` label.
+
+This path is not source-equivalent to AA84. The evidence establishes bare lexical `慢慢` and distinct AABB adverbs, not the generic rule:
+
+```text
+any stative A + identical A + any action predicate
+```
+
+The bare branch should therefore lose access to AA84 unless a future source-graded lexical or morphological profile is separately established.
+
+## Current test comparison
+
+Canonical test inspected:
+
+- `tests/constructions/MannerAdverbialVP.json`
+
+Current coverage contains:
+
+- one source-linked positive snapshot: `佢慢慢噉食飯`;
+- two very remote negative controls: an unmodified action and a stative predicate;
+- one zero-evidence reachability probe: `佢慢慢行`.
+
+This does not test the actual boundaries created by the runtime.
+
+A later implementation package should add the following matrix.
+
+### Positive AA84 cells
+
+- `慢慢噉 + intransitive VP`;
+- `慢慢噉 + object-bearing VP`;
+- `慢慢噉 + aspect-marked typed VP`;
+- `AA地咁／噉 + VP` where the modifier constituent is independently typed;
+- complex documented modifier such as `細細聲咁 + speech VP` without flattening its internal structure;
+- outer subject and temporal material kept outside the narrow AA84 node.
+
+### Composition or separate-profile cells
+
+- bare lexical `慢慢 + VP` preserved without AA84;
+- bare AABB adverb preserved without AA84;
+- `AA地 + VP` preserved without silently asserting overt `GamMarked` structure;
+- single adjective + `咁／噉 + VP` preserved through a different adverbial relation if independently supported;
+- complete inner directional, transitive, perfective, or coverb structure retained.
+
+### Negative and collision cells
+
+- adjective predication: `今日凍凍地`;
+- attributive reduplication;
+- verb reduplication;
+- repeated time/frequency expression;
+- onomatopoeia or sound-symbolic repetition;
+- speech repair or fourfold planning repetition;
+- two equal unknown/text nodes before a verb;
+- nonidentical or partially overlapping modifier material;
+- incomplete marked form without a following typed predicate;
+- intervening clause or unrelated material between modifier and predicate;
+- reverse or postverbal order not independently licensed as AA84.
+
+## Span and composition contract
+
+A future AA84 runtime node should:
+
+1. begin at the independently typed reduplicated manner constituent;
+2. include overt `咁／噉`;
+3. include one independently typed following VP child;
+4. preserve the modifier's internal morphology rather than converting every piece to identical `how` tokens;
+5. keep subjects, topics, temporal frames, locations, coverb phrases, focus material, higher modality, quotation, coordination, and sentence-final particles outside unless a separate transparent wrapper owns them;
+6. retain aspect, objects, directionals, and complements inside the typed VP child rather than rebuilding a generic predicate from leftover nodes;
+7. reject fragments, repairs, and unknown material rather than filling gaps.
+
+## Identity consequence
+
+AA84 already has a canonical narrow name that identifies overt `咁／噉`. The source review supports retaining the UUID and name. It does not justify a split or a new general `MannerAdverbialVP` identity at this stage.
+
+Potential future identity questions are reserved:
+
+- whether lexical bare `慢慢` needs only a lexicon entry or an independently useful construction identity;
+- whether `AA地 + VP` and bare AABB adverbs form one or more broader manner-reduplication identities;
+- whether marked forms with complex modifier constituents require a family/profile refinement rather than a new UUID.
+
+## Terminal outcome
+
+- AA84 overt marked core: `RETAIN_NARROWLY`.
+- Current overt runtime path: `PARTIALLY_ALIGNED_BUT_SURFACE_NARROW`.
+- Current bare runtime path: `NOT_SOURCE_EQUIVALENT_REMOVE_FROM_AA84`.
+- Bare `慢慢 + VP`: `ATTESTED_LEXICAL_ADVERBIAL`.
+- Generic bare `AA + VP`: `NOT_ESTABLISHED`.
+- Bare AABB adverbs: `ATTESTED_DISTINCT_PROFILE`.
+- `AA地 + VP`: `ATTESTED_NEIGHBORING_PROFILE`.
+- Generic token-equality rule: `REJECT_AS_EVIDENCE_INVARIANT`.
+- New UUID: no.
+- Status promotion: no.
+- Runtime change in this packet: no.
+
+## Next separately claimed action
+
+After this research packet merges, create one Codex-eligible accepted-specification issue to:
+
+1. reserve AA84 for overt `咁／噉` only;
+2. replace raw token equality with an independently typed reduplicated-manner constituent;
+3. remove the generic bare fallback from AA84;
+4. preserve bare `慢慢`, AABB, and `AA地` forms without false AA84 assignment;
+5. add the controlled matrix above;
+6. regenerate runtime outputs and run relevant verification;
+7. make no identity or status change.
+
+## Protected-state confirmation
+
+This packet changes no runtime behavior, parser matcher, test, fixture, identity, code, linguistic status, corpus classification, survey, panel, held-out, release, package, or deployment state.
+
+## Source inventory
+
+See `docs/research/ISSUE-611-REDUPLICATED-MANNER-SOURCE-INVENTORY-R1.md`.

--- a/docs/research/ISSUE-611-REDUPLICATED-MANNER-SOURCE-INVENTORY-R1.md
+++ b/docs/research/ISSUE-611-REDUPLICATED-MANNER-SOURCE-INVENTORY-R1.md
@@ -1,0 +1,98 @@
+# ISSUE-611 reduplicated-manner source inventory R1
+
+Parent issue: #611  
+Work claim: #612  
+Date: 2026-08-05
+
+## Scope
+
+This packet distinguishes the following Cantonese profiles rather than treating them as one productive rule:
+
+1. reduplicated property or manner material followed by overt `咁／噉` before a VP;
+2. reduplicated material with `地`, optionally followed by `咁／噉`, before a VP;
+3. bare lexicalized `慢慢 + VP`;
+4. broader bare AABB adverbs;
+5. reduplicated adjective predication or attenuation;
+6. verb reduplication, sound-symbolic repetition, time/frequency repetition, and speech repair.
+
+The target identity is AA84 `GamMarkedReduplicatedMannerVP`, legacy runtime label `MannerAdverbialVP`.
+
+## Source inventory
+
+| Source ID | Source and locator | Verification | Direct contribution | Limit |
+|---|---|---|---|---|
+| `SRC-LEUNG-2014-COVERBS` | Herman H. Leung. 2014. *Cantonese Coverbs: A Syntactic Reanalysis*. UC Berkeley MA qualifying paper, pp. 13-15, examples (29a-b) and discussion. | `VERIFIED_FULL_TEXT_IN_CURRENT_NOTE_AND_R23` | Directly attests `琴日慢慢噉食飯` and discusses the order of temporal, reduplicated-manner, coverb, and event material. | The paper's syntactic-height analysis is theory-specific. One lexical example does not establish unrestricted modifier productivity or bare-marker omission. |
+| `SRC-ZHENG-ZHANG-GAO-2021-HK-CANTONESE-COURSE` | 鄭定歐、張勵妍、高石英. 2021. *粵語（香港話）教程（修訂版）*, printed p. 336: `慢慢噉形成咗一套較為完善嘅公屋制度`; printed pp. 145-147 for single-syllable adjective reduplication and `AA地`. | `VERIFIED_USER_PROVIDED_FULL_TEXT_WITH_PAGE_LOCATORS` | Independently attests overt `慢慢噉 + aspect-marked VP`; separately documents reduplicated adjective `AA地` as an attenuative property pattern. | Pedagogical evidence establishes the forms but not unrestricted productivity, frequency, or one shared construction between manner modification and attenuative predication. |
+| `SRC-ARcODIA-2022-STRUCTURAL-PARTICLES` | Giorgio Francesco Arcodia. 2022. “On Structural Particles in Sinitic Languages: Typology and Diachrony.” Discussion of Cantonese adverbial `咁` and reduplicated adjectives, drawing examples from Matthews and Yip 2011, including `你偷偷哋整嘢食呀`, `我見到佢傻傻哋咁笑`, and `佢大大力咁踢個波`. | `VERIFIED_PEER_REVIEWED_OPEN_ACCESS_ARTICLE` | Treats `咁` as a general Cantonese adverbial-modification marker and shows that the modifier preceding it may include reduplication plus `地` or a more complex form such as `大大力`. | The examples support overt marked adverbial structure; they do not establish a bare productive `AA + VP` rule or the runtime's exact token-equality analysis. |
+| `SRC-MATTHEWS-YIP-2011-COMPREHENSIVE-REDUPLICATION` | Stephen Matthews and Virginia Yip. 2011. *Cantonese: A Comprehensive Grammar*, 2nd ed.; official CUHK companion materials, Chapters 2 and 9; examples also reproduced in Arcodia 2022. | `VERIFIED_OFFICIAL_UNIVERSITY_RESOURCE_AND_SECONDARY_EXAMPLE_CHAIN` | Separates adjective reduplication, attenuative `AA地`, adverbial uses, and other reduplication families. Supplies overt adverbial examples used in later scholarship. | The resource does not imply that every reduplicated stative surface is manner or that all reduplication types share one identity. |
+| `SRC-WONG-ETAL-2022-GACS-MANNER` | Wong, Cheung, Lo, and Wan. 2022. “Grammatical Analysis of Cantonese Samples,” adverbial-modifier section; examples include `你乖乖地食飯先` and `你細細聲咁講俾我聽啦`. | `VERIFIED_PUBLIC_CHAPTER_EXCERPT` | Describes preverbal adjective-based manner modification through reduplication with optional `地` and through adjective material followed by `咁`; independently corroborates distinct marked strategies. | A developmental coding framework is not automatically the correct permanent ontology. The examples do not establish a generic bare two-token runtime rule. |
+| `SRC-YIP-MATTHEWS-2017-AABB-ADVERBS` | Virginia Yip and Stephen Matthews. 2017. *Intermediate Cantonese: A Grammar and Workbook*, 2nd ed.; reduplication unit and exercises; examples include `阿玲求求其其嫁咗個鬼仔` and `我哋快快趣趣搞掂呢單生意啦`. | `VERIFIED_PUBLISHED_REFERENCE_GRAMMAR_WITH_ACCESSIBLE_TEXT` | Directly supports bare AABB adverbial forms and states that reduplication availability is lexically restricted and not entirely predictable. | AABB is structurally different from the runtime's generic AA token pair. These examples do not prove bare productivity for every monosyllabic stative. |
+| `SRC-CANTOWORDS-MAAN6MAAN6` | CantoWords entry for `慢慢`, part of speech adverb; examples include `慢慢行`, `慢慢食`, and `有事慢慢講`. | `VERIFIED_CURRENT_CANTONESE_LEXICAL_RESOURCE` | Directly attests bare `慢慢 + VP` as modern adverbial usage. | A lexical entry cannot establish a productive reduplication rule. `慢慢` may be conventionalized and its lexical tone/prosody may differ from simply repeating an ordinary stative token. |
+| `SRC-HKBU-2025-REDUPLICATION-ACCEPTABILITY` | HKBU institutional record for a 2025 MA thesis on Cantonese adjective and verb reduplication; 30 native speakers and controlled AABB/AAB items. | `VERIFIED_INSTITUTIONAL_ABSTRACT` | Reports substantial lexical/frequency and formality effects on reduplication acceptability, reinforcing that productivity cannot be inferred from a surface template alone. | The abstract does not directly test the AA `咁／噉` manner profile or bare `慢慢 + VP`; it is corroborative evidence about lexical restrictions only. |
+| `PROJECT-CP021B-R23-MANNER-MAP` | `docs/research/COVERB-MANNER-EVENT-MODIFICATION-SOURCE-MAP-CP021B-R23.md`. | `VERIFIED_PROJECT_RESEARCH_SYNTHESIS` | Records the earlier finding that inspected direct sources supported overt `慢慢噉` but did not establish the runtime's bare `慢慢行` template as the same productive construction. | Project synthesis has no independent linguistic-evidence weight beyond its cited sources. |
+| `PROJECT-WECHAT-GX-TRAVEL-002` | Native conversation record containing planning/emphatic repetition `慢慢慢慢玩`. | `PROJECT_CONTEXT_ONLY_ZERO_STRUCTURAL_WEIGHT` | Supplies a collision showing that repeated surface words can reflect speech planning or emphasis rather than a grammatical reduplication construction. | One private conversation cannot establish grammar, productivity, or dialect-wide judgments and must not receive special panel weight. |
+
+## Evidence by profile
+
+### A. Overt reduplicated manner plus `咁／噉`
+
+Strongest directly supported core:
+
+```text
+reduplicated manner/property expression + overt 咁／噉 + overt VP
+```
+
+Attested examples include:
+
+- `琴日慢慢噉食飯`;
+- `慢慢噉形成咗一套較為完善嘅公屋制度`;
+- `我見到佢傻傻哋咁笑`;
+- `佢大大力咁踢個波`;
+- `你細細聲咁講俾我聽啦`.
+
+The evidence shows that the modifier constituent is not always exactly two identical stative tokens. It may include `地`, a complex reduplicated expression, or additional lexical material such as `力` or `聲`. The invariant is therefore an overt manner expression plus overt adverbial marker and an independently licensed following predicate, not raw token equality.
+
+### B. Reduplicated modifier with `地`
+
+`AA地 + VP` is independently documented as an adverbial strategy, while `AA地` also occurs in attenuative property predication. Attachment to a following action predicate is therefore required before assigning a manner relation.
+
+This profile is adjacent to AA84 but is not automatically identical to the canonical `GamMarked` identity because `咁／噉` is not overt in every `AA地 + VP` example.
+
+### C. Bare `慢慢 + VP`
+
+Bare `慢慢行`, `慢慢食`, and `慢慢講` are directly attested in a modern Cantonese lexical resource. This closes the earlier question of whether the surface can occur naturally.
+
+It does **not** close the productivity question. The evidence supports `慢慢` as a lexical adverb; it does not license a parser rule that converts any two identical stative tokens before an action into one manner construction.
+
+### D. Bare AABB adverbs
+
+Reference materials directly attest AABB forms such as `求求其其` and `快快趣趣` in adverbial position. Their internal morphology, lexical inventory, and prosody differ from bare AA. They require separate representation or a broader independently researched reduplication family, not silent inclusion under AA84.
+
+## Collision inventory
+
+The following must remain outside a generic AA84 match unless independently composed:
+
+- reduplicated adjective predication or attenuation: `凍凍地`, `黑黑地`;
+- attributive reduplication;
+- bare lexical `慢慢 + VP` without overt `咁／噉`;
+- AABB lexical adverbs;
+- verb reduplication and delimitative or iterative action;
+- repeated time or frequency expressions such as `日日`;
+- sound-symbolic or onomatopoeic repetition;
+- planning, emphasis, stutter, quotation, or repair repetition;
+- a single adjective plus `咁` where no reduplicated modifier exists;
+- ordinary demonstrative or degree uses of `咁`;
+- untyped material between the manner expression and predicate;
+- strings without an overt independently typed action/event predicate.
+
+## Source conflict and unresolved areas
+
+1. Descriptions vary between adjective reduplication, lexical adverb, manner phrase, and structural-particle analyses. AA84 should remain theory-neutral.
+2. The optionality relation among bare AA, `AA地`, `AA咁／噉`, and `AA地咁／噉` is not established as free alternation.
+3. Lexical selection, tone change, prosody, register, and regional distribution remain incompletely documented.
+4. The source set does not establish unrestricted predicate-class compatibility or every possible modifier order.
+5. No reviewed source supports using two equal parser surfaces as sufficient evidence for morphological reduplication.
+
+## Evidence conclusion
+
+AA84 is defensible only for an overt marked manner relation centered on visible `咁／噉` and a typed following predicate. Bare `慢慢 + VP` is real but presently supported as a lexical adverbial profile, not as evidence for the runtime's generic bare reduplication rule. Bare AABB and `AA地` profiles are independently documented neighboring structures and require separate composition or later identity research.


### PR DESCRIPTION
## Outcome

Completes #611 through research-only claim #612.

This packet retains AA84 `GamMarkedReduplicatedMannerVP` narrowly for an overt marked relation:

```text
reduplicated manner expression + overt 咁／噉 + overt independently typed VP
```

## Findings

- scholarly and pedagogical sources independently support overt reduplicated manner material with `咁／噉` before a VP;
- the modifier constituent is not always exactly two identical stative tokens: documented forms include `AA地咁`, `大大力咁`, and `細細聲咁`;
- bare `慢慢 + VP` is directly attested as a lexical adverbial profile, but does not establish a productive rule over arbitrary repeated statives;
- bare AABB adverbs and `AA地 + VP` are independently documented neighboring reduplication profiles;
- adjective predication, verb reduplication, time/frequency repetition, sound symbolism, and speech repair remain separate;
- the current generic bare fallback is not source-equivalent to AA84 and should be removed in a later separately claimed implementation.

## Files

- `docs/research/ISSUE-611-REDUPLICATED-MANNER-PROFILES-R1.md`
- `docs/research/ISSUE-611-REDUPLICATED-MANNER-SOURCE-INVENTORY-R1.md`

## Protected state

No runtime/parser, test/fixture, identity/code, linguistic status, corpus classification, survey, panel, held-out, release, package, or deployment change.

## Verification

- exact diff contains only the two claimed new research files;
- source records include locators, evidence grades, and limitations;
- current note, tests, runtime, identity adjudication, and prior R23 map were compared without editing them;
- no overlap with Codex claim #606 or PR #607.

Closes #611
Closes #612