### PR TITLE
Research 變成 wh-complement profiles and AA11 boundaries

### DIFF
--- a/docs/research/ISSUE-614-BINSING-DIM-COMPLEMENT-PROFILES-R1.md
+++ b/docs/research/ISSUE-614-BINSING-DIM-COMPLEMENT-PROFILES-R1.md
@@ -1,0 +1,197 @@
+# ISSUE-614 變成 wh-complement profile disposition R1
+
+Parent issue: #614  
+Work claim: #615  
+Date: 2026-08-05
+
+## Decision
+
+Retain AA11 `BinSingDimWhComplementVP` narrowly as the exact source-linked profile:
+
+```text
+變成 + 點
+```
+
+The construction asks about the resulting state or outcome after change. It does not own the outer subject, topic, higher modal, condition, embedding, quotation, question frame, or sentence-final particle.
+
+Do not broaden AA11 automatically to all complements of lexical `變成`. This review directly attests `點樣`, `乜嘢`, nominal results, aspect-marked nominal results, and `變…做` transformation surfaces, but those profiles differ in wh dimension, category, order, and composition.
+
+## Profile dispositions
+
+| Profile | Disposition | Reason |
+|---|---|---|
+| exact `變成 + 點` | `RETAIN_AS_AA11_CORE` | Direct coursebook evidence and corroborating contemporary usage support a lexical change predicate followed by a wh expression asking the resulting state/outcome. |
+| `變成 + 點樣` | `ATTESTED_NEIGHBORING_WH_PROFILE` | Direct contemporary Cantonese attestation exists, but identity with `點` is not established. Preserve separately pending controlled contrasts. |
+| `變成 + 乜嘢` | `ATTESTED_RESULT_IDENTITY_WH_PROFILE` | Official quoted Cantonese asks what entity/category the referent becomes. The semantic question differs from result-state `點`. |
+| `變成 + NP` | `SUPPORTED_LEXICAL_RESULT_COMPLEMENT_OUTSIDE_AA11` | Current lexical evidence directly attests nominal results such as `變成大富翁`. |
+| `變成咗 + NP` | `SUPPORTED_ASPECTUAL_LEXICAL_PROFILE_OUTSIDE_AA11` | Independent current examples place perfective `咗` after `變成` and before the nominal result. |
+| `變 + 咗／緊 + 做 + NP` | `SUPPORTED_SEPARATE_TRANSFORMATION_STRATEGY` | Overt aspect and `做` distinguish the surface from lexical `變成`; no normalization to AA11 is justified. |
+| `成為 + NP` | `SUPPORTED_SEPARATE_LEXICAL_STRATEGY` | Separate lexical verb and aspect behavior; not an alias of AA11. |
+| two-verbal-element causative-resultative | `SEPARATE_CRC_FAMILY` | Peer-reviewed research establishes independent cause/result, potential, argument, and word-order properties. |
+| resultative or potential complement | `SEPARATE_RESULT_COMPLEMENT_FAMILY` | Shared change/result meaning does not transfer AA11 identity. |
+| omitted complement after `變成` | `DISCOURSE_DEPENDENT_UNRESOLVED` | No context-free core is established without overt result material. |
+| generic `變成 + result complement` | `REAL_LEXICAL_VALENCY_NOT_ONE_AA11_CONSTRUCTION` | Nominal and multiple wh complements are attested, but their structural and semantic differences require ordinary lexical composition or later family research. |
+
+## Meaning of `點` in AA11
+
+The accepted example is:
+
+```text
+成個社會會變成點？
+```
+
+The question is not “which nominal entity will society become?” It asks about the resulting condition, state, or outcome. The parser should therefore avoid coercing `點` into an NP simply because ordinary `變成` also takes nominal results.
+
+The available evidence does not force one theory-specific category for `點`. A theory-neutral implementation may record:
+
+- overt lexical head `變成`;
+- overt wh result material `點`;
+- result-state/outcome question semantics;
+- separate question force;
+- no hidden result argument.
+
+## Current runtime comparison
+
+Canonical source inspected:
+
+- `src/parser/detectors/complements/result.js`
+
+### Exact source-linked wrapper
+
+`wrapChangeIntoPredicateSubspans` currently emits the legacy `ChangeIntoPredicate` node only for exact adjacent tokens:
+
+```text
+變成 + 點
+```
+
+This is aligned with the accepted AA11 core and appropriately excludes nominal results, aspectual `變成咗`, and `變咗做` by surface form.
+
+### Generic helper description
+
+`makeChangeIntoPredicate(changeNode, complement)` creates a node with the generic trace template:
+
+```text
+change_verb + result_complement
+```
+
+The current wrapper calls it only for `變成 + 點`, so the helper does not presently implement broad lexical valency. Its generic name, note, slots, and template nevertheless overstate the supported runtime identity and could be reused unsafely by later code.
+
+A later implementation should either:
+
+1. rename or constrain the helper to the exact AA11 profile; or
+2. keep a generic internal lexical-composition helper clearly separate from the public AA11 identity and require profile-specific callers.
+
+It must not expose every nominal or wh complement as AA11 merely because the helper accepts a `complement` argument.
+
+## Current test comparison
+
+Canonical test inspected:
+
+- `tests/constructions/ChangeIntoPredicate.json`
+
+Current coverage contains:
+
+- one positive: `成個社會會變成點？`;
+- one aspectual transformation boundary: `佢變咗做老師。`;
+- one causative-resultative boundary: `佢整冧咗間屋。`.
+
+This verifies the original repair but does not close the actual lexical and wh-complement boundary inventory.
+
+A later implementation test package should add:
+
+### Positive AA11 cells
+
+- exact `變成 + 點` without outer material;
+- overt subject + AA11;
+- higher modal + AA11 while keeping the modal outside;
+- embedded or quoted AA11 while preserving the embedding frame;
+- final question particle outside the narrow node;
+- tokenization and punctuation variants that retain exact overt material.
+
+### Neighboring wh profiles that must not silently become AA11
+
+- `變成 + 點樣`;
+- `變成 + 乜嘢`;
+- `變成 + 點樣嘅 NP`;
+- other wh words without direct profile evidence;
+- incomplete `變成點…` repairs or quotations.
+
+These should parse compositionally or remain unresolved, not be deleted or normalized.
+
+### Lexical-result and aspect boundaries
+
+- `變成 + NP`;
+- `變成咗 + NP`;
+- `變 + 咗 + 做 + NP`;
+- `變 + 緊 + 做 + NP`;
+- `成為咗 + NP`;
+- bare `變 + property`;
+- complement omission requiring discourse.
+
+### Resultative-family boundaries
+
+- two-verb causative-resultatives;
+- resultative particles;
+- potential result forms;
+- directional/result combinations;
+- disposal or passive/causative frames containing change/result material.
+
+## Span and composition contract
+
+A future AA11 implementation should:
+
+1. begin at overt `變成` and end at overt `點`;
+2. preserve both visible elements without inserting a nominal result;
+3. annotate a result-state/outcome wh relation without deciding a disputed formal category;
+4. keep subject, topic, modal, condition, embedding, quotation, focus, negation, question frame, and particles outside unless separately licensed;
+5. reject or preserve as neighboring composition all nonexact complements;
+6. avoid matching through intervening aspect, modifiers, unknown text, repairs, or clause material;
+7. keep generic lexical `變成 + complement` composition separate from the permanent AA11 identity.
+
+## Identity consequence
+
+AA11's current UUID and canonical name remain appropriate for the exact `變成 + 點` profile. No split, merge, rename, or new UUID is authorized here.
+
+However, direct evidence now confirms a broader lexical complement family. A later identity adjudication may ask whether:
+
+- `點` and `點樣` are variants within one wh-result family;
+- `乜嘢` is a distinct result-identity profile;
+- ordinary `變成 + NP` needs only lexical/transitive composition;
+- a family-level ontology can group these profiles without transferring evidence or collapsing their nodes.
+
+Until that adjudication, AA11 remains exact and narrow.
+
+## Terminal outcome
+
+- AA11 exact `變成 + 點`: `RETAIN_NARROWLY`.
+- Current exact runtime wrapper: `SOURCE_ALIGNED`.
+- Generic helper wording: `OVERBROAD_INTERNAL_DESCRIPTION_REQUIRES_CONSTRAINT`.
+- `變成 + 點樣`: `ATTESTED_NEIGHBORING_PROFILE_NOT_AA11_BY_DEFAULT`.
+- `變成 + 乜嘢`: `ATTESTED_DISTINCT_WH_DIMENSION_NOT_AA11_BY_DEFAULT`.
+- `變成 + NP`: `SUPPORTED_LEXICAL_COMPLEMENT_OUTSIDE_AA11`.
+- `變成咗 + NP`: `SUPPORTED_ASPECTUAL_PROFILE_OUTSIDE_AA11`.
+- `變…做 + NP`: `SUPPORTED_SEPARATE_STRATEGY`.
+- two-verb resultatives: `SEPARATE_CRC_FAMILY`.
+- New UUID: no.
+- Status promotion: no.
+- Runtime change in this packet: no.
+
+## Next separately claimed action
+
+After this packet merges, one Codex-eligible accepted-specification task may:
+
+1. retain the exact `變成 + 點` wrapper;
+2. constrain or rename the generic helper so it cannot broaden AA11 accidentally;
+3. make outer subject/modal/question structure visibly separate;
+4. add the controlled boundary matrix above;
+5. preserve attested `點樣`, `乜嘢`, nominal, aspectual, and `變…做` profiles without assigning them AA11;
+6. regenerate runtime outputs and run relevant checks;
+7. make no identity or linguistic-status change.
+
+## Protected-state confirmation
+
+This packet changes no runtime behavior, parser matcher, construction test, fixture, identity, code, linguistic status, corpus classification, survey, panel, held-out, release, package, or deployment state.
+
+## Source inventory
+
+See `docs/research/ISSUE-614-BINSING-DIM-SOURCE-INVENTORY-R1.md`.

--- a/docs/research/ISSUE-614-BINSING-DIM-SOURCE-INVENTORY-R1.md
+++ b/docs/research/ISSUE-614-BINSING-DIM-SOURCE-INVENTORY-R1.md
@@ -1,0 +1,143 @@
+# ISSUE-614 變成 wh-complement source inventory R1
+
+Parent issue: #614  
+Work claim: #615  
+Date: 2026-08-05
+
+## Scope
+
+This inventory evaluates the narrow AA11 identity `BinSingDimWhComplementVP`, represented by legacy runtime label `ChangeIntoPredicate`, against neighboring Cantonese transformation profiles.
+
+The accepted AA11 core is:
+
+```text
+變成 + 點
+```
+
+The review keeps the following analytically separate until direct contrastive evidence justifies a broader identity:
+
+- `變成 + 點樣`;
+- `變成 + 乜嘢`;
+- `變成 + NP`;
+- aspect-marked `變成咗 + NP`;
+- `變 + 咗／緊 + 做 + NP`;
+- `成為 + NP`;
+- two-verbal-element causative-resultative constructions;
+- bare change-of-state `變 + property`;
+- resultative and potential complements.
+
+## Source inventory
+
+| Source ID | Source and locator | Verification | Direct contribution | Limit |
+|---|---|---|---|---|
+| `SRC-ZHENG-ZHANG-GAO-2021-HK-CANTONESE-COURSE` | 鄭定歐、張勵妍、高石英. 2021. *粵語（香港話）教程（修訂版）*. User PDF p. 323 / printed p. 301: `成個社會會變成點？` | `INHERITED_VERIFIED_USER_FULL_TEXT_EXACT_LOCATOR` | Directly supports the exact `變成 + 點` profile inside a clause with an overt subject, higher modal `會`, and question force. | One pedagogical example does not establish unrestricted wh-complement productivity, a broad result-complement identity, or the parser's exact node boundaries. |
+| `SRC-LAI-PANG-2023-CANTONESE-CRC` | Ryan Ka Yau Lai and Michelle Man-Long Pang. 2023. “Rethinking the Description and Typology of Cantonese Causative–Resultative Constructions: A Dynamic Constructionist Lens.” *Languages* 8(2):151. DOI 10.3390/languages8020151. | `VERIFIED_OFFICIAL_PEER_REVIEWED_FULL_TEXT` | Defines and analyzes Cantonese causative-resultative constructions with two verbal elements and documents their argument, potential, aspect, and word-order behavior. Supports keeping two-verb resultatives distinct from lexical `變成 + complement`. | The paper does not by itself analyze `變成點` as AA11 or license a broad `變成 + result complement` parser node. |
+| `SRC-WORDSHK-BINSING` | Words.hk / 粵典 entry `變成`, current lexical entry with example `由窮光蛋變成大富翁`. | `VERIFIED_CURRENT_CANTONESE_LEXICAL_RESOURCE` | Directly supports `變成` as a lexical verb taking a nominal result complement. | Lexicographic attestation does not establish that nominal complementation and wh complementation form one Canto Span construction or have identical span/semantics. |
+| `SRC-WORDSHK-BIN` | Words.hk / 粵典 entry `變`, examples `個地盤變咗做臨時嘅停車場` and `香港逐步變緊做知識型嘅經濟體系`. | `VERIFIED_CURRENT_CANTONESE_LEXICAL_RESOURCE` | Directly supports a separate transformation strategy `變 + aspect + 做 + NP`. | It does not establish interchangeability with `變成`, nor does it make `做` a complement of AA11. |
+| `SRC-WORDSHK-KEONGJAN-BINSINGZO` | Words.hk / 粵典 entry `強人`, example `國家響佢呢個強人嘅統治下，逐漸變成咗一部井井有序嘅機器`. | `VERIFIED_CURRENT_CANTONESE_LEXICAL_RESOURCE` | Directly supports aspect-marked `變成咗 + NP`. | The example supports a lexical aspect profile, not AA11 wh complementation or unrestricted aspect placement. |
+| `SRC-MPLUS-8094-CANTONESE` | M+ Museum Audio Guide Archive, Cantonese transcript “8094”: `畢加索將普通嘅客廳變成咗奇異嘅場景`. | `VERIFIED_OFFICIAL_INSTITUTIONAL_CANTONESE_TRANSCRIPT` | Independently corroborates aspect-marked `變成咗 + NP` in edited contemporary Cantonese. | Museum narration is natural edited usage, not a grammatical analysis or productivity study. |
+| `SRC-GOLDENSCENE-DORAEMON-2024` | Golden Scene Cinema official Cantonese synopsis for *Doraemon the Movie: Nobita's Earth Symphony*: `世界少咗音樂，會變成點樣呢？` | `VERIFIED_OFFICIAL_COMMERCIAL_CANTONESE_COPY` | Directly attests neighboring `變成 + 點樣` with a higher modal and final particle. | Public copy establishes occurrence only. It does not settle whether `點樣` is a result-state predicate, manner phrase, wh complement, or tokenization variant of `點` for AA11 purposes. |
+| `SRC-PLKFLPY-2025-MAGIC` | Po Leung Kuk Women's Welfare Club Fung Lee Pui Yiu Primary School activity report, quoted student speech: `可以估吓個盒變成乜嘢`. | `VERIFIED_OFFICIAL_SCHOOL_PUBLICATION_WITH_QUOTED_CANTONESE` | Directly attests `變成 + 乜嘢`, asking the identity/category of the result. | A quoted child utterance establishes a real neighboring wh surface, not unrestricted complement productivity or identity equivalence with `變成點`. |
+| `SRC-CURRENT-PUBLIC-BINSINGDIM` | Contemporary Hong Kong public examples such as forum headings `香港會變成點?` and `如果香港冇一夫一妻制...會變成點?`. | `CORROBORATIVE_PUBLIC_ATTESTATION_ONLY` | Corroborates that exact `變成點` remains a live colloquial question surface outside the coursebook. | Forum data are not controlled, source-graded structural evidence and receive no independent weight for unrestricted productivity or parser ontology. |
+| `PROJECT-AA11-ADJUDICATION` | Permanent identity record for AA11 and Batch 02 expert adjudication. | `VERIFIED_PROJECT_DECISION_ZERO_INDEPENDENT_LINGUISTIC_WEIGHT` | Retains the exact source-linked `變成 + 點` profile and rejects silent inheritance by broad result-complement, `變咗做`, or two-verb resultative analyses. | Project adjudication organizes evidence; it cannot create new linguistic support. |
+
+## Verified profile inventory
+
+### Exact `變成 + 點`
+
+The user-provided coursebook supplies the accepted example:
+
+```text
+成個社會會變成點？
+```
+
+Public Hong Kong usage independently corroborates exact questions of the form `X 會變成點?`.
+
+The best-supported interpretation is a lexical change predicate followed by a wh expression asking about the resulting state or outcome. The evidence does not support treating `點` as an ordinary nominal entity result.
+
+### `變成 + 點樣`
+
+The Golden Scene example directly attests:
+
+```text
+世界少咗音樂，會變成點樣呢？
+```
+
+This closes the question of whether the surface occurs. It does not establish that `點` and `點樣` are freely interchangeable, have identical syntax, or should share one exact runtime identity without controlled contrasts.
+
+### `變成 + 乜嘢`
+
+The official school quotation directly attests:
+
+```text
+可以估吓個盒變成乜嘢
+```
+
+Here the wh material asks what entity or category the box becomes. This differs semantically from the result-state question in `變成點`. It belongs to the broader lexical valency of `變成` but does not automatically broaden AA11.
+
+### `變成 + NP`
+
+Words.hk directly provides:
+
+```text
+由窮光蛋變成大富翁
+```
+
+This is ordinary lexical result complementation. It establishes that the runtime helper's phrase “變成 + result complement” describes a real broader lexical pattern, but not that every such complement belongs to AA11.
+
+### Aspect-marked `變成咗 + NP`
+
+Words.hk and the M+ transcript independently attest:
+
+```text
+逐漸變成咗一部井井有序嘅機器
+將普通嘅客廳變成咗奇異嘅場景
+```
+
+Aspect follows the lexical predicate before the nominal result. This profile is outside the exact adjacent `變成 + 點` runtime node.
+
+### `變 + aspect + 做 + NP`
+
+Words.hk directly provides:
+
+```text
+個地盤變咗做臨時嘅停車場
+香港逐步變緊做知識型嘅經濟體系
+```
+
+This is a visibly different transformation strategy. The aspect marker intervenes between `變` and `做`; it must not be normalized into `變成` or AA11.
+
+### Two-verb causative-resultatives
+
+Lai and Pang analyze constructions with two verbal elements related to cause and result and document their own potential, aspect, argument, and word-order properties. Examples such as `整冧咗` belong to that independently researched family, not lexical `變成 + wh complement`.
+
+## Collision inventory
+
+The following must not receive AA11 solely because they express change or result:
+
+- `變成 + NP`;
+- `變成咗 + NP`;
+- `變 + 咗／緊 + 做 + NP`;
+- `成為 + NP`;
+- `變得 + property` or other result/property strategies;
+- two-verbal-element causative-resultatives;
+- resultative particles and potential forms;
+- bare `變 + property` change of state;
+- `點樣嘅 + NP`, where the wh phrase modifies a nominal result;
+- omitted complements recoverable only from discourse;
+- repairs, fragments, quoted strings, and incomplete questions;
+- unrelated `點` uses such as manner, degree, location, discourse response, or lexical compounds;
+- outer subject, topic, modal, condition, quotation, embedding, and sentence-final particles.
+
+## Source conflicts and unresolved questions
+
+1. `點`, `點樣`, and `乜嘢` are all attested after `變成`, but they ask different dimensions of the result. One lexical head does not imply one construction identity.
+2. The reviewed sources do not establish a complete inventory of wh complements or free alternation among them.
+3. The exact category of post-`變成` `點` remains theory-sensitive: result-state predicate, wh complement, or smaller predicative phrase are all compatible with the surface evidence.
+4. Nominal complements are clearly attested, but their ordinary lexical valency does not justify broadening AA11.
+5. Aspect and transformation strategies show distinct orders. The parser must preserve overt form rather than normalize them to one abstract “change into” node.
+6. No source here establishes unrestricted productivity, population frequency, or regional uniformity.
+
+## Evidence conclusion
+
+The exact AA11 surface `變成 + 點` is independently supported and should remain narrow. The source review additionally establishes neighboring `點樣`, `乜嘢`, nominal-result, aspect-marked, and `變…做` profiles, but their semantic and structural differences block automatic evidence transfer. The current exact runtime matcher is closer to the accepted identity than the generic helper description, while its boundary coverage remains incomplete.


### PR DESCRIPTION
## Outcome

Completes #614 through research-only claim #615.

This packet retains AA11 `BinSingDimWhComplementVP` narrowly as exact `變成 + 點`, asking about the resulting state or outcome.

## Findings

- exact `變成 + 點` remains the supported AA11 core;
- `變成 + 點樣` is directly attested as a neighboring result-state/manner wh profile but is not assigned AA11 automatically;
- `變成 + 乜嘢` is directly attested as a result identity/category question and remains a distinct wh dimension;
- `變成 + NP` and `變成咗 + NP` are supported ordinary lexical-result profiles outside AA11;
- `變 + 咗／緊 + 做 + NP` is a visibly separate transformation strategy;
- two-verbal-element causative-resultatives remain a separate research family;
- the current exact runtime wrapper is source-aligned, while its generic helper description overstates the accepted AA11 scope and should be constrained in a later implementation.

## Files

- `docs/research/ISSUE-614-BINSING-DIM-COMPLEMENT-PROFILES-R1.md`
- `docs/research/ISSUE-614-BINSING-DIM-SOURCE-INVENTORY-R1.md`

## Protected state

No runtime/parser, test/fixture, identity/code, linguistic status, corpus classification, survey, panel, held-out, release, package, or deployment change.

## Verification

- exact diff contains only the two claimed new research files;
- source records include exact locators, verification grades, and limitations;
- current identity, note, tests, runtime matcher, and generic result helper were compared without editing them;
- no overlap with Codex claim #606 or PR #607.

Closes #614
Closes #615