### PR TITLE
Research 過…未 experiential-question profiles and AA61 boundaries

### DIFF
--- a/docs/research/ISSUE-617-GWO-FINAL-MEI-PROFILES-R1.md
+++ b/docs/research/ISSUE-617-GWO-FINAL-MEI-PROFILES-R1.md
@@ -1,0 +1,199 @@
+# ISSUE-617 過…未 experiential-question profile disposition R1
+
+Parent issue: #617  
+Work claim: #618  
+Date: 2026-08-05
+
+## Decision
+
+Retain AA61 `GwoFinalMeiExperientialQuestion` narrowly for a question containing:
+
+```text
+overt experiential V過 material + clause-final 未 + optional final particle
+```
+
+The defining relation is not final `未` alone. AA61 requires an independently typed experiential child before the final marker and must remain separate from completion questions, preverbal experiential negation, `有冇 + V過`, lexical `過`, and context-dependent fragments.
+
+No hidden `有冇`, repeated negative predicate, omitted clause, or specific theoretical derivation should be inserted by the parser.
+
+## Profile dispositions
+
+| Profile | Disposition | Reason |
+|---|---|---|
+| `subject + V過 + object + 未 + particle?` | `RETAIN_AS_AA61_CORE` | Multiple independent official and scholarly sources directly attest this sequence with predicate and object variation. |
+| `subject + V過 + 未 + particle?` with recoverable object | `SUPPORTED_DISCOURSE-DEPENDENT_SHORT_PROFILE` | Naturalistic school dialogue directly attests `你食過未?` with an established food referent and reply `未食過`. |
+| affirmative `V過` | `SUPPORTED_EXPERIENTIAL_STATEMENT_OUTSIDE_AA61` | Experiential aspect without final question marker is a separate statement profile. |
+| `未 + V過` | `SUPPORTED_NEGATIVE_EXPERIENTIAL_OUTSIDE_AA61` | Preverbal `未` is an overt negative/not-yet strategy and not final AA61 `未`. |
+| `冇 + V過` | `SUPPORTED_NEGATIVE_EXPERIENTIAL_OUTSIDE_AA61` | Official CUHK material directly attests the form as a negative experiential reply. |
+| `有冇 + V過` | `SUPPORTED_SEPARATE_EXPERIENTIAL_QUESTION` | The overt suppletive polarity strategy has its own runtime/identity path and must not be normalized to final `未`. |
+| `V咗…未` | `SUPPORTED_COMPLETION_QUESTION_OUTSIDE_AA61` | Official contrastive teaching material directly attests final `未` with perfective `咗` and no experiential `過`. |
+| `V完…未` | `SUPPORTED_COMPLETION_QUESTION_OUTSIDE_AA61` | Completion/result structure is independently typed and not experiential merely because `未` is final. |
+| bare reviewed VP + final `未` | `COMPLETION_OR_CONTEXTUAL_QUESTION_NOT_AA61` | Final `未` is broader than AA61; experiential interpretation requires overt experiential structure. |
+| reply fragments `V過`, `未V過`, `冇V過` | `SEPARATE_FRAGMENT_OR_RESPONSE_COMPOSITION` | Replies are attested but do not reproduce the AA61 final-marker construction. |
+| lexical/directional `過` | `SEPARATE_LEXICAL_OR_DIRECTIONAL_PROFILE` | Surface identity of the character does not establish experiential aspect. |
+| resultative, potential, comparative, or quantifying `過` | `SEPARATE_TYPED_CONSTRUCTION` | Independently researched functions must not transfer evidence to AA61. |
+| objectless `V過未` without usable context | `AMBIGUOUS_OR_NEEDS_CONTEXT` | The source supports recoverable omission, not unrestricted context-free analysis. |
+
+## Current runtime comparison
+
+Canonical source inspected:
+
+- `src/parser/detectors/questions/completion-experiential.js`
+
+### Source-aligned behavior
+
+`experientialQuestionBoundaryFallback` requires:
+
+- a node that can fill `experiential_vp`;
+- a later node with surface `未`;
+- only text or recognized particles after final `未`.
+
+It also checks preverbal `未／冇` before the experiential VP first and routes that material to `NegativeExperiential`. The separate `experientialYesNoQuestionFallback` handles `有冇 + ExperientialVP`.
+
+These order-sensitive distinctions align with the reviewed evidence and AA61's accepted identity.
+
+### Remaining runtime–research gaps
+
+The final-`未` branch currently wraps the entire `core` after confirming only that an experiential VP occurs somewhere before `未`. It does not validate every node between the experiential VP and final marker against the trace template's claimed `topic_or_object?` slot.
+
+As a result, unrelated or untyped intervening material could potentially be absorbed into one `ExperientialQuestion` node if the tail after `未` contains only particles or text.
+
+The runtime also does not explicitly distinguish:
+
+- a full-object experiential VP from discourse-recoverable object omission;
+- an embedded or quoted final-`未` question from outer host material;
+- completion and experiential ambiguity in very short strings where upstream typing is uncertain;
+- permitted final-particle inventories and combinations;
+- lexical or directional `過` when upstream typing is wrong or absent.
+
+A later implementation should validate all intervening nodes as part of the typed experiential predicate/object structure or preserve them outside the AA61 node. It must not use arbitrary rest-of-clause capture.
+
+## Current test comparison
+
+Canonical test inspected:
+
+- `tests/constructions/ExperientialQuestion.json`
+
+Current coverage contains:
+
+- one positive: `你飲過茶未？`;
+- one preverbal-`未` negative boundary: `我未去過美國。`;
+- one `有冇 + V過` question boundary: `你有冇去過澳門呀？`.
+
+This establishes the original distinction but does not test the core's actual span and collision inventory.
+
+A later implementation test package should add:
+
+### Positive AA61 cells
+
+- intransitive or motion experiential VP + place/object + final `未`;
+- transitive experiential VP + overt nominal object + final `未`;
+- predicate and object variants documented by CUHK;
+- optional final `呀` after `未`;
+- objectless short form with an explicit test context;
+- subject visibly preserved;
+- embedded or quoted AA61 with host material preserved outside;
+- topic or temporal material kept outside unless transparently licensed.
+
+### Separate composition cells
+
+- affirmative `V過` statement;
+- preverbal `未 + V過`;
+- preverbal `冇 + V過`;
+- `有冇 + V過`;
+- positive and negative reply fragments;
+- `V咗…未` completion question;
+- `V完…未` completion question;
+- bare-VP + `未` completion question;
+- lexical/directional `過` preserved through its own analysis.
+
+### Negative and collision cells
+
+- final `未` without an experiential VP;
+- lexical `過` followed by final `未` accidentally co-occurring in a larger clause;
+- unrelated material between the experiential VP and `未`;
+- a second clause between the experiential VP and final `未`;
+- nonparticle material after `未`;
+- repairs, interruptions, quotations, and incomplete alternatives;
+- objectless short form without supplied context;
+- a specific-time perfective reading where upstream analysis is completion rather than experiential;
+- `未` inside a noun, quotation, or lexicalized string.
+
+## Final `未` representation
+
+The source record supports final position and question/polarity function. It does not require one derivational analysis.
+
+A theory-neutral AA61 node should preserve:
+
+- a typed experiential predicate or VP child;
+- any overt complement licensed inside that child;
+- overt final `未` as a final polarity/question marker;
+- optional following sentence-final particle;
+- no hidden negative VP or `有冇`;
+- explicit context dependence when complement material is omitted.
+
+The parser may record competing analyses in metadata if necessary, but it should not present ellipsis or A-not-A derivation as established fact without stronger evidence.
+
+## Span and composition contract
+
+A later AA61 implementation should:
+
+1. require an overt typed experiential child containing aspectual `過`;
+2. place final `未` after that experiential material;
+3. permit only typed complement/object material between the experiential head and final marker;
+4. reject or preserve outside all unrelated intervening material;
+5. keep outer topic, condition, quotation, embedding, focus, discourse relation, and host clause separate;
+6. preserve optional final particles as visible material and verify their allowed combinations;
+7. distinguish source-supported discourse recovery from context-free omission;
+8. keep completion, negative experiential, and `有冇` strategies separate;
+9. never infer experiential status from the characters `過` and `未` alone.
+
+## Identity consequence
+
+AA61's current UUID and canonical name correctly expose the two defining overt markers and remain appropriate. No split, merge, rename, or new UUID is authorized.
+
+Potential later family work may organize:
+
+- final-`未` experiential questions;
+- `有冇 + V過` experiential questions;
+- preverbal negative experiential profiles;
+- affirmative experiential clauses;
+- completion questions with final `未`.
+
+Family membership must not transfer identity, evidence, or runtime behavior across these profiles.
+
+## Terminal outcome
+
+- full `V過…未` profile: `RETAIN_NARROWLY_AS_AA61`.
+- objectless context-linked short form: `SUPPORTED_WITH_CONTEXT`.
+- final `未` alone: `INSUFFICIENT_FOR_AA61`.
+- current order-sensitive runtime distinction: `SOURCE_ALIGNED`.
+- current whole-core/intervening-material policy: `UNDERCONSTRAINED`.
+- preverbal `未／冇 + V過`: `SEPARATE_NEGATIVE_EXPERIENTIAL`.
+- `有冇 + V過`: `SEPARATE_EXPERIENTIAL_QUESTION`.
+- completion `V咗／V完…未`: `SEPARATE_COMPLETION_QUESTION`.
+- lexical/directional/resultative `過`: `SEPARATE_TYPED_PROFILE`.
+- formal ellipsis derivation of final `未`: `NOT_ESTABLISHED`.
+- New UUID: no.
+- Status promotion: no.
+- Runtime change in this packet: no.
+
+## Next separately claimed action
+
+After this packet merges, one Codex-eligible accepted-specification task may:
+
+1. retain the order-sensitive typed experiential + final `未` requirement;
+2. validate every intervening node rather than wrapping arbitrary core material;
+3. add explicit context-bearing short-form tests;
+4. preserve outer host and final-particle structure visibly;
+5. add the controlled completion, negation, 有冇, lexical-過, and repair matrix;
+6. regenerate runtime outputs and run relevant verification;
+7. make no identity or linguistic-status change.
+
+## Protected-state confirmation
+
+This packet changes no runtime behavior, parser matcher, construction test, fixture, identity, code, linguistic status, corpus classification, survey, panel, held-out, release, package, or deployment state.
+
+## Source inventory
+
+See `docs/research/ISSUE-617-GWO-FINAL-MEI-SOURCE-INVENTORY-R1.md`.

--- a/docs/research/ISSUE-617-GWO-FINAL-MEI-SOURCE-INVENTORY-R1.md
+++ b/docs/research/ISSUE-617-GWO-FINAL-MEI-SOURCE-INVENTORY-R1.md
@@ -1,0 +1,147 @@
+# ISSUE-617 過…未 experiential-question source inventory R1
+
+Parent issue: #617  
+Work claim: #618  
+Date: 2026-08-05
+
+## Scope
+
+This inventory evaluates AA61 `GwoFinalMeiExperientialQuestion`, represented by legacy runtime label `ExperientialQuestion`.
+
+The accepted surface core contains:
+
+```text
+overt experiential V過 material + clause-final 未 + optional final particle
+```
+
+The packet keeps the following neighboring profiles separate:
+
+- affirmative experiential `V過` statements;
+- preverbal negative experiential `未／冇 + V過`;
+- `有冇 + V過` experiential questions;
+- completion questions with `V咗…未`, `V完…未`, or a contextually completed bare VP;
+- lexical/directional `過`;
+- potential or result uses involving `過`;
+- objectless short forms licensed only by discourse;
+- reply fragments such as `食過`, `未食過`, or `冇食過`.
+
+## Source inventory
+
+| Source ID | Source and locator | Verification | Direct contribution | Limit |
+|---|---|---|---|---|
+| `SRC-MATTHEWS-YIP-2011-ASPECT-MULTIMEDIA` | Stephen Matthews and Virginia Yip. 2011. *Cantonese: A Comprehensive Grammar*, 2nd ed., official CUHK multimedia supplement, Chapter 11, section 11.2.5: `你食過醉雞未呀?` | `VERIFIED_OFFICIAL_UNIVERSITY_REFERENCE_SUPPLEMENT` | Directly supports an overt experiential predicate, overt object, final `未`, and a following sentence-final particle. | One example does not establish all predicates, object omission, embedding, or a formal ellipsis analysis of final `未`. |
+| `SRC-CUHK-ILC-EXP-FINAL-MEI` | CUHK Independent Learning Centre, Cantonese Express, Campus Life contrast page: `你去過九龍城寨公園未呀?`, `你食過煎釀三寶未呀?`, with substitution sets for places and foods. | `VERIFIED_OFFICIAL_UNIVERSITY_TEACHING_RESOURCE` | Independently establishes productive-looking predicate and object variation within the overt `V過 + object + 未呀` teaching pattern. | Substitution exercises establish controlled pedagogical coverage, not unrestricted lexical productivity, population frequency, or exact parser span. |
+| `SRC-YIP-MATTHEWS-2000-BASIC` | Virginia Yip and Stephen Matthews. 2000. *Basic Cantonese: A Grammar and Workbook*, Unit 23, PDF pp. 134-135. | `INHERITED_VERIFIED_FULL_TEXT_EXACT_LOCATOR` | Documents experiential `過`, final-`未` questions, and positive/negative response patterns. | The grammar does not by itself establish every current dialect, particle, embedding, or short-form boundary. |
+| `SRC-ZHANG-1970-PREDICATIVE-SUFFIXES` | 張洪年. 1970. Cantonese predicative-suffix discussion, pp. 467-468, cited in the current source matrix for `你飲過茶未?`. | `INHERITED_VERIFIED_SCHOLARLY_SOURCE_EXACT_LOCATOR` | Supplies an earlier scholarly example of transitive `V過 + object + final 未`. | The inherited locator was not independently re-rendered in this task. One historical description does not settle current productivity or formal analysis. |
+| `SRC-CUHK-ILC-HAVE-MOU-EXPERIENTIAL` | CUHK Independent Learning Centre, Cantonese Express, Daily Conversation 05: `你有冇食過楊枝甘露呀?` and reply `我冇食過呀`. | `VERIFIED_OFFICIAL_UNIVERSITY_TEACHING_RESOURCE` | Directly supports `有冇 + V過` as a separate experiential-question strategy and `冇 + V過` as a negative response profile. | It does not imply that 有冇 is hidden or omitted inside AA61. |
+| `SRC-CUHK-ILC-COMPLETION-MEI` | Same CUHK Daily Conversation 05 contrast page: `你睇咗書未呀?` and `我（仲）未睇`. | `VERIFIED_OFFICIAL_UNIVERSITY_TEACHING_RESOURCE` | Directly supports final `未` in a completion/not-yet question without experiential `過`. | Final `未` alone therefore cannot identify AA61. The page does not provide a complete taxonomy of completion questions. |
+| `SRC-WFB-K3-NOODLES-2025` | World Buddhist Fellowship Mantra Institute Nursery School, 2024-2025 K3 project PDF “好玩的線”: child dialogue `你食過未?` and reply `未食過!`. | `VERIFIED_OFFICIAL_SCHOOL-PUBLISHED NATURALISTIC TRANSCRIPT` | Directly attests an objectless short `V過未` question with a discourse-recoverable food referent and a preverbal-`未` experiential reply. | A classroom transcript supports occurrence and discourse recovery, not unrestricted object omission, adult population judgments, or one mandatory negative-response form. |
+| `SRC-CUHK-ILC-EXP-INVENTORY` | CUHK Cantonese Express lists `食過`, `去過`, `試過`, `見過`, and `上過` profiles. | `VERIFIED_OFFICIAL_UNIVERSITY_TEACHING_RESOURCE` | Supports lexical and predicate diversity for affirmative experiential VPs. | The inventory does not show that every listed VP occurs with final `未` in every object/adjunct configuration. |
+| `PROJECT-AA61-ADJUDICATION` | Permanent AA61 identity/adjudication record. | `VERIFIED_PROJECT_DECISION_ZERO_INDEPENDENT_LINGUISTIC_WEIGHT` | Narrows the legacy `ExperientialQuestion` name to overt `過` plus final `未` and prevents evidence transfer from 有冇 or other experiential questions. | Project adjudication organizes evidence; it cannot create linguistic support. |
+
+## Verified profile inventory
+
+### Full overt-object experiential question
+
+Direct examples include:
+
+```text
+你食過醉雞未呀？
+你去過九龍城寨公園未呀？
+你食過煎釀三寶未呀？
+你飲過茶未？
+```
+
+The recurring overt sequence is:
+
+```text
+subject + V-過 + object + 未 + optional particle
+```
+
+The sources support variation in action predicates and nominal/place complements. They do not prove unrestricted compatibility with every stative, modal, clausal complement, or aspect marker.
+
+### Objectless short question
+
+The school transcript supplies:
+
+```text
+你食過未？
+```
+
+The preceding activity establishes the food referent, and the reply is `未食過`. This supports discourse-recoverable omission. It does not license arbitrary context-free `V過未` analyses where the missing material or intended reading is unclear.
+
+### `有冇 + V過` question
+
+CUHK directly provides:
+
+```text
+你有冇食過楊枝甘露呀？
+```
+
+This is a separate overt polarity strategy. AA61 must not insert, delete, or infer `有冇`.
+
+### Negative experiential statements and replies
+
+Reviewed sources attest both:
+
+```text
+冇 + V過
+未 + V過
+```
+
+The forms may differ in not-yet, never, expectation, or discourse nuance. This packet does not collapse them or assign either to AA61, because AA61 requires final `未` after overt experiential material.
+
+### Completion question with final `未`
+
+CUHK directly contrasts:
+
+```text
+你睇咗書未呀？
+```
+
+Final `未` therefore participates in broader completion/not-yet questions. AA61 requires independently typed experiential `過`; the final marker is necessary but not sufficient.
+
+## Final `未` analysis
+
+The sources consistently place `未` after the experiential predicate/object material and before an optional final particle. Some pedagogical descriptions relate this form to an affirmative-negative alternative or an omitted negative predicate, while others simply gloss `未` as “not yet” in a final question pattern.
+
+The evidence does not require Canto Span to choose one disputed derivation. A theory-neutral record can preserve:
+
+- an overt experiential VP;
+- overt final `未`;
+- final polarity/question function;
+- optional following particle;
+- no hidden `有冇`, repeated VP, or negative clause.
+
+## Collision inventory
+
+The following must remain outside AA61 unless separately composed:
+
+- affirmative `V過` statements;
+- preverbal `未 + V過` and `冇 + V過` negatives;
+- `有冇 + V過` questions;
+- `V咗 + object + 未` completion questions;
+- `V完 + object + 未` completion questions;
+- bare-VP + final `未` completion questions without experiential `過`;
+- A-not-A questions;
+- lexical motion `過` meaning pass/cross;
+- directional, resultative, potential, quantifying, or comparative uses involving `過`;
+- `過` inside a noun, name, quotation, or unknown string;
+- final `未` followed by nonparticle clause material;
+- multiple clauses where an experiential VP and a later `未` are not one question;
+- repairs, interruptions, incomplete questions, and ambiguous short forms;
+- outer topic, condition, quotation, embedding predicate, focus, and discourse material.
+
+## Source conflicts and unresolved questions
+
+1. Final `未` has both experiential and completion uses; its function cannot be inferred without the preceding predicate structure.
+2. `未 + V過` and `冇 + V過` are both attested negative experiential profiles, but their distribution and semantic contrast require separate research.
+3. Objectless `V過未` is attested with discourse recovery; unrestricted object omission is not established.
+4. The source set does not determine whether every final particle may follow `未`, or whether particle combinations alter the construction.
+5. The sources do not settle whether final `未` is synchronically an ellipsis, a polarity marker, a question particle, or a construction-specific final predicate. The parser should remain theory-neutral.
+6. Short strings such as `食過未` can be interpreted through context; a parser cannot infer experiential versus recent-completion readings from surface form alone in every case.
+7. No source here establishes unrestricted productivity, frequency, regional uniformity, or panel sufficiency.
+
+## Evidence conclusion
+
+AA61 is well supported as a narrow overt experiential `過` plus final `未` question profile. Official sources independently establish predicate/object variation, optional following `呀`, a discourse-recoverable short form, and neighboring 有冇, negative, and completion strategies. The final marker is not unique to experiential questions, so runtime recognition must depend on a typed experiential child and controlled intervening/tail structure rather than surface co-occurrence alone.


### PR DESCRIPTION
## Outcome

Completes #617 through research-only claim #618.

This packet retains AA61 `GwoFinalMeiExperientialQuestion` narrowly for overt experiential `V過` material followed by clause-final `未` and an optional final particle.

## Findings

- official CUHK sources independently support `V過 + object + 未呀` across action, place, and food complements;
- an official school transcript directly attests discourse-recoverable short `你食過未?` with reply `未食過`;
- `有冇 + V過`, preverbal `未／冇 + V過`, completion `V咗／V完…未`, and lexical/directional `過` remain separate profiles;
- final `未` alone is insufficient to identify AA61;
- the current runtime's order-sensitive distinction is source-aligned, but its whole-core wrapper does not validate every node between the experiential child and final `未`;
- no hidden 有冇, repeated VP, ellipsis derivation, or negative clause is licensed.

## Files

- `docs/research/ISSUE-617-GWO-FINAL-MEI-PROFILES-R1.md`
- `docs/research/ISSUE-617-GWO-FINAL-MEI-SOURCE-INVENTORY-R1.md`

## Protected state

No runtime/parser, test/fixture, identity/code, linguistic status, corpus classification, survey, panel, held-out, release, package, or deployment change.

## Verification

- exact diff contains only the two claimed new research files;
- source records include exact locators, verification grades, and limitations;
- current identity, note, tests, and completion/experiential runtime paths were compared without editing them;
- no overlap with Codex claim #606 or PR #607.

Closes #617
Closes #618