### PR TITLE
Research 幫 beneficiary-coverb profiles and boundaries

### DIFF
--- a/docs/research/ISSUE-622-BONG-BENEFACTIVE-PROFILES-R1.md
+++ b/docs/research/ISSUE-622-BONG-BENEFACTIVE-PROFILES-R1.md
@@ -1,0 +1,240 @@
+# ISSUE-622 幫 beneficiary-coverb profile disposition R1
+
+Parent issue: #622  
+Work claim: #623  
+Date: 2026-08-05
+
+## Decision
+
+Retain the Week 18 `幫` route as a coherent, narrowly source-supported Cantonese benefactive/coverb profile with the core shape:
+
+```text
+subject + 幫 + overt beneficiary NP + following VP
+```
+
+The first phrase introduces the beneficiary of the event expressed by the following VP. The profile is not identified by the token `幫` alone, because Cantonese also has an ordinary transitive lexical use meaning ‘help’.
+
+This packet does not allocate a new construction identity, reuse AA18, change runtime behavior, or promote linguistic status. The current AA18 legacy `BenefactiveVP` implementation is `畀`-based; identity relation between that family and `幫` requires separate expert adjudication.
+
+## Profile dispositions
+
+| Profile | Disposition | Reason |
+|---|---|---|
+| `subject + 幫 + overt beneficiary NP + action VP` | `SOURCE_SUPPORTED_NARROW_CORE` | Multiple direct scholarly sources analyze this as a benefactive coverb/asymmetric serial-verb profile and distinguish it from lexical `幫`. |
+| `幫 + beneficiary + transitive VP + object` | `SOURCE_SUPPORTED` | Direct examples include buying a car for someone and washing dishes for someone. |
+| `幫 + beneficiary + VP-咗 + object` | `SOURCE_SUPPORTED_LOWER_VP_ASPECT` | Wong et al. directly attest `我幫你洗咗啲碗啦`. |
+| `幫 + beneficiary + VP + 啦` | `SOURCE_SUPPORTED_ONE_PARTICLE_PROFILE` | The same reference example contains clause-final `啦`. It does not establish all particles or stacks. |
+| lexical `幫 + object` with no following VP | `SEPARATE_LEXICAL_HELP_PROFILE` | Francis et al. directly contrast main-verb `ngo5 bong1 keoi5` with coverb `ngo5 bong1 keoi5 maai5 ce1`. |
+| aspect directly on coverb `幫過 + beneficiary + VP` | `SOURCE_SUGGESTED_NOT_BOUNDARY_COMPLETE` | Coverbs can bear aspect, and a preliminary `bong-gwo` extraction-context example exists, but the main controlled aspect experiment did not test `bong1` and the example is marginal. |
+| omitted/extracted beneficiary in ordinary clauses | `NOT_LICENSED_BY_CURRENT_CORE` | Coverb-object extraction is strongly dispreferred and resumptive pronouns are preferred. Gradient extraction data do not establish free ordinary-clause omission. |
+| relative-clause beneficiary gap | `GRADIENT_SPECIAL_DEPENDENCY_PROFILE` | Gaps occurred in experiments, but `bong1` strongly favored an overt resumptive pronoun. This is not an ordinary declarative template. |
+| lower-VP object extraction | `SEPARATE_FOLLOWING_VP_DEPENDENCY` | The literature distinguishes extraction from the following VP from extraction of the coverb object. |
+| `幫 + beneficiary + VP + 返嚟` | `ATTESTED_DIRECTIONAL_COMPOSITION_ONLY` | The Glossika trigger contains it; no reviewed direct source defines unrestricted directional-tail composition. |
+| bare `幫 + VP` with no beneficiary | `UNRESOLVED_OR_SEPARATE` | The direct ordinary-clause core contains an overt beneficiary; extraction evidence cannot be used as an omission rule. |
+| arbitrary stative, modal, passive, clausal, idiomatic, or multi-clause complements | `UNRESOLVED` | Reviewed examples use ordinary action predicates and do not establish unrestricted complement classes. |
+| lexicalized `幫手` | `SEPARATE_LEXICAL_PROFILE` | Lexical identity and valency differ; token overlap is insufficient. |
+| AA18 `畀`-based benefactive identity transfer | `NOT_AUTHORIZED` | Runtime and semantic similarity carry no identity authority. |
+
+## Structural interpretation
+
+### Narrow ordinary-clause composition
+
+The reviewed sources converge on an asymmetric serial structure in which:
+
+```text
+[幫 beneficiary] [following VP]
+```
+
+The first predicate contributes a beneficiary relation and modifies the event expressed by the second predicate. The subject is shared or understood across the serial structure in the ordinary examples.
+
+A theory-neutral parser specification should preserve:
+
+- overt `幫`;
+- an overt beneficiary NP as the object of the first predicate/coverb phrase;
+- a separately typed following VP;
+- any object, aspect, result, direction, or particle material only when independently licensed inside or after that VP;
+- no hidden beneficiary, covert preposition, omitted lexical-help object, or inferred event.
+
+The sources call this a coverb construction, a benefactive serial-verb construction, or an asymmetric serial construction. The parser need not choose a derivational theory, but it must preserve the two-predicate relation and the beneficiary’s attachment to `幫`.
+
+### Lexical-help boundary
+
+The direct contrast is:
+
+```text
+ngo5 bong1 keoi5
+‘I help her’
+```
+
+versus:
+
+```text
+ngo5 bong1 keoi5 maai5 ce1
+‘I buy a car for her’
+```
+
+The second predicate is therefore not optional noise. It is the principal surface evidence distinguishing the benefactive coverb profile from ordinary transitive `幫`.
+
+A future matcher must not:
+
+- label every occurrence of `幫` as benefactive;
+- relabel lexical `幫 + object` merely because the object is animate;
+- wrap arbitrary later clause material as a following VP;
+- infer a beneficiary when no licensed NP is present.
+
+## Aspect boundary
+
+### Directly supported
+
+The following-VP aspect profile is directly supported:
+
+```text
+我幫你 [洗咗啲碗] 啦。
+```
+
+A future composition may preserve the lower VP’s aspectual structure inside the benefactive relation.
+
+### Not categorically excluded, but incomplete
+
+Francis and Matthews argue that Cantonese coverbs retain verbal properties and can carry aspect. Their preliminary data include `bong-gwo` in an extraction context. However:
+
+- the example is marginal;
+- it tests extraction as well as aspect;
+- `bong1` was not among the coverbs in their main controlled aspect experiment.
+
+Accordingly, this packet rejects both overgeneralizations:
+
+- **unsupported ban:** “aspect can never occur on benefactive `幫`”; and
+- **unsupported license:** “all `幫過 + beneficiary + VP` strings instantiate the same productive core.”
+
+Direct coverb-marked `幫過` remains a separate research boundary.
+
+## Extraction and omission boundary
+
+The beneficiary is the object of the first predicate/coverb phrase, not the object of the following VP. Francis and Matthews find extraction from this position substantially worse than extraction from the following VP. Francis et al. report a strong resumptive-pronoun preference in coverb-object relative clauses; for `bong1`, 88.2% of target productions retained the pronoun.
+
+The later experiment also found some gaps, so a categorical impossibility claim would be false. The parser consequence is narrower:
+
+1. ordinary-clause recognition should require the directly supported overt beneficiary;
+2. relative-clause gaps and resumptives require their own typed dependency structure;
+3. extraction data must not become a generic beneficiary-deletion fallback;
+4. omission licensed by discourse, coordination, ellipsis, or repairs remains independently unresolved.
+
+## Directional and result composition
+
+The Week 18 trigger is:
+
+```text
+我幫你買嘢返嚟啦。
+```
+
+It is semantically coherent: `你` is the beneficiary, `買嘢返嚟` is the following event, and `啦` is final clause material. However, the learner source alone cannot establish:
+
+- whether every directional VP can follow `幫 + beneficiary`;
+- whether `返嚟` belongs inside one motion/result predicate or composes above a buying VP;
+- the exact benefactive span when additional adjuncts or clauses occur;
+- regional or lexical restrictions;
+- productivity across other directionals.
+
+A future implementation must therefore consume only an independently typed following VP. It must not scan for `幫`, take the next NP, and wrap the rest of the clause.
+
+## Collision inventory
+
+The following must remain outside the narrow core unless separately typed and composed:
+
+- ordinary lexical `幫 + object` ‘help’;
+- `幫手` and other lexicalized expressions;
+- bare `幫` fragments or replies;
+- `幫 + VP` without an overt beneficiary;
+- relative clauses with a beneficiary gap or resumptive pronoun;
+- wh-dependencies and topicalization of the beneficiary;
+- coordination or multiple following predicates;
+- quoted, embedded, conditional, focused, interrupted, or repaired material;
+- arbitrary modal, negation, passive, disposal, comparative, or clausal-complement structures;
+- untyped resultative or directional tails;
+- unrelated material after the following VP;
+- all `畀` benefactive, recipient, disposal, and passive profiles;
+- any AA18 behavior or identity inferred from semantic similarity.
+
+## Current repository comparison
+
+### Week 18 route
+
+Canonical route `W18-F08` correctly recorded:
+
+- one Glossika trigger;
+- no qualifying direct pattern-specific source at intake;
+- the risk of token-only benefactive assignment;
+- the risk of a generic `幫 + NP + VP` rule.
+
+This packet supplies the missing direct construction-level evidence and resolves the route narrowly. It does not edit the route ledger because the work claim authorizes only the issue-specific research packet.
+
+### Current runtime
+
+The inspected legacy detector `src/parser/detectors/transfer/legacy-recipient.js` defines AA18 `BenefactiveVP` around `畀` profiles. It does not establish ownership of `幫`.
+
+Consequences:
+
+- no existing UUID is reused here;
+- no canonical name is changed;
+- no new identity is allocated;
+- no runtime matcher or test is authorized;
+- an expert identity adjudication is required before implementation specification.
+
+## Identity consequence
+
+The sources establish a linguistic profile but do not determine Canto Span ontology.
+
+Plausible identity choices to adjudicate later include:
+
+1. a distinct permanent `幫` beneficiary-coverb construction;
+2. a broader benefactive family with separate `幫` and `畀` members;
+3. composition from a more general typed coverb/serial relation plus lexical entries.
+
+The current evidence does **not** authorize collapsing `幫` into AA18. AA18’s accepted identity, examples, runtime behavior, and evidence remain protected.
+
+## Terminal outcome
+
+- `幫 + overt beneficiary NP + following action VP`: `SOURCE_SUPPORTED_NARROWLY`.
+- lower-VP object: `SOURCE_SUPPORTED`.
+- lower-VP perfective `咗`: `SOURCE_SUPPORTED`.
+- final `啦`: `SOURCE_SUPPORTED_IN_ONE_PROFILE`.
+- lexical `幫 + object` ‘help’: `SEPARATE_MAIN_VERB_PROFILE`.
+- coverb-object extraction: `STRONGLY_DISPREFERRED_BUT_GRADIENT`.
+- ordinary beneficiary omission: `NOT_ESTABLISHED`.
+- aspect directly on `幫`: `NOT_CATEGORICALLY_EXCLUDED_BUT_BOUNDARY_INCOMPLETE`.
+- directional `返嚟` composition: `ATTESTATION_ONLY`.
+- unrestricted complement classes: `NOT_ESTABLISHED`.
+- AA18 identity transfer: `NOT_AUTHORIZED`.
+- new UUID: no.
+- status promotion: no.
+- runtime change: no.
+
+## Next separately claimed action
+
+The next action should be **construction-identity adjudication**, not immediate coding.
+
+That adjudication should decide whether the narrow `幫` profile receives a new permanent identity, belongs to a typed coverb family, or composes through an existing identity without evidence transfer from AA18. It should inspect the full canonical identity registry and all neighboring benefactive, recipient, serial-verb, and lexical-help records.
+
+Only after that decision should a separate implementation specification define:
+
+1. the required overt beneficiary slot;
+2. the typed following-VP contract;
+3. the lexical-main-verb boundary;
+4. lower-VP aspect and object composition;
+5. directional/result composition policy;
+6. host-clause and particle boundaries;
+7. extraction and omission exclusions;
+8. controlled positive, negative, and collision tests.
+
+A separate corpus route may extract `幫 + NP + VP` candidates for human adjudication, but raw counts or unreviewed hits must not promote the construction or settle identity.
+
+## Protected-state confirmation
+
+This packet changes no parser behavior, detector, template, test, fixture, generated output, runtime version, UUID, short code, canonical name, construction status, readiness state, corpus classification, survey, native panel, held-out evidence, release, package, or deployment state.
+
+It does not touch or depend on the Codex-owned AB33 implementation in issues #620/#621.
+
+## Source inventory
+
+See `docs/research/ISSUE-622-BONG-BENEFACTIVE-SOURCE-INVENTORY-R1.md`.

--- a/docs/research/ISSUE-622-BONG-BENEFACTIVE-SOURCE-INVENTORY-R1.md
+++ b/docs/research/ISSUE-622-BONG-BENEFACTIVE-SOURCE-INVENTORY-R1.md
@@ -1,0 +1,168 @@
+# ISSUE-622 幫 beneficiary-coverb source inventory R1
+
+Parent issue: #622  
+Work claim: #623  
+Date: 2026-08-05
+
+## Scope
+
+This inventory evaluates the unresolved Week 18 route `W18-F08`, triggered by:
+
+```text
+我幫你買嘢返嚟啦。
+```
+
+The route asks whether Cantonese has a source-supported profile in which `幫` introduces a beneficiary before a following VP. It keeps the following questions separate:
+
+- ordinary transitive `幫` meaning ‘help’;
+- benefactive/coverb `幫 + beneficiary NP + VP`;
+- aspect on `幫` itself versus aspect inside the following VP;
+- omission or extraction of the beneficiary;
+- directional material such as `返嚟` inside the following predicate;
+- sentence-final particles;
+- any identity relationship to the existing `畀`-based AA18 `BenefactiveVP` family.
+
+Parser behavior, project labels, generated examples, and the Week 18 learner source carry no independent construction-level linguistic weight.
+
+## Linguistic source inventory
+
+| Source ID | Source and locator | Evidence grade | Direct contribution | Limit |
+|---|---|---|---|---|
+| `SRC-FRANCIS-MATTHEWS-2006-COVERBS` | Elaine J. Francis and Stephen Matthews. 2006. “Categoriality and Object Extraction in Cantonese Serial Verb Constructions.” *Natural Language & Linguistic Theory* 24:751–801. DOI `10.1007/s11049-006-0005-3`; especially pp. 753, 769 and the extraction experiments. | `DIRECT_SCHOLARLY_CORE` | Defines Cantonese coverb constructions as asymmetric serial-verb structures of the form `V1 NP1 V2 (NP2)`; lists `bong1` ‘help, for’; directly illustrates `ngo5 bong1 go2 go3 jan4 zou6-je5` ‘I work for that person’; argues that coverbs retain verbal properties; and documents strong restrictions on extracting the coverb object compared with the following VP’s object. | The main 40-participant aspect experiment used other coverbs, not `bong1`. Its general aspect result must not be converted into unrestricted `幫過 + NP + VP` productivity. The preliminary `bong-gwo` example occurs in an extraction context and is marginal, not a clean positive paradigm. |
+| `SRC-FRANCIS-YUASA-2008-GRAMMATICALIZATION` | Elaine J. Francis and Etsuyo Yuasa. 2008. “A Multi-Modular Approach to Gradual Change in Grammaticalization.” *Journal of Linguistics* 44:45–86. DOI `10.1017/S0022226707004951`; Cantonese coverbs, especially pp. 61–71. | `DIRECT_SCHOLARLY_CORE` | Analyzes the coverb phrase as `[V1 NP1]` preceding and modifying the main VP in an asymmetric serial construction. Identifies `bong1` ‘for’ as deriving from ‘help’ and states that the coverb use coexists with a homophonous main verb retaining the original lexical sense. | This source establishes categorial and diachronic relations, not a complete synchronic inventory of complements, particles, aspect combinations, or parser spans. |
+| `SRC-FRANCIS-LAM-ZHENG-HITZ-MATTHEWS-2015` | Elaine J. Francis, Charles Lam, Carol Chun Zheng, John Hitz, and Stephen Matthews. 2015. “Resumptive Pronouns, Structural Complexity, and the Elusive Distinction between Grammar and Performance: Evidence from Cantonese.” *Lingua* 162:56–81. DOI `10.1016/j.lingua.2015.04.006`; examples (12c), (14), experiment materials, and coverb-object results. | `CONTROLLED_JUDGMENT_EVIDENCE` | Directly contrasts lexical main-verb `bong1` in `ngo5 bong1 keoi5` with coverb `bong1` in `ngo5 bong1 keoi5 maai5 ce1`. Treats the beneficiary as an object inside a coverb phrase adjunct to the following VP. Controlled production and judgment work found a strong preference for an overt resumptive pronoun rather than a gap in coverb-object relative clauses; `bong1` showed 88.2% resumptive-pronoun production in the target coverb-object condition. | The study concerns relative-clause dependency formation, not ordinary declarative omission. Gaps occurred in some coverb-object responses, so the result is gradient and cannot support a categorical ban. It does not license beneficiary omission in ordinary parser input. |
+| `SRC-WONG-CHEUNG-LO-WAN-2022-GACS` | Anita Mei-Yin Wong, Candice Chi-Hang Cheung, Jessica Man-Wai Lo, and Emily Ka-Hei Wan. 2022. “Grammatical Analysis of Cantonese Samples.” In *Understanding Development and Disorder in Cantonese Using Language Sample Analysis*, pp. 19–64. Routledge. DOI `10.4324/9780367824013-2`; section 14.1, p. 50. | `DIRECT_SCHOLARLY_CORE` | Classifies benefactive serial-verb constructions as expressing help or benefit, states that `幫 bong1` typically introduces the beneficiary, and gives `我幫你洗咗啲碗啦`, directly supporting an overt beneficiary, a following transitive VP, perfective aspect inside that VP, and a clause-final particle. | One descriptive example does not establish every VP class, every aspect marker, beneficiary omission, extraction, directionals, embedding, or the full sentence-final-particle inventory. |
+| `SRC-GLOSSIKA-W18-F08` | Glossika Week 18 learner source, canonical route `W18-F08`: `我幫你買嘢返嚟啦。` | `ATTESTATION_ONLY` | Attests one learner-source sequence containing `幫 + overt beneficiary + buying VP + 返嚟 + 啦`. | It is not independent construction-level analysis and cannot establish productivity, exact span, directional composition, beneficiary restrictions, or identity. |
+| `PROJECT-AA18-RUNTIME` | `src/parser/detectors/transfer/legacy-recipient.js`, current AA18 legacy detector. | `RUNTIME_OBSERVATION_ONLY` | Shows that the existing runtime label `BenefactiveVP` is implemented around `畀` profiles rather than `幫`. | Runtime organization cannot determine linguistic identity or justify transferring AA18 evidence, UUID, status, or behavior to `幫`. |
+
+## Repository-only governance record
+
+`data/research-ledgers/glossika-week18-followup-candidates.json`, route `W18-F08`, preserves the empirical trigger and blocks token-only benefactive assignment and a generic `幫 + NP + VP` rule pending direct research. This is a project work record, not a linguistic source, so it is deliberately kept outside the evidence-grade table.
+
+## Directly supported core
+
+The sources converge on a narrow ordinary-clause profile:
+
+```text
+subject + 幫 + overt beneficiary NP + following VP
+```
+
+The `幫 + beneficiary NP` phrase precedes and semantically modifies the following VP. The construction is commonly described as a coverb or benefactive serial-verb construction. The evidence supports:
+
+- an overt beneficiary object after `幫`;
+- a following action predicate;
+- lower-VP objects, as in buying a car or washing dishes;
+- perfective `咗` inside the following VP;
+- clause-final `啦` in a documented example;
+- the coexistence of a distinct lexical main-verb use of `幫` ‘help’.
+
+The label “coverb” does not mean that `幫` has lost every verbal property. Francis and Matthews and Francis and Yuasa instead argue that Cantonese coverbs retain significant verbal syntax while developing modifier-like semantics.
+
+## Lexical-help contrast
+
+Francis et al. directly contrast:
+
+```text
+ngo5 bong1 keoi5
+‘I help her’
+```
+
+with:
+
+```text
+ngo5 bong1 keoi5 maai5 ce1
+‘I buy a car for her’
+```
+
+The first has `keoi5` as the direct object of lexical `bong1`; the second has `keoi5` as the beneficiary inside a coverb phrase followed by the main predicate `maai5 ce1`.
+
+Therefore:
+
+- the token `幫` alone is insufficient for benefactive classification;
+- `幫 + NP` without a following predicate may be ordinary lexical ‘help’;
+- a typed following VP is a central discriminator for the benefactive profile;
+- surface similarity must not erase the lexical-main-verb analysis.
+
+## Aspect profile
+
+### Aspect inside the following VP
+
+Wong et al. directly provide:
+
+```text
+我幫你洗咗啲碗啦。
+```
+
+This supports aspect on the following predicate, not aspect on `幫`:
+
+```text
+幫 + beneficiary + [VP 洗咗啲碗]
+```
+
+### Aspect on the coverb
+
+Francis and Matthews argue generally that Cantonese coverbs can bear aspect and remain verbs. Their preliminary materials include a `bong-gwo` example in a coverb-object extraction context. That example is marginal, and the main controlled aspect experiment did not use `bong1`.
+
+The correct disposition is therefore:
+
+- do not impose a categorical “no aspect on `幫`” rule;
+- do not infer unrestricted `幫過 + beneficiary + VP` productivity;
+- classify coverb-marked `幫過` as `SOURCE_SUGGESTED_BUT_NOT_BOUNDARY_COMPLETE` pending direct ordinary-clause evidence.
+
+## Beneficiary extraction and omission
+
+Francis and Matthews identify the coverb object as structurally distinct from the object of the following VP and find coverb-object extraction strongly degraded relative to extraction from the following VP.
+
+Francis et al. later report gradient production and acceptability data. Resumptive pronouns were strongly preferred in coverb-object relative clauses; for `bong1`, 88.2% of target coverb-object productions contained the overt resumptive pronoun. Gaps still occurred, so the evidence is a strong preference rather than an absolute grammatical prohibition.
+
+This evidence supports a conservative parser boundary:
+
+- an overt beneficiary is part of the directly supported ordinary-clause core;
+- extraction data must not be reinterpreted as general permission to omit the beneficiary;
+- ordinary `幫 + VP` without an overt beneficiary remains unresolved unless independently licensed by context, valency, or a separate construction.
+
+## Directional and particle composition
+
+The Week 18 trigger contains:
+
+```text
+買嘢返嚟啦
+```
+
+The reviewed scholarly core establishes that the following VP may contain its own object and aspect. It does not directly establish the complete syntax or productivity of `返嚟` after every benefactive VP.
+
+Disposition:
+
+- `返嚟` in the Glossika sentence: `ATTESTED_IN_ONE_SOURCE`;
+- general directional-tail composition under the benefactive profile: `NOT_YET_BOUNDARY_COMPLETE`;
+- final `啦`: directly supported by Wong et al. in one benefactive example, but the wider particle inventory remains unresolved.
+
+## Unsupported or unresolved profiles
+
+The reviewed sources do not establish unrestricted support for:
+
+- bare `幫 + VP` with no overt beneficiary;
+- every stative, modal, passive, clausal, or idiomatic following predicate;
+- every nominal type as beneficiary, including unrestricted inanimate beneficiaries;
+- negation or modal scope at every possible position;
+- `幫過 + beneficiary + VP` as a fully productive ordinary-clause paradigm;
+- arbitrary directional/resultative chains after the following VP;
+- every sentence-final particle or particle stack;
+- A-not-A, wh-question, imperative, focus, topic, quotation, embedding, coordination, repair, or fragment profiles;
+- lexicalized `幫手` as an instance of this construction;
+- transfer of AA18 `畀` identity, evidence, tests, or status to `幫`.
+
+## Source conflicts and cautions
+
+1. The literature uses both verbal and coverb/preposition-like descriptions. The strongest reviewed analyses treat `幫` as retaining verbal syntax in a modifier-like serial construction rather than as a pure preposition.
+2. Coverb-object extraction is strongly dispreferred but gradient; a categorical island ban would overstate the later experimental evidence.
+3. Coverb aspect is generally supported, but `bong1` was not included in the main Francis and Matthews aspect experiment. A broad `幫過` rule would exceed the direct evidence.
+4. The Glossika directional example is useful attestation but cannot define parser span or productivity.
+5. The descriptive GACS example supports lower-VP `咗` and final `啦`; it does not establish the whole particle or aspect system.
+6. No reviewed source determines whether this `幫` profile should reuse, split from, or sit beside AA18. That is an identity adjudication question, not a research-source inference.
+
+## Evidence conclusion
+
+Direct Cantonese scholarship and controlled judgment evidence isolate a coherent narrow `幫 + overt beneficiary NP + following VP` profile. The profile is structurally distinct from ordinary lexical `幫 + object`, and its beneficiary behaves as the object of the first predicate/coverb phrase rather than as an object of the following VP. Lower-VP objects and lower-VP perfective aspect are directly supported. Beneficiary extraction is strongly dispreferred but gradient. Aspect directly on `幫` is not categorically excluded, yet its ordinary-clause boundary remains incomplete. Directional `返嚟` composition is currently attestation-only.
+
+The route can therefore advance from “no direct pattern-specific source” to a narrow source-supported research disposition, but not to runtime implementation, status promotion, or identity reuse without separate adjudication and specification.


### PR DESCRIPTION
Closes #622

Work claim: #623

## Outcome and scope

Resolves Week 18 route `W18-F08` narrowly through direct Cantonese scholarship and controlled judgment evidence. The packet distinguishes benefactive/coverb `幫 + overt beneficiary NP + following VP` from lexical transitive `幫` ‘help’ and records aspect, extraction, omission, directional, particle, and identity limits.

## Decisions and evidence basis

- Retain a narrow source-supported core: `subject + 幫 + overt beneficiary NP + following action VP`.
- Treat lexical `幫 + object` without a following VP as a separate main-verb profile.
- Directly support lower-VP objects, lower-VP perfective `咗`, and one final-`啦` profile.
- Treat coverb-object extraction as strongly dispreferred but gradient; do not convert relative-clause gaps into an ordinary beneficiary-omission rule.
- Do not ban aspect directly on `幫`, but do not generalize unrestricted `幫過 + NP + VP`; the direct `bong1` boundary is incomplete.
- Keep `返嚟` directional composition at attestation-only strength.
- Authorize no AA18 identity transfer, UUID allocation, status promotion, or runtime change.
- Require separate construction-identity adjudication before any implementation specification.

Primary evidence:

- Francis & Matthews 2006, *Natural Language & Linguistic Theory* 24:751–801.
- Francis & Yuasa 2008, *Journal of Linguistics* 44:45–86.
- Francis et al. 2015, *Lingua* 162:56–81.
- Wong et al. 2022, GACS chapter, section 14.1 p. 50.

## Changed files

- `docs/research/ISSUE-622-BONG-BENEFACTIVE-PROFILES-R1.md`
- `docs/research/ISSUE-622-BONG-BENEFACTIVE-SOURCE-INVENTORY-R1.md`

## Explicitly unchanged / protected

- Codex-owned AB33 scope in #620/#621.
- Parser detectors, templates, tests, fixtures, generated outputs, `main.js`, and runtime version.
- Permanent codes, UUIDs, canonical names, identity/status/readiness records.
- Corpus classifications, surveys, native-panel and held-out evidence.
- Release, packaging, and deployment state.

## Generated outputs

None.

## Validation

- Branch comparison against current base: only the two authorized new research files differ.
- Evidence grades checked against `config/research-evidence-grades.json`; only canonical grades are used.
- Fresh diff review completed after the final evidence-grade correction.
- GitHub Actions `Research provenance`: **PASS** (run 31008540456).

The connector-only environment has no local checkout, so the workflow run is the authoritative execution of `npm run verify:research` for this head.

## Unresolved issues and next action

The next separately claimed action is expert construction-identity adjudication for the `幫` profile and its relation to AA18 and other benefactive/serial constructions. Runtime implementation must wait for that decision.
