### PR TITLE
Implement AB33 preference VP boundaries

### DIFF
--- a/data/construction-candidate-readiness.json
+++ b/data/construction-candidate-readiness.json
@@ -3972,8 +3972,8 @@
       ],
       "preserved_source_ids": [],
       "future_research_preserved_as": "",
-      "standard_positive_test_count": 1,
-      "standard_boundary_test_count": 2,
+      "standard_positive_test_count": 2,
+      "standard_boundary_test_count": 12,
       "gates": {
         "language_claim_defined": {
           "status": "pass",
@@ -3995,7 +3995,7 @@
         "executable_positive_cases_present": {
           "status": "pass",
           "evidence": "executable_positive_cases_present_implementation_only",
-          "detail": "1"
+          "detail": "2"
         },
         "negative_boundaries_complete": {
           "status": "partial",

--- a/docs/current/PROJECT-STATE.md
+++ b/docs/current/PROJECT-STATE.md
@@ -120,7 +120,7 @@ All eligible respondents form one anonymized role-neutral panel. No named person
 
 - aggregate regression cases: **551**;
 - NP-subsystem cases: **43**;
-- per-construction assertions: **1,569** across **134** files;
+- per-construction assertions: **1,578** across **134** files;
 - current test coverage: 133 positive-and-boundary and 1 compatibility-alias-only construction file;
 
 Canonical documentation-verifier values:
@@ -129,7 +129,7 @@ Canonical documentation-verifier values:
 |---|---:|
 | Aggregate regression cases | 551 |
 | NP-subsystem cases | 43 |
-| Per-construction assertions | 1,569 |
+| Per-construction assertions | 1,578 |
 | Construction test files | 134 |
 
 Stable task-scoped core verification is `npm run verify`. Runtime verification is `npm run verify:runtime`. The explicit full diagnostic sweep is `npm run verify:all`; it includes core, research, runtime, generated-bundle, promotion, and release checks and is not a routine requirement for unrelated work. Passing tests and implementation reachability have zero independent linguistic evidence weight.

--- a/docs/current/PROJECT-STATE.md
+++ b/docs/current/PROJECT-STATE.md
@@ -120,7 +120,7 @@ All eligible respondents form one anonymized role-neutral panel. No named person
 
 - aggregate regression cases: **551**;
 - NP-subsystem cases: **43**;
-- per-construction assertions: **1,558** across **134** files;
+- per-construction assertions: **1,569** across **134** files;
 - current test coverage: 133 positive-and-boundary and 1 compatibility-alias-only construction file;
 
 Canonical documentation-verifier values:
@@ -129,7 +129,7 @@ Canonical documentation-verifier values:
 |---|---:|
 | Aggregate regression cases | 551 |
 | NP-subsystem cases | 43 |
-| Per-construction assertions | 1,558 |
+| Per-construction assertions | 1,569 |
 | Construction test files | 134 |
 
 Stable task-scoped core verification is `npm run verify`. Runtime verification is `npm run verify:runtime`. The explicit full diagnostic sweep is `npm run verify:all`; it includes core, research, runtime, generated-bundle, promotion, and release checks and is not a routine requirement for unrelated work. Passing tests and implementation reachability have zero independent linguistic evidence weight.

--- a/grammar/research_pending/PreferenceVP.md
+++ b/grammar/research_pending/PreferenceVP.md
@@ -47,10 +47,10 @@ independent_evidence_beyond_internal_tests: true
 promotion_gate_version: "v3"
 standard_test_file: "tests/constructions/PreferenceVP.json"
 standard_test_coverage: "positive_and_boundary"
-standard_positive_test_count: 1
-standard_boundary_test_count: 2
+standard_positive_test_count: 2
+standard_boundary_test_count: 12
 standard_implementation_probe_count: 0
-standard_executable_test_count: 3
+standard_executable_test_count: 14
 source_ids: ["SRC-LUKE-NANCARROW-1998-AUXILIARIES", "SRC-YIP-MATTHEWS-2000-BASIC"]
 runtime_active: true
 workflow_state: "archived"

--- a/main.js
+++ b/main.js
@@ -3622,12 +3622,6 @@ var require_construction_templates = __commonJS({
         note: "Prohibitive imperative: 唔好 + VP."
       },
       {
-        type: "PreferenceVP",
-        label: "Preference",
-        template: ["subject?", "preference_predicate!", "vp!", "particle?"],
-        note: "Preference predicate followed by a VP/object complement."
-      },
-      {
         type: "DegreeMannerModifiedVP",
         label: "DegMannerVP",
         template: ["degree_manner_adverbial!", "vp!", "particle?"],
@@ -9086,6 +9080,8 @@ var require_a_not_a = __commonJS({
       function copularANotAComplementCandidate(complementCore) {
         const possessive = possessiveFragmentAnswerCandidate2(complementCore);
         if (possessive) return { node: possessive, profile: "possessive_fragment" };
+        const quantifiedPreferenceClause = copularANotAQuantifiedPreferenceClauseCandidate(complementCore);
+        if (quantifiedPreferenceClause) return { node: quantifiedPreferenceClause, profile: "clausal_or_predicate" };
         const wrapped = applyConstructionPatterns2(complementCore);
         if (wrapped.length === 1 && wrapped[0] && wrapped[0].kind === "construction") {
           const candidate = wrapped[0];
@@ -9125,13 +9121,51 @@ var require_a_not_a = __commonJS({
         }
         return null;
       }
+      function copularANotAQuantifiedPreferenceClauseCandidate(complementCore) {
+        const compact = withoutIgnorableSpaceText2(applyConstructionPatterns2(complementCore));
+        if (compact.length !== 4) return null;
+        const [quantifier, subject, focus, predicate] = compact;
+        if (!isToken2(quantifier, "每")) return null;
+        if (!nodeCanFillSlot2(subject, "subject")) return null;
+        if (!isToken2(focus, "都") || !nodeCanFillSlot2(focus, "focus_adverb")) return null;
+        if (!flattenSurface2(predicate).startsWith("鍾意")) return null;
+        if (!nodeCanFillSlot2(predicate, "predicate") && !directPredicateCapableNode2(predicate)) return null;
+        const children = [quantifier, subject, focus, predicate];
+        return construction2("SubjectPredicateClause", "SubjPred", children, {
+          note: "Bounded copular A-not-A complement: 每 + overt subject + 都 + overt preference predicate.",
+          slots: cleanSlots2([
+            "subject_predicate_clause",
+            "clause",
+            "subject",
+            "focus_adverb",
+            "predicate",
+            ...templateDerivedSlots2("SubjectPredicateClause", children)
+          ]),
+          trace: traceInfo2("generative_template", {
+            construction_type: "SubjectPredicateClause",
+            template_family: "copular_a_not_a_bounded_complement",
+            template: ["distributive_quantifier!", "subject!", "focus_adverb!", "predicate!"],
+            assigned_slots: ["distributive_quantifier", "subject", "focus_adverb", "predicate"],
+            surfaces: children.map((node) => flattenSurface2(node)),
+            reason: "Keeps the sourced 每...都 preference predicate visible as a copular A-not-A complement without restoring broad PreferenceVP matching."
+          })
+        });
+      }
+      function isQuestionPunctuationText(node) {
+        if (!node || node.kind !== "text") return false;
+        return /^[?？]+$/.test(surfaceOf2(node) || node.text || "");
+      }
       function copularANotAQuestionFallback2(core) {
-        let particleStart = core.length;
-        while (particleStart > 0 && isParticle2(core[particleStart - 1]) && !isToken2(core[particleStart - 1], "嘅")) {
+        let questionCore = core;
+        while (questionCore.length && isQuestionPunctuationText(questionCore[questionCore.length - 1])) {
+          questionCore = questionCore.slice(0, -1);
+        }
+        let particleStart = questionCore.length;
+        while (particleStart > 0 && isParticle2(questionCore[particleStart - 1]) && !isToken2(questionCore[particleStart - 1], "嘅")) {
           particleStart -= 1;
         }
-        const bareCore = core.slice(0, particleStart);
-        const particles = core.slice(particleStart);
+        const bareCore = questionCore.slice(0, particleStart);
+        const particles = questionCore.slice(particleStart);
         const offset = bareCore.length >= 4 && nodeCanFillSlot2(bareCore[0], "subject") && !isToken2(bareCore[0], "係") ? 1 : 0;
         if (bareCore.length - offset < 3) return null;
         if (!isToken2(bareCore[offset], "係")) return null;
@@ -10381,7 +10415,7 @@ var require_intention_preference = __commonJS({
         });
       }
       function rawPreferenceTemplateFallback2(core) {
-        return templateConstructionFor2(core, ["PreferenceVP"]);
+        return null;
       }
       function desiderativeVPWrapCoreFallback2(core) {
         if (!hasSurface2(core, "想") || !hasSurface2(core, "好") && !hasSurface2(core, "試吓")) return null;
@@ -10394,14 +10428,7 @@ var require_intention_preference = __commonJS({
         });
       }
       function preferenceVPWrapCoreFallback2(core) {
-        if (!hasSurface2(core, "鍾意")) return null;
-        return construction2("PreferenceVP", "Preference", core, {
-          note: "Preference fallback: preference predicate taking a VP/object complement.",
-          trace: traceInfo2("construction_function", {
-            construction_type: "PreferenceVP",
-            reason: "Fallback only; generative PreferenceVP should normally catch this before ModifiedNP wrapping."
-          })
-        });
+        return null;
       }
       return {
         desiderativeVPWrapCoreFallback: desiderativeVPWrapCoreFallback2,

--- a/main.js
+++ b/main.js
@@ -8927,6 +8927,8 @@ var require_a_not_a = __commonJS({
         yesNoQuestionMarkerClone: yesNoQuestionMarkerClone2
       } = dependencies;
       function aNotAQuestionFallback2(core) {
+        const preferenceANotA = preferenceANotAQuestionFallback(core);
+        if (preferenceANotA) return preferenceANotA;
         const offset = optionalSubjectOffset2(core);
         if (core.length - offset < 3) return null;
         const first = core[offset];
@@ -8942,6 +8944,62 @@ var require_a_not_a = __commonJS({
           trace: traceInfo2("generative_or_heuristic_slot_rule", {
             rule: "subject? + verb + 唔 + copied verb + complement?",
             reason: "Structural A-not-A heuristic runs before VP subspan wrapping so the copied verb remains visible."
+          })
+        });
+      }
+      function splitFinalQuestionMaterial(core, options = {}) {
+        let questionCore = core;
+        const punctuation = [];
+        while (questionCore.length && isQuestionPunctuationText(questionCore[questionCore.length - 1])) {
+          punctuation.unshift(questionCore[questionCore.length - 1]);
+          questionCore = questionCore.slice(0, -1);
+        }
+        let particleStart = questionCore.length;
+        while (particleStart > 0 && isParticle2(questionCore[particleStart - 1]) && !(options.keepGeParticle && isToken2(questionCore[particleStart - 1], "嘅"))) {
+          particleStart -= 1;
+        }
+        return {
+          bareCore: questionCore.slice(0, particleStart),
+          particles: questionCore.slice(particleStart),
+          punctuation
+        };
+      }
+      function preferenceANotAQuestionFallback(core) {
+        const { bareCore, particles } = splitFinalQuestionMaterial(core);
+        const compact = withoutIgnorableSpaceText2(bareCore);
+        const offset = compact.length >= 5 && nodeCanFillSlot2(compact[0], "subject") ? 1 : 0;
+        if (compact.length - offset < 4) return null;
+        const firstSyllable = compact[offset];
+        const negator = compact[offset + 1];
+        const preferencePredicate = compact[offset + 2];
+        if (!isToken2(firstSyllable, "鍾") || !isToken2(negator, "唔") || !isToken2(preferencePredicate, "鍾意")) return null;
+        const complementCore = compact.slice(offset + 3);
+        if (!complementCore.length) return null;
+        const wrappedComplement = applyConstructionPatterns2(complementCore);
+        if (wrappedComplement.length !== 1) return null;
+        const complement = wrappedComplement[0];
+        const complementSlot = nodeCanFillSlot2(complement, "vp") ? "vp" : nodeCanFillSlot2(complement, "np") || nodeCanFillSlot2(complement, "object") ? "object" : "";
+        if (!complementSlot) return null;
+        const children = [...compact.slice(0, offset), firstSyllable, negator, preferencePredicate, complement, ...particles];
+        const assignedSlots = [
+          ...compact.slice(0, offset).map(() => "subject"),
+          "a_not_a_first_syllable",
+          "negator",
+          "preference_predicate",
+          complementSlot,
+          ...particles.map(() => "particle")
+        ];
+        return construction2("ANotAQuestion", "A-not-A", children, {
+          note: "Bounded first-syllable preference A-not-A question: optional subject + 鍾唔鍾意 + overt typed NP/VP complement.",
+          slots: cleanSlots2(["question_fragment", "predicate", "negator", complementSlot, ...templateDerivedSlots2("ANotAQuestion", children)]),
+          trace: traceInfo2("generative_template", {
+            construction_type: "ANotAQuestion",
+            template_family: "first_syllable_preference_a_not_a",
+            template: ["subject?", "a_not_a_first_syllable!", "negator!", "preference_predicate!", `${complementSlot}!`, "particle?"],
+            assigned_slots: assignedSlots,
+            surfaces: children.map((node) => flattenSurface2(node)),
+            copied_surface_profile: "first_syllable_plus_full_preference_predicate",
+            reason: "Preserves reviewed 鍾唔鍾意 + overt typed complement questions without reclassifying them as AB33 PreferenceVP."
           })
         });
       }
@@ -9128,8 +9186,7 @@ var require_a_not_a = __commonJS({
         if (!isToken2(quantifier, "每")) return null;
         if (!nodeCanFillSlot2(subject, "subject")) return null;
         if (!isToken2(focus, "都") || !nodeCanFillSlot2(focus, "focus_adverb")) return null;
-        if (!flattenSurface2(predicate).startsWith("鍾意")) return null;
-        if (!nodeCanFillSlot2(predicate, "predicate") && !directPredicateCapableNode2(predicate)) return null;
+        if (!isPreferencePredicateWithTypedActivityComplement(predicate)) return null;
         const children = [quantifier, subject, focus, predicate];
         return construction2("SubjectPredicateClause", "SubjPred", children, {
           note: "Bounded copular A-not-A complement: 每 + overt subject + 都 + overt preference predicate.",
@@ -9151,21 +9208,20 @@ var require_a_not_a = __commonJS({
           })
         });
       }
+      function isPreferencePredicateWithTypedActivityComplement(node) {
+        if (!node || node.kind !== "construction" || node.type !== "ModifierNP") return false;
+        const children = withoutIgnorableSpaceText2(node.children || []);
+        if (children.length !== 2 || !isToken2(children[0], "鍾意")) return false;
+        const complement = children[1];
+        if (!nodeCanFillSlot2(complement, "vp")) return false;
+        return ["TransitiveVP", "ProductiveVO", "DirectionalMotionVP", "CompoundDirectionalMotionVP", "VerbComplementVP"].includes(complement.type);
+      }
       function isQuestionPunctuationText(node) {
         if (!node || node.kind !== "text") return false;
         return /^[?？]+$/.test(surfaceOf2(node) || node.text || "");
       }
       function copularANotAQuestionFallback2(core) {
-        let questionCore = core;
-        while (questionCore.length && isQuestionPunctuationText(questionCore[questionCore.length - 1])) {
-          questionCore = questionCore.slice(0, -1);
-        }
-        let particleStart = questionCore.length;
-        while (particleStart > 0 && isParticle2(questionCore[particleStart - 1]) && !isToken2(questionCore[particleStart - 1], "嘅")) {
-          particleStart -= 1;
-        }
-        const bareCore = questionCore.slice(0, particleStart);
-        const particles = questionCore.slice(particleStart);
+        const { bareCore, particles, punctuation } = splitFinalQuestionMaterial(core, { keepGeParticle: true });
         const offset = bareCore.length >= 4 && nodeCanFillSlot2(bareCore[0], "subject") && !isToken2(bareCore[0], "係") ? 1 : 0;
         if (bareCore.length - offset < 3) return null;
         if (!isToken2(bareCore[offset], "係")) return null;
@@ -9214,14 +9270,15 @@ var require_a_not_a = __commonJS({
           slots: ["copula", "copular_negative_arm"],
           reason: "係 is the copied negative arm of the copular A-not-A question."
         });
-        const children = [...bareCore.slice(0, offset), positiveCopula, negator, negativeCopula, complement, ...particles];
+        const children = [...bareCore.slice(0, offset), positiveCopula, negator, negativeCopula, complement, ...particles, ...punctuation];
         const assignedSlots = [
           ...bareCore.slice(0, offset).map(() => "subject"),
           "copula_positive_arm",
           "negator",
           "copula_negative_arm",
           complementSlot,
-          ...particles.map(() => "particle")
+          ...particles.map(() => "particle"),
+          ...punctuation.map(() => "question_punctuation")
         ];
         return construction2("CopularANotAQuestion", "CopularQ", children, {
           note: complementCandidate.profile === "clausal_or_predicate" ? "Copular A-not-A question: optional subject/topic + 係唔係 + overt predicate or clause complement." : "Copular A-not-A question: optional subject + 係唔係 + bounded nominal or possessive complement.",
@@ -19504,6 +19561,25 @@ var require_apply_terminal_patterns = __commonJS({
           return constructionTypePresent(node.children, expectedType);
         });
       }
+      function withCopularANotATerminalQuestionSurface(nodes, terminalText = "") {
+        if (!/[？?]/u.test(String(terminalText || ""))) return nodes;
+        if (!Array.isArray(nodes) || nodes.length !== 1) return nodes;
+        const [node] = nodes;
+        if (!node || node.kind !== "construction" || node.type !== "CopularANotAQuestion") return nodes;
+        const punctuationNode = {
+          kind: "text",
+          text: terminalText,
+          trace: { kind: "punctuation_or_plain_text", surface: terminalText }
+        };
+        return [{
+          ...node,
+          children: [...node.children || [], punctuationNode],
+          trace: {
+            ...node.trace || {},
+            terminal_question_punctuation_preserved: true
+          }
+        }];
+      }
       function locativeWhQuestionForTerminal(segment, terminalText = "", ordinaryWrapped = null) {
         if (!/[？?]/u.test(String(terminalText || "")) || !segment || !segment.length) return null;
         const surface = segment.map(terminalSurface).join("");
@@ -19565,10 +19641,11 @@ var require_apply_terminal_patterns = __commonJS({
         const connectorLinked = connectorAwareClauseLinkingForTerminal2(segment);
         if (connectorLinked) return connectorLinked;
         const ordinaryWrapped = applyConstructionPatterns2(segment);
+        const terminalAwareOrdinaryWrapped = withCopularANotATerminalQuestionSurface(ordinaryWrapped, terminalText);
         const locativeWhQuestion = locativeWhQuestionForTerminal(segment, terminalText, ordinaryWrapped);
         if (locativeWhQuestion) return [locativeWhQuestion];
         const particleClusterInfo = orderedParticleClusterInfo2(segment, terminalText);
-        if (particleClusterInfo && !particleClusterInfo.supportedOrder) return ordinaryWrapped;
+        if (particleClusterInfo && !particleClusterInfo.supportedOrder) return terminalAwareOrdinaryWrapped;
         const orderedParticleCluster = orderedParticleClusterFallback2(segment, terminalText, particleClusterInfo);
         if (orderedParticleCluster) return [orderedParticleCluster];
         const restrictiveFocusParticle = restrictiveFocusParticleFallback2(segment, terminalText, ordinaryWrapped);
@@ -19583,7 +19660,7 @@ var require_apply_terminal_patterns = __commonJS({
         if (scopedEpistemicParticle) return [scopedEpistemicParticle];
         const finalMePolarQuestion = finalMePolarQuestionFallbackForPunctuation2(segment, terminalText, ordinaryWrapped);
         if (finalMePolarQuestion) return [finalMePolarQuestion];
-        return ordinaryWrapped;
+        return terminalAwareOrdinaryWrapped;
       }
       function applyConstructionPatternsByPunctuation2(nodes) {
         const boundedAcknowledgementRepetition = boundedAcknowledgementRepetitionForPunctuation2(nodes);
@@ -19600,8 +19677,10 @@ var require_apply_terminal_patterns = __commonJS({
         };
         for (const node of nodes) {
           if (node.kind === "text" && hasSentencePunctuation2(node.text)) {
+            const beforeFlushLength = rendered.length;
             flush(node.text);
-            rendered.push(node);
+            const terminalAbsorbed = rendered.length === beforeFlushLength + 1 && rendered[beforeFlushLength] && rendered[beforeFlushLength].kind === "construction" && rendered[beforeFlushLength].trace && rendered[beforeFlushLength].trace.terminal_question_punctuation_preserved;
+            if (!terminalAbsorbed) rendered.push(node);
           } else {
             segment.push(node);
           }

--- a/src/parser/detectors/modality/intention-preference.js
+++ b/src/parser/detectors/modality/intention-preference.js
@@ -64,7 +64,7 @@ module.exports = function createIntentionPreferenceDetectors(dependencies = {}) 
   }
 
   function rawPreferenceTemplateFallback(core) {
-    return templateConstructionFor(core, ["PreferenceVP"]);
+    return null;
   }
 
   function desiderativeVPWrapCoreFallback(core) {
@@ -79,14 +79,7 @@ module.exports = function createIntentionPreferenceDetectors(dependencies = {}) 
   }
 
   function preferenceVPWrapCoreFallback(core) {
-    if (!hasSurface(core, "鍾意")) return null;
-    return construction("PreferenceVP", "Preference", core, {
-      note: "Preference fallback: preference predicate taking a VP/object complement.",
-      trace: traceInfo("construction_function", {
-        construction_type: "PreferenceVP",
-        reason: "Fallback only; generative PreferenceVP should normally catch this before ModifiedNP wrapping.",
-      }),
-    });
+    return null;
   }
 
   return {

--- a/src/parser/detectors/questions/a-not-a.js
+++ b/src/parser/detectors/questions/a-not-a.js
@@ -29,6 +29,9 @@ module.exports = function createANotAQuestionDetectors(dependencies = {}) {
   } = dependencies;
 
   function aNotAQuestionFallback(core) {
+    const preferenceANotA = preferenceANotAQuestionFallback(core);
+    if (preferenceANotA) return preferenceANotA;
+
     const offset = optionalSubjectOffset(core);
     if (core.length - offset < 3) return null;
     const first = core[offset];
@@ -45,6 +48,72 @@ module.exports = function createANotAQuestionDetectors(dependencies = {}) {
         rule: "subject? + verb + 唔 + copied verb + complement?",
         reason: "Structural A-not-A heuristic runs before VP subspan wrapping so the copied verb remains visible."
       })
+    });
+  }
+
+  function splitFinalQuestionMaterial(core, options = {}) {
+    let questionCore = core;
+    const punctuation = [];
+    while (questionCore.length && isQuestionPunctuationText(questionCore[questionCore.length - 1])) {
+      punctuation.unshift(questionCore[questionCore.length - 1]);
+      questionCore = questionCore.slice(0, -1);
+    }
+    let particleStart = questionCore.length;
+    while (
+      particleStart > 0 &&
+      isParticle(questionCore[particleStart - 1]) &&
+      !(options.keepGeParticle && isToken(questionCore[particleStart - 1], "嘅"))
+    ) {
+      particleStart -= 1;
+    }
+    return {
+      bareCore: questionCore.slice(0, particleStart),
+      particles: questionCore.slice(particleStart),
+      punctuation,
+    };
+  }
+
+  function preferenceANotAQuestionFallback(core) {
+    const { bareCore, particles } = splitFinalQuestionMaterial(core);
+    const compact = withoutIgnorableSpaceText(bareCore);
+    const offset = compact.length >= 5 && nodeCanFillSlot(compact[0], "subject") ? 1 : 0;
+    if (compact.length - offset < 4) return null;
+    const firstSyllable = compact[offset];
+    const negator = compact[offset + 1];
+    const preferencePredicate = compact[offset + 2];
+    if (!isToken(firstSyllable, "鍾") || !isToken(negator, "唔") || !isToken(preferencePredicate, "鍾意")) return null;
+
+    const complementCore = compact.slice(offset + 3);
+    if (!complementCore.length) return null;
+    const wrappedComplement = applyConstructionPatterns(complementCore);
+    if (wrappedComplement.length !== 1) return null;
+    const complement = wrappedComplement[0];
+    const complementSlot = nodeCanFillSlot(complement, "vp")
+      ? "vp"
+      : (nodeCanFillSlot(complement, "np") || nodeCanFillSlot(complement, "object") ? "object" : "");
+    if (!complementSlot) return null;
+
+    const children = [...compact.slice(0, offset), firstSyllable, negator, preferencePredicate, complement, ...particles];
+    const assignedSlots = [
+      ...compact.slice(0, offset).map(() => "subject"),
+      "a_not_a_first_syllable",
+      "negator",
+      "preference_predicate",
+      complementSlot,
+      ...particles.map(() => "particle"),
+    ];
+    return construction("ANotAQuestion", "A-not-A", children, {
+      note: "Bounded first-syllable preference A-not-A question: optional subject + 鍾唔鍾意 + overt typed NP/VP complement.",
+      slots: cleanSlots(["question_fragment", "predicate", "negator", complementSlot, ...templateDerivedSlots("ANotAQuestion", children)]),
+      trace: traceInfo("generative_template", {
+        construction_type: "ANotAQuestion",
+        template_family: "first_syllable_preference_a_not_a",
+        template: ["subject?", "a_not_a_first_syllable!", "negator!", "preference_predicate!", `${complementSlot}!`, "particle?"],
+        assigned_slots: assignedSlots,
+        surfaces: children.map((node) => flattenSurface(node)),
+        copied_surface_profile: "first_syllable_plus_full_preference_predicate",
+        reason: "Preserves reviewed 鍾唔鍾意 + overt typed complement questions without reclassifying them as AB33 PreferenceVP.",
+      }),
     });
   }
 
@@ -237,8 +306,7 @@ module.exports = function createANotAQuestionDetectors(dependencies = {}) {
     if (!isToken(quantifier, "每")) return null;
     if (!nodeCanFillSlot(subject, "subject")) return null;
     if (!isToken(focus, "都") || !nodeCanFillSlot(focus, "focus_adverb")) return null;
-    if (!flattenSurface(predicate).startsWith("鍾意")) return null;
-    if (!nodeCanFillSlot(predicate, "predicate") && !directPredicateCapableNode(predicate)) return null;
+    if (!isPreferencePredicateWithTypedActivityComplement(predicate)) return null;
 
     const children = [quantifier, subject, focus, predicate];
     return construction("SubjectPredicateClause", "SubjPred", children, {
@@ -262,6 +330,15 @@ module.exports = function createANotAQuestionDetectors(dependencies = {}) {
     });
   }
 
+  function isPreferencePredicateWithTypedActivityComplement(node) {
+    if (!node || node.kind !== "construction" || node.type !== "ModifierNP") return false;
+    const children = withoutIgnorableSpaceText(node.children || []);
+    if (children.length !== 2 || !isToken(children[0], "鍾意")) return false;
+    const complement = children[1];
+    if (!nodeCanFillSlot(complement, "vp")) return false;
+    return ["TransitiveVP", "ProductiveVO", "DirectionalMotionVP", "CompoundDirectionalMotionVP", "VerbComplementVP"].includes(complement.type);
+  }
+
   function isQuestionPunctuationText(node) {
     if (!node || node.kind !== "text") return false;
     return /^[?？]+$/.test(surfaceOf(node) || node.text || "");
@@ -271,16 +348,7 @@ module.exports = function createANotAQuestionDetectors(dependencies = {}) {
     // 嘅 may close a possessive complement (你嘅), so do not strip it as a
     // sentence-final particle before complement analysis. Other final particles
     // remain outside the complement and visible at the question level.
-    let questionCore = core;
-    while (questionCore.length && isQuestionPunctuationText(questionCore[questionCore.length - 1])) {
-      questionCore = questionCore.slice(0, -1);
-    }
-    let particleStart = questionCore.length;
-    while (particleStart > 0 && isParticle(questionCore[particleStart - 1]) && !isToken(questionCore[particleStart - 1], "嘅")) {
-      particleStart -= 1;
-    }
-    const bareCore = questionCore.slice(0, particleStart);
-    const particles = questionCore.slice(particleStart);
+    const { bareCore, particles, punctuation } = splitFinalQuestionMaterial(core, { keepGeParticle: true });
     const offset = bareCore.length >= 4 && nodeCanFillSlot(bareCore[0], "subject") && !isToken(bareCore[0], "係") ? 1 : 0;
     if (bareCore.length - offset < 3) return null;
     if (!isToken(bareCore[offset], "係")) return null;
@@ -324,11 +392,12 @@ module.exports = function createANotAQuestionDetectors(dependencies = {}) {
           slots: ["copula", "copular_negative_arm"], reason: "係 is the copied negative arm of the copular A-not-A question.",
         });
 
-    const children = [...bareCore.slice(0, offset), positiveCopula, negator, negativeCopula, complement, ...particles];
+    const children = [...bareCore.slice(0, offset), positiveCopula, negator, negativeCopula, complement, ...particles, ...punctuation];
     const assignedSlots = [
       ...bareCore.slice(0, offset).map(() => "subject"),
       "copula_positive_arm", "negator", "copula_negative_arm", complementSlot,
       ...particles.map(() => "particle"),
+      ...punctuation.map(() => "question_punctuation"),
     ];
     return construction("CopularANotAQuestion", "CopularQ", children, {
       note: complementCandidate.profile === "clausal_or_predicate"

--- a/src/parser/detectors/questions/a-not-a.js
+++ b/src/parser/detectors/questions/a-not-a.js
@@ -200,6 +200,9 @@ module.exports = function createANotAQuestionDetectors(dependencies = {}) {
     const possessive = possessiveFragmentAnswerCandidate(complementCore);
     if (possessive) return { node: possessive, profile: "possessive_fragment" };
 
+    const quantifiedPreferenceClause = copularANotAQuantifiedPreferenceClauseCandidate(complementCore);
+    if (quantifiedPreferenceClause) return { node: quantifiedPreferenceClause, profile: "clausal_or_predicate" };
+
     const wrapped = applyConstructionPatterns(complementCore);
     if (wrapped.length === 1 && wrapped[0] && wrapped[0].kind === "construction") {
       const candidate = wrapped[0];
@@ -227,16 +230,57 @@ module.exports = function createANotAQuestionDetectors(dependencies = {}) {
     return null;
   }
 
+  function copularANotAQuantifiedPreferenceClauseCandidate(complementCore) {
+    const compact = withoutIgnorableSpaceText(applyConstructionPatterns(complementCore));
+    if (compact.length !== 4) return null;
+    const [quantifier, subject, focus, predicate] = compact;
+    if (!isToken(quantifier, "每")) return null;
+    if (!nodeCanFillSlot(subject, "subject")) return null;
+    if (!isToken(focus, "都") || !nodeCanFillSlot(focus, "focus_adverb")) return null;
+    if (!flattenSurface(predicate).startsWith("鍾意")) return null;
+    if (!nodeCanFillSlot(predicate, "predicate") && !directPredicateCapableNode(predicate)) return null;
+
+    const children = [quantifier, subject, focus, predicate];
+    return construction("SubjectPredicateClause", "SubjPred", children, {
+      note: "Bounded copular A-not-A complement: 每 + overt subject + 都 + overt preference predicate.",
+      slots: cleanSlots([
+        "subject_predicate_clause",
+        "clause",
+        "subject",
+        "focus_adverb",
+        "predicate",
+        ...templateDerivedSlots("SubjectPredicateClause", children),
+      ]),
+      trace: traceInfo("generative_template", {
+        construction_type: "SubjectPredicateClause",
+        template_family: "copular_a_not_a_bounded_complement",
+        template: ["distributive_quantifier!", "subject!", "focus_adverb!", "predicate!"],
+        assigned_slots: ["distributive_quantifier", "subject", "focus_adverb", "predicate"],
+        surfaces: children.map((node) => flattenSurface(node)),
+        reason: "Keeps the sourced 每...都 preference predicate visible as a copular A-not-A complement without restoring broad PreferenceVP matching.",
+      }),
+    });
+  }
+
+  function isQuestionPunctuationText(node) {
+    if (!node || node.kind !== "text") return false;
+    return /^[?？]+$/.test(surfaceOf(node) || node.text || "");
+  }
+
   function copularANotAQuestionFallback(core) {
     // 嘅 may close a possessive complement (你嘅), so do not strip it as a
     // sentence-final particle before complement analysis. Other final particles
     // remain outside the complement and visible at the question level.
-    let particleStart = core.length;
-    while (particleStart > 0 && isParticle(core[particleStart - 1]) && !isToken(core[particleStart - 1], "嘅")) {
+    let questionCore = core;
+    while (questionCore.length && isQuestionPunctuationText(questionCore[questionCore.length - 1])) {
+      questionCore = questionCore.slice(0, -1);
+    }
+    let particleStart = questionCore.length;
+    while (particleStart > 0 && isParticle(questionCore[particleStart - 1]) && !isToken(questionCore[particleStart - 1], "嘅")) {
       particleStart -= 1;
     }
-    const bareCore = core.slice(0, particleStart);
-    const particles = core.slice(particleStart);
+    const bareCore = questionCore.slice(0, particleStart);
+    const particles = questionCore.slice(particleStart);
     const offset = bareCore.length >= 4 && nodeCanFillSlot(bareCore[0], "subject") && !isToken(bareCore[0], "係") ? 1 : 0;
     if (bareCore.length - offset < 3) return null;
     if (!isToken(bareCore[offset], "係")) return null;

--- a/src/parser/orchestration/apply-terminal-patterns.js
+++ b/src/parser/orchestration/apply-terminal-patterns.js
@@ -38,6 +38,26 @@ function constructionTypePresent(nodes, expectedType) {
   });
 }
 
+function withCopularANotATerminalQuestionSurface(nodes, terminalText = "") {
+  if (!/[？?]/u.test(String(terminalText || ""))) return nodes;
+  if (!Array.isArray(nodes) || nodes.length !== 1) return nodes;
+  const [node] = nodes;
+  if (!node || node.kind !== "construction" || node.type !== "CopularANotAQuestion") return nodes;
+  const punctuationNode = {
+    kind: "text",
+    text: terminalText,
+    trace: { kind: "punctuation_or_plain_text", surface: terminalText },
+  };
+  return [{
+    ...node,
+    children: [...(node.children || []), punctuationNode],
+    trace: {
+      ...(node.trace || {}),
+      terminal_question_punctuation_preserved: true,
+    },
+  }];
+}
+
 function locativeWhQuestionForTerminal(segment, terminalText = "", ordinaryWrapped = null) {
   if (!/[？?]/u.test(String(terminalText || "")) || !segment || !segment.length) return null;
   const surface = segment.map(terminalSurface).join("");
@@ -104,10 +124,11 @@ function applyConstructionPatternsForTerminal(segment, terminalText = "") {
   const connectorLinked = connectorAwareClauseLinkingForTerminal(segment);
   if (connectorLinked) return connectorLinked;
   const ordinaryWrapped = applyConstructionPatterns(segment);
+  const terminalAwareOrdinaryWrapped = withCopularANotATerminalQuestionSurface(ordinaryWrapped, terminalText);
   const locativeWhQuestion = locativeWhQuestionForTerminal(segment, terminalText, ordinaryWrapped);
   if (locativeWhQuestion) return [locativeWhQuestion];
   const particleClusterInfo = orderedParticleClusterInfo(segment, terminalText);
-  if (particleClusterInfo && !particleClusterInfo.supportedOrder) return ordinaryWrapped;
+  if (particleClusterInfo && !particleClusterInfo.supportedOrder) return terminalAwareOrdinaryWrapped;
   const orderedParticleCluster = orderedParticleClusterFallback(segment, terminalText, particleClusterInfo);
   if (orderedParticleCluster) return [orderedParticleCluster];
   const restrictiveFocusParticle = restrictiveFocusParticleFallback(segment, terminalText, ordinaryWrapped);
@@ -122,7 +143,7 @@ function applyConstructionPatternsForTerminal(segment, terminalText = "") {
   if (scopedEpistemicParticle) return [scopedEpistemicParticle];
   const finalMePolarQuestion = finalMePolarQuestionFallbackForPunctuation(segment, terminalText, ordinaryWrapped);
   if (finalMePolarQuestion) return [finalMePolarQuestion];
-  return ordinaryWrapped;
+  return terminalAwareOrdinaryWrapped;
 }
 
 function applyConstructionPatternsByPunctuation(nodes) {
@@ -141,8 +162,14 @@ function applyConstructionPatternsByPunctuation(nodes) {
 
   for (const node of nodes) {
     if (node.kind === "text" && hasSentencePunctuation(node.text)) {
+      const beforeFlushLength = rendered.length;
       flush(node.text);
-      rendered.push(node);
+      const terminalAbsorbed = rendered.length === beforeFlushLength + 1
+        && rendered[beforeFlushLength]
+        && rendered[beforeFlushLength].kind === "construction"
+        && rendered[beforeFlushLength].trace
+        && rendered[beforeFlushLength].trace.terminal_question_punctuation_preserved;
+      if (!terminalAbsorbed) rendered.push(node);
     } else {
       segment.push(node);
     }

--- a/src/runtime-resources/grammar/templates/construction-templates.js
+++ b/src/runtime-resources/grammar/templates/construction-templates.js
@@ -259,13 +259,6 @@ module.exports = [
     note: "Prohibitive imperative: 唔好 + VP."
   },
   {
-    type: "PreferenceVP",
-    label: "Preference",
-    template: ["subject?", "preference_predicate!", "vp!", "particle?"],
-    note: "Preference predicate followed by a VP/object complement."
-  },
-
-  {
     type: "DegreeMannerModifiedVP",
     label: "DegMannerVP",
     template: ["degree_manner_adverbial!", "vp!", "particle?"],

--- a/tests/construction-test-index.json
+++ b/tests/construction-test-index.json
@@ -1507,15 +1507,15 @@
       "file": "tests/constructions/PreferenceVP.json",
       "state": "positive_and_boundary",
       "exact_snapshot_positive_count": 0,
-      "focused_positive_count": 1,
-      "focused_boundary_count": 2,
+      "focused_positive_count": 2,
+      "focused_boundary_count": 12,
       "focused_review_only_count": 0,
       "np_case_count": 0,
       "implementation_probe_count": 0,
       "compatibility_alias_probe_count": 0,
-      "positive_case_count": 1,
-      "boundary_case_count": 2,
-      "executable_case_count": 3
+      "positive_case_count": 2,
+      "boundary_case_count": 12,
+      "executable_case_count": 14
     },
     {
       "construction": "PriorityMarkerClause",

--- a/tests/construction-test-index.json
+++ b/tests/construction-test-index.json
@@ -7,15 +7,15 @@
       "file": "tests/constructions/ANotAQuestion.json",
       "state": "positive_and_boundary",
       "exact_snapshot_positive_count": 10,
-      "focused_positive_count": 0,
-      "focused_boundary_count": 2,
+      "focused_positive_count": 2,
+      "focused_boundary_count": 5,
       "focused_review_only_count": 0,
       "np_case_count": 0,
       "implementation_probe_count": 0,
       "compatibility_alias_probe_count": 0,
-      "positive_case_count": 10,
-      "boundary_case_count": 2,
-      "executable_case_count": 12
+      "positive_case_count": 12,
+      "boundary_case_count": 5,
+      "executable_case_count": 17
     },
     {
       "construction": "AcceptabilityANotA",
@@ -308,14 +308,14 @@
       "state": "positive_and_boundary",
       "exact_snapshot_positive_count": 0,
       "focused_positive_count": 2,
-      "focused_boundary_count": 1,
+      "focused_boundary_count": 4,
       "focused_review_only_count": 0,
       "np_case_count": 0,
-      "implementation_probe_count": 1,
+      "implementation_probe_count": 2,
       "compatibility_alias_probe_count": 0,
       "positive_case_count": 2,
-      "boundary_case_count": 1,
-      "executable_case_count": 4
+      "boundary_case_count": 4,
+      "executable_case_count": 8
     },
     {
       "construction": "CopularIdentificationFrame",

--- a/tests/constructions/ANotAQuestion.json
+++ b/tests/constructions/ANotAQuestion.json
@@ -97,6 +97,30 @@
   ],
   "focused_cases": [
     {
+      "case_id": "AB33-ZUNGJI-ANOTA-P01",
+      "source": "你鍾唔鍾意睇戲呀？",
+      "class": "first_syllable_preference_a_not_a_typed_vp_complement",
+      "expected_profile": "construction_present",
+      "assertion": "construction_present",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-YIP-MATTHEWS-2000-BASIC",
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-ANOTA-P02",
+      "source": "你鍾唔鍾意音樂呀？",
+      "class": "first_syllable_preference_a_not_a_typed_np_complement",
+      "expected_profile": "construction_present",
+      "assertion": "construction_present",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-YIP-MATTHEWS-2000-BASIC",
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
+    },
+    {
       "case_id": "CP061-ANA-N01",
       "source": "幾錢呀？",
       "class": "scalar_question_not_a_not_a",
@@ -121,6 +145,33 @@
         "SRC-YIP-MATTHEWS-2000-BASIC",
         "SRC-ZHENG-ZHANG-GAO-2021-HK-CANTONESE-COURSE"
       ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-ANOTA-N01",
+      "source": "你鍾唔鍾意呀？",
+      "class": "first_syllable_preference_a_not_a_requires_overt_complement",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#boundary-cells"
+    },
+    {
+      "case_id": "AB33-ZUNGJI-ANOTA-N02",
+      "source": "你鍾唔鍾意食飯你呀？",
+      "class": "first_syllable_preference_a_not_a_rejects_arbitrary_trailing_material",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#boundary-cells"
+    },
+    {
+      "case_id": "AB33-ZUNGJI-ANOTA-N03",
+      "source": "你鍾唔鍾意燒鵝定係燒鴨多啲呀？",
+      "class": "first_syllable_preference_a_not_a_does_not_absorb_alternative_scalar_material",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
     }
   ],
   "np_cases": [],
@@ -128,14 +179,14 @@
   "coverage": {
     "state": "positive_and_boundary",
     "exact_snapshot_positive_count": 10,
-    "focused_positive_count": 0,
-    "focused_boundary_count": 2,
+    "focused_positive_count": 2,
+    "focused_boundary_count": 5,
     "focused_review_only_count": 0,
     "np_case_count": 0,
     "implementation_probe_count": 0,
     "compatibility_alias_probe_count": 0,
-    "positive_case_count": 10,
-    "boundary_case_count": 2,
-    "executable_case_count": 12
+    "positive_case_count": 12,
+    "boundary_case_count": 5,
+    "executable_case_count": 17
   }
 }

--- a/tests/constructions/CopularANotAQuestion.json
+++ b/tests/constructions/CopularANotAQuestion.json
@@ -40,6 +40,36 @@
         "SRC-WONG-2023-LANGUAGE-SAMPLE"
       ],
       "source_locator": "printed p. 55 / PDF p. 65"
+    },
+    {
+      "case_id": "AB33-ZUNGJI-COPA-N01",
+      "source": "係唔係每個學生都鍾意音樂呀？",
+      "class": "copular_a_not_a_preference_np_object_outside_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-YIP-MATTHEWS-2000-BASIC"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-COPA-N02",
+      "source": "係唔係每個學生都鍾意咗個學生呀？",
+      "class": "copular_a_not_a_aspect_marked_np_preference_outside_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells"
+    },
+    {
+      "case_id": "AB33-ZUNGJI-COPA-N03",
+      "source": "係唔係每個學生都鍾意燒鵝定係燒鴨多啲呀？",
+      "class": "copular_a_not_a_alternative_scalar_preference_outside_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
     }
   ],
   "np_cases": [],
@@ -52,19 +82,32 @@
       "source_role": "candidate_unverified_corpus_item",
       "linguistic_evidence_weight": 0,
       "purpose": "runtime_reachability_only"
+    },
+    {
+      "case_id": "AB33-ZUNGJI-COPA-SURF-01",
+      "source": "係唔係每個學生都鍾意睇電視呀？",
+      "assertion": "trace_detail_equals",
+      "expected_surface": "係唔係每個學生都鍾意睇電視呀？",
+      "expected_trace_detail": {
+        "tokenization_path": "positive_copula_plus_fused_negative_copula"
+      },
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_role": "runtime_surface_fidelity_regression",
+      "linguistic_evidence_weight": 0,
+      "purpose": "runtime_reachability_only"
     }
   ],
   "coverage": {
     "state": "positive_and_boundary",
     "exact_snapshot_positive_count": 0,
     "focused_positive_count": 2,
-    "focused_boundary_count": 1,
+    "focused_boundary_count": 4,
     "focused_review_only_count": 0,
     "np_case_count": 0,
-    "implementation_probe_count": 1,
+    "implementation_probe_count": 2,
     "compatibility_alias_probe_count": 0,
     "positive_case_count": 2,
-    "boundary_case_count": 1,
-    "executable_case_count": 4
+    "boundary_case_count": 4,
+    "executable_case_count": 8
   }
 }

--- a/tests/constructions/PreferenceVP.json
+++ b/tests/constructions/PreferenceVP.json
@@ -15,6 +15,18 @@
       ]
     },
     {
+      "case_id": "AB33-ZUNGJI-P01",
+      "source": "我鍾意食飯。",
+      "class": "overt_subject_zungji_object_bearing_activity_vp",
+      "expected_profile": "construction_present",
+      "assertion": "construction_present",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#positive-retained-ab33-cells",
+      "source_ids": [
+        "SRC-YIP-MATTHEWS-2000-BASIC",
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
+    },
+    {
       "case_id": "CP060-PREF-02",
       "source": "我聽音樂。",
       "assertion": "construction_absent",
@@ -25,6 +37,116 @@
       "source": "我唔鍾意。",
       "assertion": "construction_absent",
       "provenance": "docs/research/PARSER-CONSTRUCTION-SOURCE-MATRIX-CP021B-R37.tsv#PF-C07"
+    },
+    {
+      "case_id": "AB33-ZUNGJI-N01",
+      "source": "我鍾意音樂。",
+      "class": "np_object_preference_outside_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-YIP-MATTHEWS-2000-BASIC",
+        "SRC-MATTHEWS-YIP-2011-COMPREHENSIVE-WEB"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-N02",
+      "source": "我唔鍾意落雨。",
+      "class": "negated_overt_complement_composes_outside_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-N03",
+      "source": "你鍾唔鍾意睇戲呀？",
+      "class": "first_syllable_a_not_a_composes_outside_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-YIP-MATTHEWS-2000-BASIC",
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-N04",
+      "source": "佢鍾意咗個學生。",
+      "class": "aspect_marked_np_object_preference_outside_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-CHEN-2018-CLASSIFIER-REFERENCE-ABSTRACT",
+        "SRC-LUKE-NANCARROW-1998-AUXILIARIES"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-N05",
+      "source": "鍾意呀。",
+      "class": "predicate_less_discourse_reply_outside_context_free_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#boundary-cells",
+      "source_ids": [
+        "SRC-YIP-MATTHEWS-2000-BASIC"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-N06",
+      "source": "你鍾意紅色定係黃色？",
+      "class": "alternative_choice_preference_outside_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-N07",
+      "source": "你鍾意燒鵝定係燒鴨多啲？",
+      "class": "alternative_scalar_preference_outside_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#composition-cells",
+      "source_ids": [
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-N08",
+      "source": "我鍾意佢嚟香港。",
+      "class": "finite_or_event_like_complement_not_established_as_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#boundary-cells",
+      "source_ids": [
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-N09",
+      "source": "鍾意睇戲。",
+      "class": "subjectless_preference_vp_not_ab33_core",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#boundary-cells",
+      "source_ids": [
+        "SRC-CUHK-ILC-CANTONESE-TUTORIAL-ZUNGJI"
+      ]
+    },
+    {
+      "case_id": "AB33-ZUNGJI-N10",
+      "source": "我鍾意食飯你。",
+      "class": "arbitrary_trailing_material_not_captured_by_ab33",
+      "expected_profile": "construction_absent",
+      "assertion": "construction_absent",
+      "provenance": "docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md#boundary-cells"
     }
   ],
   "np_cases": [],
@@ -32,14 +154,14 @@
   "coverage": {
     "state": "positive_and_boundary",
     "exact_snapshot_positive_count": 0,
-    "focused_positive_count": 1,
-    "focused_boundary_count": 2,
+    "focused_positive_count": 2,
+    "focused_boundary_count": 12,
     "focused_review_only_count": 0,
     "np_case_count": 0,
     "implementation_probe_count": 0,
     "compatibility_alias_probe_count": 0,
-    "positive_case_count": 1,
-    "boundary_case_count": 2,
-    "executable_case_count": 3
+    "positive_case_count": 2,
+    "boundary_case_count": 12,
+    "executable_case_count": 14
   }
 }


### PR DESCRIPTION
## Outcome and scope

Implements issue #620 for AB33 / legacy `PreferenceVP` by keeping only the source-linked `overt subject + lexical 鍾意 + typed VP/activity complement` path and removing broad token-presence/template matching.

Also preserves the existing sourced `CopularANotAQuestion` clause-complement case by adding a bounded complement wrapper for `每 + subject NP + 都 + 鍾意...predicate` inside `係唔係`, without restoring broad `PreferenceVP` behavior.

## Coordination handoff

- Intake issue: #620
- Work claim: #621
- Active worker: Codex
- Ownership revision: 2
- Branch and dependencies: `agent/ab33-zungji-vp-boundaries`; depends on #608, #609, #610, #620
- Overlapping semantic regions: none observed within the live claim
- Pending changesets or integration work: none

Closes #621.

## Canonical inputs and generated outputs

- Canonical inputs: `docs/research/ISSUE-608-ZUNGJI-COMPLEMENT-PROFILES-R1.md`, `docs/research/ISSUE-608-ZUNGJI-SOURCE-INVENTORY-R1.md`, issue #620
- Generated outputs: `main.js`, `tests/construction-test-index.json`, `grammar/research_pending/PreferenceVP.md`, `data/construction-candidate-readiness.json`
- Integration-owned files reconciled: `docs/current/PROJECT-STATE.md` construction assertion count updated from 1,558 to 1,569

## Explicitly protected or unchanged

No UUID, construction code, canonical name, linguistic status, corpus classification, survey state, native-panel state, held-out state, release state, package, or deployment changes.

No broad finite-clause complement profile is added.

## Validation

Validated head: `9e63ed6150d82b9f1e5f488d13fb83dbc3ebaf34`

- `node --check src/parser/detectors/modality/intention-preference.js` PASS
- `node --check src/parser/detectors/questions/a-not-a.js` PASS
- `node --check src/runtime-resources/grammar/templates/construction-templates.js` PASS
- `npm run build:runtime` PASS, with existing esbuild legacy HTML-comment warnings
- `node tools/build-construction-tests.js` PASS: 134 active constructions, 1,569 executable case references
- `node tools/sync-construction-test-metadata.js` PASS: updated PreferenceVP metadata
- `npm run test:constructions -- PreferenceVP` PASS: 1,569 passed, 0 failed
- `node --check main.js` PASS
- `npm run verify:runtime` PASS: 3 passed, 0 failed
- `npm run discovery:generate` PASS: 182 records, 134 current, 48 retired, 0 promotion-ready
- `npm run verify` PASS: 7 passed, 0 failed
- `npm run verify:all -- --keep-going` completed all 17 checks: 16 passed, 1 failed
- `node tools/verify-release-handoff.js` FAIL, accepted limitation: pre-existing release-handoff mismatch for `JauDakMouDakAvailabilityPredicate` against release baseline `v0.5.215`; this PR does not prepare or change a release
- `git diff --cached --check` PASS before commit

## Human merge review

- Review status: `PENDING_USER_REVIEW`
- User notified that this exact head is ready: `no`
- Explicit approval for this pull request and exact head: `not received`

Keep this PR draft until fresh review covers the exact head.

## Remaining work

No unresolved implementation dependency, pending changeset, or generated validation byproduct remains for this PR. The only full-sweep limitation is the unrelated release-handoff gate noted above.


## Review Repair Update

Fresh repair head: `b97b332881c89b2c548087b88fb4c36cff7c2368`

Addressed PR review findings:

- Added bounded first-syllable `鍾唔鍾意` A-not-A handling for overt typed NP/VP complements, with positive and collision-boundary coverage.
- Preserved terminal question punctuation in the `CopularANotAQuestion` diagnostic surface and added a surface-fidelity probe for `係唔係每個學生都鍾意睇電視呀？`.
- Tightened the copular preference complement wrapper from broad `startsWith("鍾意")` matching to exact lexical `鍾意` plus an independently typed VP/activity complement, with NP/aspect/alternative-scalar negative controls.

Repair validation:

- `node --check src/parser/detectors/questions/a-not-a.js` PASS
- `node --check src/parser/orchestration/apply-terminal-patterns.js` PASS
- `npm run build:runtime` PASS, with existing esbuild legacy HTML-comment warnings
- `npm run test:constructions -- ANotAQuestion` PASS: 1578/1578
- `npm run test:constructions -- CopularANotAQuestion` PASS: 1578/1578
- `npm run test:constructions -- PreferenceVP` PASS: 1578/1578
- `node tools/build-construction-tests.js` PASS: 134 active constructions, 1578 executable case references
- `node tools/sync-construction-test-metadata.js` PASS: updated 1
- `npm run discovery:generate` PASS: 182 records, 0 promotion-ready
- `node --check main.js` PASS
- `npm run verify:runtime` PASS: 3/3
- `npm run verify` PASS: 7/7
- `npm run verify:all -- --keep-going` completed all 17 checks: 16 PASS, 1 FAIL (`release-handoff`, same unrelated non-release baseline limitation)
- `git diff --check` PASS

No UUID, construction-code, canonical-name, linguistic-status, corpus, survey, panel, held-out, release, package, or deployment state changed.
