### PR TITLE
Research 返嚟 directional attachment and deictic boundaries

### DIFF
--- a/docs/research/ISSUE-626-FAAN-LAI-DIRECTIONAL-PROFILES-R1.md
+++ b/docs/research/ISSUE-626-FAAN-LAI-DIRECTIONAL-PROFILES-R1.md
@@ -1,0 +1,230 @@
+# ISSUE-626 返嚟 directional profile disposition R1
+
+Parent issue: #626  
+Work claim: #627  
+Date: 2026-08-05
+
+## Decision
+
+Retain a narrow source-supported Cantonese compound directional:
+
+```text
+返 + 嚟
+return + toward the speaker
+```
+
+Direct evidence also supports agentive motion with the order:
+
+```text
+co-event verb + theme object + 返嚟 + optional locative
+```
+
+However, the exact Week 18 sequence `買嘢返嚟` remains structurally and interpretively underdetermined. The reviewed sources establish neither its mover nor its event attachment. Possible goods-motion, subject-return, or multi-event analyses are hypotheses for later contextual testing, not source-derived findings.
+
+No runtime, identity, code, status, corpus, survey, or release change is authorized.
+
+## Profile dispositions
+
+| Profile | Disposition | Reason |
+|---|---|---|
+| independent `返嚟` motion predicate | `SOURCE_SUPPORTED_SEPARATE_PROFILE` | `返` and `嚟` may form a return-plus-deictic motion predicate. |
+| self-agentive `manner V + 返嚟` | `SOURCE_SUPPORTED` | Yiu directly analyzes the subject as moving theme in examples such as swimming back toward the speaker. |
+| agentive `V + theme object + 返嚟` | `SOURCE_SUPPORTED_NARROWLY` | Yiu gives `還咗本書返嚟/去`, with the object before the compound directional. |
+| `V + theme object + 返嚟 + locative` | `SOURCE_SUPPORTED_OPTIONAL_LOCATIVE_PROFILE` | The cited agentive example permits an optional destination after the directional. |
+| exact `買嘢返嚟` mover and attachment | `ATTACHMENT_NOT_ESTABLISHED_BY_CURRENT_SOURCES` | Glossika attests the string and its order is compatible with the general directional profile, but the reviewed sources do not establish whether the goods move, the subject returns, or another event structure applies. |
+| `返去` | `SOURCE_SUPPORTED_DEICTIC_CONTRAST` | It encodes return plus movement away from the speaker. |
+| `返過嚟`, `返上嚟`, other three-part directionals | `SEPARATE_DIRECTIONAL_PROFILES` | Additional path material changes the overt directional structure and object-placement boundaries. |
+| nonspatial/restorative/evaluative `返` | `SEPARATE_GRAMMATICALIZED_PROFILES` | Chor directly documents development beyond literal direction. |
+| final `啦` | `OUTER_CLAUSE_MATERIAL` | The Week 18 source attests it, but no source makes it part of `返嚟`. |
+| preceding `幫你` benefactive phrase | `SEPARATE_PROFILE_OWNED_BY_PR624_RESEARCH` | Benefactive attachment is not part of this claim. |
+
+## Directional semantics
+
+### `返`
+
+In the directional core, `返` expresses movement back toward a prior or original location. It therefore adds a return relation rather than merely indicating generic motion.
+
+This core must not absorb every `返`. Direct research also documents resumptive, restorative, evaluative, and interactional developments. Those uses require their own lexical or constructional analysis.
+
+### `嚟`
+
+The direct source claim is speaker-oriented: `嚟` contributes direction toward the speaker, while an overt locative may identify the speaker's location more precisely. A parser may preserve this deictic relation without inventing real-world coordinates. This packet does not establish reported-discourse, narrative-perspective, or other shifted deictic centers; those possibilities require separate direct evidence.
+
+### Combined `返嚟`
+
+The compound preserves both relations:
+
+```text
+RETURN + TOWARD-SPEAKER
+```
+
+`返去` preserves the return relation but reverses the deictic orientation:
+
+```text
+RETURN + AWAY-FROM-SPEAKER
+```
+
+Neither compound should be reduced to a generic motion or aspect marker.
+
+## Agent and theme boundary
+
+Yiu distinguishes two event types.
+
+### Self-agentive motion
+
+The subject is the moving theme:
+
+```text
+subject + manner/action motion + 返嚟
+```
+
+The directional describes the subject’s path.
+
+### Agentive or caused motion
+
+The subject acts on a theme object:
+
+```text
+agent subject + co-event verb + theme object + 返嚟
+```
+
+The directional describes the theme object’s change of location. The close source example uses `還` and an overt book object.
+
+A parser cannot choose between these event types merely from the characters `返嚟`. It needs a typed predicate, overt arguments, and compatible lexical semantics.
+
+## `買嘢返嚟` attachment status
+
+The string is attested in the Week 18 learner source and matches a documented object-before-directional order. The reviewed sources do not establish its mover or event attachment.
+
+The following are candidate hypotheses for later corpus or panel testing only; none is a positive finding of this packet:
+
+1. the purchased goods are the moving theme;
+2. the subject purchases the goods and then returns;
+3. the sequence receives an underspecified multi-event interpretation.
+
+No claim is made here that any candidate is natural, conventional, productive, or uniquely available. The repository must preserve the visible sequence and defer hidden-role or hidden-event assignment.
+
+## Object, aspect, and locative boundaries
+
+Directly supported close order:
+
+```text
+V-咗 + theme object + 返嚟/返去 + optional locative
+```
+
+This supports:
+
+- theme object before the compound directional;
+- perfective marking on the co-event verb in the cited profile;
+- optional following destination material.
+
+It does not authorize:
+
+- every object type;
+- every aspect marker or scope;
+- split placement of arbitrary objects inside `返嚟`;
+- unrestricted post-directional NPs;
+- automatic caused-motion readings for nonmotion verbs.
+
+## Orthographic boundary
+
+The direct Yiu source writes directional `faan1` as `翻`, while the project and common modern usage may write `返`. Preserve exact source forms in evidence records, but treat orthographic variation separately from construction identity.
+
+No parser route should:
+
+- infer direction from either character alone;
+- merge every `返/翻` occurrence;
+- allocate separate constructions solely from spelling.
+
+## Collision inventory
+
+Keep outside the narrow `返嚟` directional unless independently typed:
+
+- lexicalized words and names;
+- nonspatial `返` particles;
+- independent `返` or `嚟` without the compound relation;
+- `返上嚟`, `返過嚟`, and other larger directionals;
+- potential directionals such as `攞唔返嚟`;
+- resultatives and metaphorical path extensions;
+- coordination or serial events with an overt linker;
+- fragments, repairs, quotations, embedded clauses, and interruptions;
+- final particles and outer discourse relations;
+- the preceding benefactive `幫你` relation.
+
+## Repository comparison
+
+The current ontology already separates several neighboring records:
+
+- AA27 `ReturnUpDeicticDirectionalVP`: narrowly `返上嚟/返上去`;
+- AA47 `MannerMotionDirectionalWrapper`: heterogeneous parser aggregate;
+- AA49 `IndependentMotionPredicateVP`: independent motion predicates;
+- retired AA48 `DirectionalCausedMotionVP`.
+
+The Week 18 string does not automatically belong to any of them. In particular:
+
+- AA27 is structurally narrower and includes overt `上`;
+- AA47 is not a single settled linguistic construction;
+- AA49 excludes postverbal directional complements;
+- retirement of AA48 prevents name-based revival without fresh identity adjudication.
+
+## Identity consequence
+
+The sources establish general directional grammar but do not settle the correct Canto Span owner for `V + object + 返嚟`.
+
+A later expert adjudication may consider:
+
+1. a source-bounded caused-motion directional identity;
+2. composition from a typed event predicate, theme object, and general directional complex;
+3. separate self-agentive and agentive profiles under one family.
+
+No UUID, canonical name, family assignment, or lifecycle change is made here.
+
+## Terminal outcome
+
+- `返` directional return relation: `SOURCE_SUPPORTED`.
+- `嚟` toward-speaker deictic relation: `SOURCE_SUPPORTED`.
+- compound `返嚟`: `SOURCE_SUPPORTED`.
+- `返去` contrast: `SOURCE_SUPPORTED`.
+- agentive `V + object + 返嚟`: `SOURCE_SUPPORTED_NARROWLY`.
+- self-agentive `V + 返嚟`: `SOURCE_SUPPORTED_NARROWLY`.
+- exact `買嘢返嚟` attachment: `ATTACHMENT_NOT_ESTABLISHED_BY_CURRENT_SOURCES`.
+- purchased goods as mover: `HYPOTHESIS_ONLY_NOT_ESTABLISHED`.
+- subject as mover: `HYPOTHESIS_ONLY_NOT_ESTABLISHED`.
+- underspecified multi-event analysis: `HYPOTHESIS_ONLY_NOT_ESTABLISHED`.
+- shifted or narrative deictic center: `NOT_ESTABLISHED_BY_THIS_PACKET`.
+- generic aspect analysis: `REJECTED`.
+- nonspatial `返` merger: `REJECTED`.
+- AA27/AA47/AA49 identity transfer: `NOT_AUTHORIZED`.
+- revival of retired AA48: `NOT_AUTHORIZED`.
+- new UUID: no.
+- runtime/status change: no.
+
+## Next separately claimed action
+
+The next method should be a contextual Cantonese corpus inventory for sequences matching:
+
+```text
+買 + object + 返嚟/返去
+acquisition verb + object + return directional
+```
+
+Each hit must retain preceding destination/source context, the later discourse, the apparent mover, and whether an overt transport verb is present. Raw counts are insufficient.
+
+If reviewed corpus contexts still leave the mover or event decomposition unresolved, a blinded role-neutral interpretation task may test the candidate hypotheses:
+
+- goods brought back;
+- subject returns after purchase;
+- more than one interpretation available;
+- context required or another analysis.
+
+Only after that evidence should construction-identity adjudication or an implementation specification proceed.
+
+## Protected-state confirmation
+
+This packet changes no parser detector, runtime template, test, fixture, generated output, version, UUID, code, canonical name, status, readiness record, corpus classification, survey, panel result, held-out evidence, release, package, or deployment state.
+
+It does not modify Codex PR #625 or the `幫` research in PR #624.
+
+## Source inventory
+
+See `docs/research/ISSUE-626-FAAN-LAI-DIRECTIONAL-SOURCE-INVENTORY-R1.md`.

--- a/docs/research/ISSUE-626-FAAN-LAI-DIRECTIONAL-SOURCE-INVENTORY-R1.md
+++ b/docs/research/ISSUE-626-FAAN-LAI-DIRECTIONAL-SOURCE-INVENTORY-R1.md
@@ -1,0 +1,115 @@
+# ISSUE-626 返嚟 directional source inventory R1
+
+Parent issue: #626  
+Work claim: #627  
+Date: 2026-08-05
+
+## Scope
+
+This inventory evaluates Week 18 route `W18-F09`, triggered by:
+
+```text
+我幫你買嘢返嚟啦。
+```
+
+It separates the general Cantonese directional profile from the sentence-specific question of mover and event attachment. Goods-motion, subject-return, and multi-event analyses are retained only as candidate hypotheses for later contextual testing.
+
+## Linguistic sources
+
+| Source ID | Source and locator | Evidence grade | Direct contribution | Limit |
+|---|---|---|---|---|
+| `SRC-YIU-2013-DIRECTIONALS` | Carine Yuk-man Yiu. 2013. “Directional Verbs in Cantonese: A Typological and Historical Study.” *Language and Linguistics* 14(3):511–569; especially pp. 516–519, 543–547, examples (108), (115), (123), and Figure 4. | `DIRECT_SCHOLARLY_CORE` | Identifies `faan1` ‘return’, `lai4` ‘come’, and `heoi3` ‘go’; treats `lai4/heoi3` as speaker-oriented deictic directionals; records `faan1 + lai4/heoi3`; distinguishes self-agentive from agentive motion; and gives `佢還咗本書翻嚟/去(圖書館)`, with co-event verb + theme object + compound directional + optional locative object. | The paper uses `翻` as its spelling for directional `faan1`. The close example uses `還` ‘return’, not `買` ‘buy’, so it does not decide the mover or attachment in `買嘢返嚟`. It does not establish reported-discourse or narrative shifted centers in the material reviewed here. |
+| `SRC-CHOR-2018-DIRECTIONALS` | Winnie Chor. 2018. *Directional Particles in Cantonese: Form, Function, and Grammaticalization*. John Benjamins. DOI `10.1075/scld.9`; inherited verified locator pp. 42–45 / PDF pp. 59–63. | `DIRECT_SCHOLARLY_CORE` | Gives postverbal directional strings including `佢行返過嚟`, supporting `返` before path material and deictic `嚟` at the outer edge. | This is a three-part directional after a manner verb, not the exact two-part structure after `買嘢`. |
+| `SRC-CHOR-2013-FAAN` | Winnie Chor. 2013. “From ‘Direction’ to ‘Positive Evaluation’: On the Grammaticalization, Subjectification and Intersubjectification of `faan1` ‘return’ in Cantonese.” *Language and Linguistics* 14(1):91–134. | `DIRECT_SCHOLARLY_CORE` | Traces `faan1` from motion meaning ‘return to the original location’ into resumptive, evaluative, and tone-softening uses. | It establishes polyfunctionality and collision risk, not the constituency of the Week 18 sentence. |
+| `SRC-LAI-PANG-2023-RESULTATIVES` | Ryan Ka Yau Lai and Michelle Man-Long Pang. 2023. “Rethinking the Description and Typology of Cantonese Causative–Resultative Constructions.” *Languages* 8(2):151. DOI `10.3390/languages8020151`. | `DIRECT_SCHOLARLY_CORE` | Shows that directional material can contribute physical or extended result-state structure and documents `返` in larger directional combinations. | It does not establish that `買嘢返嚟` is one causative-resultative construction. |
+| `SRC-GLOSSIKA-W18-F09` | Glossika Week 18: `我幫你買嘢返嚟啦。` | `ATTESTATION_ONLY` | Attests the exact sequence. | It supplies insufficient context to settle mover, speaker-oriented endpoint, constituency, or productivity. |
+| `PROJECT-AA27-RUNTIME` | Current AA27 note `grammar/research_pending/CompoundDirectionalMotionVP.md` and identity `ReturnUpDeicticDirectionalVP`. | `RUNTIME_OBSERVATION_ONLY` | Shows that AA27 is narrowly retained for `返上嚟/返上去`, not all `返嚟` strings. | Runtime identity carries zero authority for assigning this route. |
+| `PROJECT-AA47-RUNTIME` | Current AA47 note `grammar/research_pending/DirectedMannerMotionVP.md` and identity `MannerMotionDirectionalWrapper`. | `RUNTIME_OBSERVATION_ONLY` | Shows that the wrapper aggregates heterogeneous motion profiles. | It is not a settled linguistic owner for `買嘢返嚟`. |
+
+## Supported directional meanings
+
+Yiu supports the following distinction:
+
+- `返 faan1`: return/back orientation toward a prior or original location;
+- `嚟 lai4`: movement toward the speaker;
+- `去 heoi3`: movement away from the speaker.
+
+Thus `返嚟` combines return with movement toward the speaker, while `返去` combines return with movement away from the speaker. An overt locative may specify the speaker's location more precisely. The reviewed material does not establish reported-discourse, narrative-perspective, or other shifted deictic centers; those possibilities require separate evidence.
+
+## Event type and object order
+
+Yiu distinguishes:
+
+- **self-agentive motion**, where the subject is the moving theme; and
+- **agentive/caused motion**, where an agent causes a theme object to change location.
+
+The close agentive example is:
+
+```text
+佢還咗本書翻嚟/去(圖書館)。
+```
+
+The paper states the order as:
+
+```text
+co-event verb + theme object + compound directional + optional locative object
+```
+
+This directly supports `V + object + 返嚟` as a Cantonese order. It does not prove that every preceding verb supplies caused motion.
+
+## Aspect and locative material
+
+The close examples place perfective `咗` after the co-event verb and before the theme object. Yiu also permits optional locative material after the compound directional in the cited profile. These are supported orders, not a license for every aspect marker, locative class, or scope relation.
+
+## The `買嘢返嚟` attachment gap
+
+The Week 18 sequence matches the supported surface order:
+
+```text
+買 + 嘢 + 返嚟
+```
+
+The exact string is attested, but the reviewed sources do not establish its mover or event attachment. The following are candidate hypotheses for later corpus or panel testing only:
+
+1. the purchased goods are the moving theme;
+2. the subject purchases the goods and then returns;
+3. the sequence receives an underspecified multi-event interpretation;
+4. another context-dependent analysis applies.
+
+None of these is a source-supported positive disposition in this packet. The sentence-level result is therefore:
+
+```text
+ATTACHMENT_NOT_ESTABLISHED_BY_CURRENT_SOURCES
+```
+
+## Orthography
+
+Yiu uses `翻` for directional `faan1`; the project trigger uses `返`. Preserve quoted spelling, but do not create separate constructions from this variation. Orthographic identity also must not merge unrelated lexical or particle uses.
+
+## Collision boundaries
+
+Keep separate:
+
+- independent motion predicate `返嚟` ‘come back’;
+- self-agentive `V + 返嚟`;
+- agentive `V + theme object + 返嚟`;
+- three-part directionals such as `返過嚟` and `返上嚟`;
+- resultative or metaphorical extensions;
+- resumptive, restorative, evaluative, or tone-softening `返`;
+- potential-directional structures;
+- lexicalized expressions, fragments, repairs, quotations, and multi-clause sequences.
+
+## Repository comparison
+
+Current identities include:
+
+- AA27 `ReturnUpDeicticDirectionalVP`, only for `返上嚟/返上去`;
+- AA47 `MannerMotionDirectionalWrapper`, an implementation aggregate;
+- AA49 `IndependentMotionPredicateVP`, for independent motion predicates;
+- retired AA48 `DirectionalCausedMotionVP`.
+
+None automatically owns `買嘢返嚟`. A retired label must not be revived merely because its name appears relevant.
+
+## Evidence conclusion
+
+Direct research supports `返嚟` as return plus speaker-oriented `嚟` and supports the order `V + theme object + 返嚟` in agentive motion. It does not determine the mover or event attachment in `買嘢返嚟`. Goods-motion, subject-return, and multi-event analyses remain candidate hypotheses only. The route therefore resolves the general directional grammar while assigning the exact sentence the terminal result `ATTACHMENT_NOT_ESTABLISHED_BY_CURRENT_SOURCES`. No runtime, status, or identity change is authorized.


### PR DESCRIPTION
Closes #626

Work claim: #627

## Outcome and scope

Resolves the general Cantonese `返嚟` directional profile while assigning the exact Week 18 `買嘢返嚟` sequence the terminal result:

```text
ATTACHMENT_NOT_ESTABLISHED_BY_CURRENT_SOURCES
```

## Decisions and evidence basis

- `返` contributes return/back orientation toward a prior or original location.
- `嚟` contributes motion toward the speaker; `去` supplies the away-from-speaker contrast.
- This packet does not establish reported-discourse, narrative-perspective, or other shifted deictic centers.
- Direct agentive-motion evidence supports `co-event verb + theme object + 返嚟/返去 + optional locative`.
- Self-agentive and agentive/caused-motion profiles remain distinct.
- Glossika attests the exact `買嘢返嚟` string, but the reviewed sources do not establish its mover or event attachment.
- Goods-motion, subject-return, and underspecified multi-event analyses are retained only as hypotheses for later contextual testing, not source-derived findings.
- Nonspatial, restorative, resumptive, evaluative, and tone-softening `返` profiles remain separate.
- No AA27/AA47/AA49 transfer and no revival of retired AA48 are authorized.
- The next method is contextual corpus review, followed by a role-neutral interpretation task only if necessary.

Primary evidence:

- Yiu 2013, *Language and Linguistics* 14(3):511–569.
- Chor 2018, *Directional Particles in Cantonese*.
- Chor 2013, *Language and Linguistics* 14(1):91–134.
- Lai & Pang 2023, *Languages* 8(2):151.

## Changed files

- `docs/research/ISSUE-626-FAAN-LAI-DIRECTIONAL-PROFILES-R1.md`
- `docs/research/ISSUE-626-FAAN-LAI-DIRECTIONAL-SOURCE-INVENTORY-R1.md`

## Explicitly protected or unchanged

- Merged AB33 implementation from PR #625.
- Merged `幫` research from PR #624.
- Parser/runtime code, tests, fixtures, generated outputs, and runtime version.
- Construction UUIDs, codes, canonical names, status, and readiness.
- Corpus classifications, surveys, panels, held-out evidence, release, packaging, and deployment.

## Generated outputs

None.

## Validation

- Exact head: `6ae244acf52d6e79bfcbc8bf9bde5c9a7361ca0d`.
- Branch is rebased onto current `main` commit `cedba4667b5678881cde0ec18236477ff1a82974`.
- Exact branch comparison contains only the two claimed new research documents.
- Evidence grades checked against `config/research-evidence-grades.json`.
- Both prior source-grounding review findings are corrected.
- GitHub Actions `Research provenance`: **PASS** (run 31016256001).

## Unresolved issue and next action

The exact mover and event attachment of `買嘢返嚟` remain unresolved. A separately claimed contextual corpus inventory should preserve surrounding discourse and apparent mover before any identity or implementation decision.
