### PR TITLE
Research 留喺屋企睇電視 attachment boundaries

### DIFF
--- a/docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-PROFILES-R1.md
+++ b/docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-PROFILES-R1.md
@@ -1,0 +1,260 @@
+# ISSUE-650 留喺 locative-activity profile disposition R1
+
+Parent issue: #650  
+Work claim: #651  
+Date: 2026-08-07
+
+## Decision
+
+Retain Week 18 I078:
+
+```text
+我留喺屋企睇電視。
+ngo5 lau4 hai2 uk1 kei2 tai2 din6 si6.
+```
+
+as a source-attested composition containing three independently visible components:
+
+```text
+我 | 留 | 喺屋企 | 睇電視
+subject | stay/remain | at home | watch television
+```
+
+The strongest evidence-supported result is:
+
+```text
+LEXICAL_STAY + OVERT_LOCATION + FOLLOWING_ACTIVITY;
+EVENT_LOCATION_AND_CIRCUMSTANCE_READINGS_COMPATIBLE;
+EXACT_ATTACHMENT_NOT_UNIQUELY_ESTABLISHED
+```
+
+Direct research supports preverbal `喺 + place` as the location of a following action. A published Cantonese coding framework independently supports `喺 + place + VP` and a circumstance serial-verb profile in which the first predicate describes the circumstance under which the second action occurs. Lexical and contextual sources attest `留喺 + place` and close `留喺屋企 + activity` strings.
+
+No inspected direct source analyzes the exact I078 string or selects one unique tree. The packet therefore does not decide whether:
+
+1. `喺屋企` is selected primarily by lexical `留`;
+2. `喺屋企` modifies the following `睇電視` event;
+3. `留喺屋企` forms the circumstance under which `睇電視` occurs;
+4. the location is shared by both predicates in a layered composition.
+
+No hidden conjunction, progressive marker, purpose relation, or omitted argument is inserted. No parser, identity, status, source, corpus, survey, release, or deployment change is authorized.
+
+## Terminal profile dispositions
+
+| Profile | Disposition | Reason |
+|---|---|---|
+| lexical `留 lau4` ‘stay/remain’ | `LEXICALLY_SUPPORTED` | Dictionary evidence defines remaining in the same place without leaving. |
+| `留 + 喺 + place` | `LEXICALLY_AND_CONTEXTUALLY_ATTESTED` | Dictionary examples and close attestations support the sequence. |
+| `喺 + place + activity VP` | `DIRECTLY_SUPPORTED_EVENT_LOCATION_PROFILE` | Kwan and Wong et al. directly support preverbal `喺` PP as action location. |
+| `留…睇電視` circumstance relation | `COMPATIBLE_WITH_DIRECT_CIRCUMSTANCE_SVC_PROFILE` | Wong et al. define a close first-predicate-as-circumstance relation, but do not analyze this exact intervening locative structure. |
+| exact I078 attachment | `UNRESOLVED_LAYERED_ATTACHMENT` | Multiple source-compatible analyses preserve the same surface and interpretation. |
+| one `留喺 + place + VP` construction | `NOT_JUSTIFIED` | No direct source establishes this as one independent productive construction. |
+| AA80 ownership of semantic role | `REJECTED` | AA80 is an implementation wrapper that explicitly does not determine role or attachment. |
+| parser/runtime change | `NOT_AUTHORIZED` | Research outcome requires later audit before any implementation decision. |
+
+## Lexical `留`
+
+Words.hk defines `留 lau4` as continuing to be active in the same place without leaving, with English glosses including ‘remain’, ‘stay’, and ‘reside’. Its examples include locative material after `留`, such as staying in a safe place.
+
+Close contextual attestations include:
+
+```text
+禮拜六日我鍾意留喺屋企煲劇。
+On weekends, I like staying home and watching a drama series for a long time.
+```
+
+and learner/pedagogical examples such as `留喺屋企休息`.
+
+These sources support lexical identity and natural contextual combinations. They do not independently define a construction-level valency rule for every `留 + 喺 + NP + VP` sequence.
+
+## Preverbal `喺 + place` event location
+
+Kwan directly contrasts Cantonese locative PP placement:
+
+```text
+[PP V]  我 喺 屋企 食 早餐
+        I at home eat breakfast
+        ‘I have breakfast at home.’
+```
+
+The article states that a preverbal locative PP indicates the location of the action, while a postverbal locative PP may indicate the participant’s resulting location after the action.
+
+Wong et al. independently define a `喺` construction in which the `喺` PP may be followed by a VP or appear alone:
+
+```text
+佢喺泳池游水。
+S/he swims at the swimming pool.
+
+佢喺泳池。
+S/he is at the swimming pool.
+```
+
+For I078, the contiguous substring:
+
+```text
+喺屋企睇電視
+at home watch television
+```
+
+therefore fits an independently supported event-location order. This does not establish whether the PP attaches only to `睇電視`, because `留` precedes it and is itself compatible with a locative continuation.
+
+## Static, event, and result-location boundaries
+
+The following profiles must remain separate:
+
+```text
+我喺屋企。
+I am at home.
+```
+
+Static locative predication contains no following activity VP.
+
+```text
+我喺屋企睇電視。
+I watch television at home.
+```
+
+Preverbal event location places the action at home.
+
+```text
+佢掉咗本書喺地下。
+S/he threw the book onto the floor.
+```
+
+Postverbal `喺` can encode a resulting or participant location. It must not inherit the same role merely because `喺` is present.
+
+I078 visibly contains lexical `留` before the PP and therefore cannot be reduced to any one of these simpler profiles without preserving the extra predicate.
+
+## `喺度` ambiguity boundary
+
+Wong et al. and the existing repository sources distinguish:
+
+```text
+我喺度做功課。
+```
+
+which may mean either ‘I do my homework here’ or ‘I am doing my homework’, depending on context. This locative/progressive ambiguity is tied to `喺度`, not to every `喺 + lexical place` phrase.
+
+I078 contains `喺屋企`, not `喺度`. No progressive aspect marker is inserted. The source English progressive wording describes the situation but is not evidence of an overt Cantonese progressive construction.
+
+## Circumstance serial-verb compatibility
+
+Wong et al. define circumstance SVCs as structures in which the first verb describes the circumstance under which the action denoted by the second verb takes place. Their example is:
+
+```text
+搭地鐵 睇書
+ride subway read book
+‘read while taking the subway’
+```
+
+I078 is semantically compatible with this relation:
+
+```text
+留喺屋企 | 睇電視
+stay at home | watch television
+```
+
+The staying-at-home situation can be understood as the circumstance during which television watching occurs. However, the direct example has no intervening locative PP inside the first predicate and does not establish that every `stay + location + activity` sequence is a circumstance SVC.
+
+The correct disposition is therefore compatibility with a documented semantic SVC subtype, not direct proof that I078 belongs to one fixed serial-verb construction.
+
+## Attachment alternatives preserved
+
+### Analysis A: lexical stay predicate plus following activity
+
+```text
+[留喺屋企] [睇電視]
+[stay at home] [watch television]
+```
+
+The first predicate describes the circumstance of the second activity.
+
+### Analysis B: stay predicate plus event-location activity phrase
+
+```text
+留 [喺屋企睇電視]
+stay [watch television at home]
+```
+
+This reflects the independently supported `喺 + place + VP` substring but may require a specific relation between `留` and the following event.
+
+### Analysis C: shared-location layered composition
+
+```text
+留 + [喺屋企] + 睇電視
+```
+
+The overt location is interpreted with both remaining and watching, without requiring exclusive syntactic attachment to either predicate.
+
+Current direct evidence does not choose among these analyses. A parser may preserve the visible components and an unresolved attachment trace rather than inventing a unique hierarchy.
+
+## Neighboring profiles excluded
+
+Keep I078 separate from:
+
+- motion-purpose chains such as `去超市買嘢`;
+- goal/result locations after an action;
+- posture SVCs such as `瞓住睇書`;
+- progressive `喺度 + VP`;
+- static `subject + 喺 + place` predication;
+- overt conjunctions such as `同埋`, `而且`, or `然後`;
+- covert purpose ‘stay in order to watch’ unless context independently supplies it;
+- complement clauses selected by cognition or speech verbs;
+- fragments that depend on a prior subject;
+- lexical senses of `留` meaning leave behind, retain an object, reserve, detain, or leave a message.
+
+## Repository consequence
+
+Current AA80 `OvertPlaceExpressionWrapper` is a parser representation over several overt spatial environments. Its accepted profile explicitly says it does not determine whether the place expression is a subject, topic, adjunct, predicate, goal, result, or coda.
+
+I078 confirms why that limitation matters. AA80 may preserve the `喺屋企` surface span, but it cannot serve as linguistic evidence for the event-location role or decide attachment to `留` versus `睇電視`.
+
+No current permanent identity found in the bounded audit directly owns the complete lexical-stay + location + activity relation. This is a possible composition gap, not an instruction to allocate a UUID.
+
+## Terminal outcome
+
+- `留` stay/remain: `LEXICALLY_SUPPORTED`.
+- `留喺 + place`: `CONTEXTUALLY_ATTESTED`.
+- `喺 + place + VP`: `DIRECTLY_SUPPORTED_EVENT_LOCATION_PROFILE`.
+- circumstance relation: `DIRECTLY_DOCUMENTED_CLOSE_PROFILE`.
+- I078: `SUPPORTED_COMPONENTS_WITH_UNRESOLVED_ATTACHMENT`.
+- exact circumstance-SVC classification: `COMPATIBLE_NOT_ESTABLISHED`.
+- progressive analysis: `NOT_SUPPORTED_BY_OVERT_FORM`.
+- purpose relation: `NOT_ESTABLISHED`.
+- AA80 semantic-role transfer: `NOT_AUTHORIZED`.
+- new UUID/runtime/status change: no.
+
+## Next separately claimed action
+
+Open one bounded parser-output audit for I078 and controlled contrasts. It should test whether current output preserves:
+
+1. lexical `留` as an overt predicate;
+2. the complete `喺屋企` place span;
+3. `睇電視` as a following activity VP;
+4. one overt subject without inserting a second subject;
+5. no hidden conjunction, purpose marker, or progressive marker;
+6. AA80 only as a role-neutral compatibility wrapper, if it appears;
+7. punctuation and full surface fidelity.
+
+Contrast set:
+
+- `我留喺屋企。`
+- `我喺屋企睇電視。`
+- `我留喺屋企睇電視。`
+- `我喺度睇電視。`
+- a postverbal result-location example;
+- a motion-purpose example;
+- a posture SVC example;
+- lexical non-locative `留` examples.
+
+A contextual corpus inventory should then collect `留喺 + place + activity` examples with full surrounding context. Only if the corpus and parser audit expose a stable relation not preserved compositionally should a separate identity/composition issue be opened.
+
+## Protected-state confirmation
+
+This packet changes no immutable source value, parser detector, runtime template, test, generated output, version, UUID, code, canonical name, linguistic status, readiness record, corpus classification, survey, panel result, held-out evidence, release, package, or deployment state.
+
+It does not modify active AB33 or AA84 scopes.
+
+## Source inventory
+
+See `docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-SOURCE-INVENTORY-R1.md`.

--- a/docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-PROFILES-R1.md
+++ b/docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-PROFILES-R1.md
@@ -13,14 +13,14 @@ Retain Week 18 I078:
 ngo5 lau4 hai2 uk1 kei2 tai2 din6 si6.
 ```
 
-as a source-attested composition containing three independently visible components:
+as a source-attested composition with three independently visible components:
 
 ```text
 我 | 留 | 喺屋企 | 睇電視
 subject | stay/remain | at home | watch television
 ```
 
-The strongest evidence-supported result is:
+Terminal result:
 
 ```text
 LEXICAL_STAY + OVERT_LOCATION + FOLLOWING_ACTIVITY;
@@ -28,14 +28,15 @@ EVENT_LOCATION_AND_CIRCUMSTANCE_READINGS_COMPATIBLE;
 EXACT_ATTACHMENT_NOT_UNIQUELY_ESTABLISHED
 ```
 
-Direct research supports preverbal `喺 + place` as the location of a following action. A published Cantonese coding framework independently supports `喺 + place + VP` and a circumstance serial-verb profile in which the first predicate describes the circumstance under which the second action occurs. Lexical and contextual sources attest `留喺 + place` and close `留喺屋企 + activity` strings.
+Direct research supports preverbal `喺 + place` as the location of a following action. A published Cantonese coding framework independently supports `喺 + place + VP` and a circumstance serial-verb profile in which a first predicate describes the circumstance under which a second action occurs. Lexical and contextual sources attest bare `留喺屋企 + activity` strings.
 
-No inspected direct source analyzes the exact I078 string or selects one unique tree. The packet therefore does not decide whether:
+No inspected direct source analyzes the exact I078 string or selects one unique tree. The evidence leaves open whether:
 
-1. `喺屋企` is selected primarily by lexical `留`;
-2. `喺屋企` modifies the following `睇電視` event;
-3. `留喺屋企` forms the circumstance under which `睇電視` occurs;
-4. the location is shared by both predicates in a layered composition.
+1. `留喺屋企` forms a stay-at-home predicate followed by the activity `睇電視`;
+2. `喺屋企` has event-location scope over `睇電視` while remaining semantically compatible with `留`;
+3. the overt location is shared by the stay situation and the watching event in a layered composition.
+
+The packet does **not** analyze lexical `留` as selecting the entire constituent `喺屋企睇電視`; no inspected source licenses that complement structure.
 
 No hidden conjunction, progressive marker, purpose relation, or omitted argument is inserted. No parser, identity, status, source, corpus, survey, release, or deployment change is authorized.
 
@@ -43,29 +44,32 @@ No hidden conjunction, progressive marker, purpose relation, or omitted argument
 
 | Profile | Disposition | Reason |
 |---|---|---|
-| lexical `留 lau4` ‘stay/remain’ | `LEXICALLY_SUPPORTED` | Dictionary evidence defines remaining in the same place without leaving. |
-| `留 + 喺 + place` | `LEXICALLY_AND_CONTEXTUALLY_ATTESTED` | Dictionary examples and close attestations support the sequence. |
+| lexical `留 lau4` ‘stay/remain’ | `LEXICALLY_SUPPORTED` | Dictionary evidence establishes the lexeme, reading, and stay/remain sense. |
+| bare `留 + 喺 + place + activity` | `CONTEXTUALLY_ATTESTED` | Words.hk and Glossika provide close or exact surface attestations. |
 | `喺 + place + activity VP` | `DIRECTLY_SUPPORTED_EVENT_LOCATION_PROFILE` | Kwan and Wong et al. directly support preverbal `喺` PP as action location. |
-| `留…睇電視` circumstance relation | `COMPATIBLE_WITH_DIRECT_CIRCUMSTANCE_SVC_PROFILE` | Wong et al. define a close first-predicate-as-circumstance relation, but do not analyze this exact intervening locative structure. |
-| exact I078 attachment | `UNRESOLVED_LAYERED_ATTACHMENT` | Multiple source-compatible analyses preserve the same surface and interpretation. |
-| one `留喺 + place + VP` construction | `NOT_JUSTIFIED` | No direct source establishes this as one independent productive construction. |
+| `留…睇電視` circumstance relation | `COMPATIBLE_WITH_DIRECT_CIRCUMSTANCE_SVC_PROFILE` | Wong et al. define a close first-predicate-as-circumstance relation but do not analyze this exact intervening locative structure. |
+| exact I078 attachment | `UNRESOLVED_LAYERED_ATTACHMENT` | More than one source-compatible scope relation preserves the surface and interpretation. |
+| lexical `留` selecting `喺屋企睇電視` | `NOT_SUPPORTED` | No inspected source establishes that clausal/complement structure. |
+| one `留喺 + place + VP` construction | `NOT_JUSTIFIED` | No direct source establishes one independent productive construction. |
 | AA80 ownership of semantic role | `REJECTED` | AA80 is an implementation wrapper that explicitly does not determine role or attachment. |
-| parser/runtime change | `NOT_AUTHORIZED` | Research outcome requires later audit before any implementation decision. |
+| parser/runtime change | `NOT_AUTHORIZED` | Research outcome requires a later audit before implementation decisions. |
 
 ## Lexical `留`
 
-Words.hk defines `留 lau4` as continuing to be active in the same place without leaving, with English glosses including ‘remain’, ‘stay’, and ‘reside’. Its examples include locative material after `留`, such as staying in a safe place.
+Words.hk defines `留 lau4` as continuing to be in the same place without leaving, with English glosses including ‘remain’, ‘stay’, and ‘reside’. This supports the lexical identity and stay/remain meaning.
 
-Close contextual attestations include:
+The entry’s cited locative example contains `留低`, not bare `留`, so it is not used to establish the syntax of bare `留 + 喺`.
+
+Bare `留喺 + place + activity` is instead supported as contextual attestation by examples including:
 
 ```text
 禮拜六日我鍾意留喺屋企煲劇。
-On weekends, I like staying home and watching a drama series for a long time.
+On weekends, I like staying home and watching drama series for a long time.
 ```
 
-and learner/pedagogical examples such as `留喺屋企休息`.
+and the exact Glossika I078 string.
 
-These sources support lexical identity and natural contextual combinations. They do not independently define a construction-level valency rule for every `留 + 喺 + NP + VP` sequence.
+These attestations establish occurrence and interpretation, not a general construction-level valency rule.
 
 ## Preverbal `喺 + place` event location
 
@@ -89,18 +93,18 @@ S/he swims at the swimming pool.
 S/he is at the swimming pool.
 ```
 
-For I078, the contiguous substring:
+The contiguous I078 substring:
 
 ```text
 喺屋企睇電視
 at home watch television
 ```
 
-therefore fits an independently supported event-location order. This does not establish whether the PP attaches only to `睇電視`, because `留` precedes it and is itself compatible with a locative continuation.
+therefore fits an independently supported event-location order. This supports event-location scope over the watching event, but does not prove exclusive syntactic attachment because lexical `留` precedes the PP and the exact complete sentence has not been directly analyzed.
 
 ## Static, event, and result-location boundaries
 
-The following profiles must remain separate:
+Keep the following profiles separate:
 
 ```text
 我喺屋企。
@@ -123,7 +127,7 @@ S/he threw the book onto the floor.
 
 Postverbal `喺` can encode a resulting or participant location. It must not inherit the same role merely because `喺` is present.
 
-I078 visibly contains lexical `留` before the PP and therefore cannot be reduced to any one of these simpler profiles without preserving the extra predicate.
+I078 contains lexical `留` before the PP and cannot be reduced to any of these simpler profiles without preserving that predicate.
 
 ## `喺度` ambiguity boundary
 
@@ -133,13 +137,13 @@ Wong et al. and the existing repository sources distinguish:
 我喺度做功課。
 ```
 
-which may mean either ‘I do my homework here’ or ‘I am doing my homework’, depending on context. This locative/progressive ambiguity is tied to `喺度`, not to every `喺 + lexical place` phrase.
+which may mean either ‘I do my homework here’ or ‘I am doing my homework’, depending on context. This locative/progressive ambiguity is tied to `喺度`, not every `喺 + lexical place` phrase.
 
-I078 contains `喺屋企`, not `喺度`. No progressive aspect marker is inserted. The source English progressive wording describes the situation but is not evidence of an overt Cantonese progressive construction.
+I078 contains `喺屋企`, not `喺度`. No progressive aspect marker is inserted. The progressive English translation describes the situation but is not evidence of an overt Cantonese progressive construction.
 
 ## Circumstance serial-verb compatibility
 
-Wong et al. define circumstance SVCs as structures in which the first verb describes the circumstance under which the action denoted by the second verb takes place. Their example is:
+Wong et al. define circumstance SVCs as structures in which the first verb describes the circumstance under which the action denoted by the second verb takes place:
 
 ```text
 搭地鐵 睇書
@@ -154,39 +158,34 @@ I078 is semantically compatible with this relation:
 stay at home | watch television
 ```
 
-The staying-at-home situation can be understood as the circumstance during which television watching occurs. However, the direct example has no intervening locative PP inside the first predicate and does not establish that every `stay + location + activity` sequence is a circumstance SVC.
+The staying-at-home situation may describe the circumstance during which watching occurs. The direct example, however, lacks an intervening `喺 + place` phrase inside its first predicate. It does not establish that every `stay + location + activity` sequence is a circumstance SVC.
 
-The correct disposition is therefore compatibility with a documented semantic SVC subtype, not direct proof that I078 belongs to one fixed serial-verb construction.
+The correct disposition is compatibility with a documented relation, not direct classification of I078 as one fixed serial-verb construction.
 
-## Attachment alternatives preserved
+## Source-supported attachment space
 
-### Analysis A: lexical stay predicate plus following activity
+### Stay predicate followed by activity
 
 ```text
 [留喺屋企] [睇電視]
 [stay at home] [watch television]
 ```
 
-The first predicate describes the circumstance of the second activity.
+This is compatible with the close circumstance relation and the exact contextual translation.
 
-### Analysis B: stay predicate plus event-location activity phrase
-
-```text
-留 [喺屋企睇電視]
-stay [watch television at home]
-```
-
-This reflects the independently supported `喺 + place + VP` substring but may require a specific relation between `留` and the following event.
-
-### Analysis C: shared-location layered composition
+### Event-location scope inside a layered sequence
 
 ```text
-留 + [喺屋企] + 睇電視
+留 + [喺屋企] + [睇電視]
 ```
 
-The overt location is interpreted with both remaining and watching, without requiring exclusive syntactic attachment to either predicate.
+The PP has independently supported event-location scope over `睇電視`, while the full sequence still preserves lexical `留` and does not decide an exclusive constituent boundary.
 
-Current direct evidence does not choose among these analyses. A parser may preserve the visible components and an unresolved attachment trace rather than inventing a unique hierarchy.
+### Shared-location interpretation
+
+The overt place may be interpreted with both the stay situation and the watching event. This is a semantic scope possibility, not a claim that one hidden syntactic node or deleted marker exists.
+
+Current evidence does not choose one hierarchy. A parser may preserve the overt components and unresolved attachment rather than inventing a clausal complement after `留`.
 
 ## Neighboring profiles excluded
 
@@ -198,27 +197,28 @@ Keep I078 separate from:
 - progressive `喺度 + VP`;
 - static `subject + 喺 + place` predication;
 - overt conjunctions such as `同埋`, `而且`, or `然後`;
-- covert purpose ‘stay in order to watch’ unless context independently supplies it;
+- covert purpose ‘stay in order to watch’ unless context supplies it;
 - complement clauses selected by cognition or speech verbs;
-- fragments that depend on a prior subject;
-- lexical senses of `留` meaning leave behind, retain an object, reserve, detain, or leave a message.
+- fragments requiring a prior subject;
+- non-locative lexical senses of `留` such as leave behind, retain an object, reserve, detain, or leave a message.
 
 ## Repository consequence
 
-Current AA80 `OvertPlaceExpressionWrapper` is a parser representation over several overt spatial environments. Its accepted profile explicitly says it does not determine whether the place expression is a subject, topic, adjunct, predicate, goal, result, or coda.
+AA80 `OvertPlaceExpressionWrapper` is a parser representation over several overt spatial environments. Its accepted profile explicitly does not determine whether a place expression is a subject, topic, adjunct, predicate, goal, result, or coda.
 
-I078 confirms why that limitation matters. AA80 may preserve the `喺屋企` surface span, but it cannot serve as linguistic evidence for the event-location role or decide attachment to `留` versus `睇電視`.
+AA80 may preserve the `喺屋企` surface span, but it cannot serve as linguistic evidence for event-location role or decide attachment to `留` versus `睇電視`.
 
-No current permanent identity found in the bounded audit directly owns the complete lexical-stay + location + activity relation. This is a possible composition gap, not an instruction to allocate a UUID.
+No current permanent identity found in the bounded audit directly owns the complete stay + location + activity relation. This is a possible composition gap, not an instruction to allocate a UUID.
 
 ## Terminal outcome
 
 - `留` stay/remain: `LEXICALLY_SUPPORTED`.
-- `留喺 + place`: `CONTEXTUALLY_ATTESTED`.
+- bare `留喺 + place + activity`: `CONTEXTUALLY_ATTESTED`.
 - `喺 + place + VP`: `DIRECTLY_SUPPORTED_EVENT_LOCATION_PROFILE`.
 - circumstance relation: `DIRECTLY_DOCUMENTED_CLOSE_PROFILE`.
 - I078: `SUPPORTED_COMPONENTS_WITH_UNRESOLVED_ATTACHMENT`.
 - exact circumstance-SVC classification: `COMPATIBLE_NOT_ESTABLISHED`.
+- `留` selecting a locative activity clause: `NOT_SUPPORTED`.
 - progressive analysis: `NOT_SUPPORTED_BY_OVERT_FORM`.
 - purpose relation: `NOT_ESTABLISHED`.
 - AA80 semantic-role transfer: `NOT_AUTHORIZED`.
@@ -226,13 +226,13 @@ No current permanent identity found in the bounded audit directly owns the compl
 
 ## Next separately claimed action
 
-Open one bounded parser-output audit for I078 and controlled contrasts. It should test whether current output preserves:
+Open one bounded parser-output audit for I078 and controlled contrasts. It should preserve:
 
 1. lexical `留` as an overt predicate;
 2. the complete `喺屋企` place span;
 3. `睇電視` as a following activity VP;
 4. one overt subject without inserting a second subject;
-5. no hidden conjunction, purpose marker, or progressive marker;
+5. no hidden conjunction, purpose marker, progressive marker, or selected clausal complement;
 6. AA80 only as a role-neutral compatibility wrapper, if it appears;
 7. punctuation and full surface fidelity.
 
@@ -245,9 +245,9 @@ Contrast set:
 - a postverbal result-location example;
 - a motion-purpose example;
 - a posture SVC example;
-- lexical non-locative `留` examples.
+- non-locative lexical `留` examples.
 
-A contextual corpus inventory should then collect `留喺 + place + activity` examples with full surrounding context. Only if the corpus and parser audit expose a stable relation not preserved compositionally should a separate identity/composition issue be opened.
+A contextual corpus inventory should collect `留喺 + place + activity` examples with full surrounding context. Only if corpus and parser evidence expose a stable relation not preserved compositionally should a separate identity/composition issue be opened.
 
 ## Protected-state confirmation
 

--- a/docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-SOURCE-INVENTORY-R1.md
+++ b/docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-SOURCE-INVENTORY-R1.md
@@ -17,10 +17,10 @@ The exact source remains attestation only. No parser, identity, status, corpus, 
 | `SRC-KWAN-2010-LOCATIVE` | `DIRECT_SCHOLARLY_CORE` | `journal_fulltext_inspected` | Stella Wing-Man Kwan. 2010. “The Placement of Locative Prepositional Phrases in Cantonese: Processing and Iconicity.” *Taiwan Journal of Linguistics* 8(2):163–198; journal pp.165–169, especially examples (1)–(2) and the preverbal/postverbal interpretation contrast. Repository source record: `grammar/unsupported_generalization/LocativePlacePhrase.md`. | Directly supports preverbal `喺 + place + V` as location of the action and contrasts postverbal `V + 喺 + place` resulting/participant location; gives `我喺屋企食早餐`. | Does not analyze lexical `留`, serial verbs, or the complete I078 attachment. | `RETAIN_EVENT_VS_RESULT_LOCATION_BOUNDARY` |
 | `SRC-WONG-ETAL-2023-HAI-CONSTRUCTION` | `DIRECT_SCHOLARLY_CORE` | `published_full_book_pdf_and_exact_pages_inspected` | Anita Mei-Yin Wong, with Candice Chi-Hang Cheung, Jessica Ming-Wai Lo, and Elaine Ka-Ho Wan. 2023. “Grammatical Analysis of Cantonese Samples.” Chapter 2 of *Understanding Development and Disorder in Cantonese using Language Sample Analysis*. Routledge. DOI `10.4324/9780367824013`; printed p.47 / PDF p.57, section 12.2. | Defines `喺` PP followed by a VP or appearing alone; gives `佢喺泳池游水`, `佢喺泳池`, and ambiguous `我喺度做功課`. | Descriptive coding framework; does not analyze `留喺 + place + VP` or select attachment in I078. | `RETAIN_HAI_PREDICATE_EVENT_AND_HAIDOU_BOUNDARIES` |
 | `SRC-WONG-ETAL-2023-CIRCUMSTANCE-SVC` | `DIRECT_SCHOLARLY_CORE` | `published_full_book_pdf_and_exact_page_inspected` | Same chapter; printed p.52 / PDF p.62, section 14.1 VIII “Circumstance,” example `搭地鐵 睇書` ‘read while taking the subway’. | Directly describes a circumstance SVC subtype in which the first verb describes the circumstance under which the second action takes place. | Close semantic profile only; the example lacks intervening `喺 + place` and does not establish I078 as a member or define all attachment properties. | `RETAIN_AS_CLOSE_RELATION_PROFILE` |
-| `SRC-WORDSHK-LAU4` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `留`, reading `lau4`, sense 1: remain/stay/reside in the same location without leaving; examples include `留低喺安全地方`. | Supports lexical identity, reading, verb category, stay/remain meaning, and compatibility with overt locative material. | Dictionary evidence does not establish construction syntax, productivity, or the relation to a following VP. | `RETAIN_LEXICAL_STAY_PROFILE` |
-| `SRC-WORDSHK-BOU1KEK6` | `ATTESTATION_ONLY` | `dictionary_example_inspected` | Words.hk, entry `煲劇`, example `禮拜六日我鍾意留喺屋企煲劇。` | Close contextual attestation of `留喺屋企 + television-related activity`. | Isolated dictionary example; does not decide constituent attachment or serial-verb classification. | `RETAIN_CLOSE_ATTESTATION` |
-| `SRC-HKUST-WEEKEND-PLAN` | `ATTESTATION_ONLY` | `official_teaching_transcript_inspected` | HKUST Cantonese Listening Tasks, Unit 9.1 “Weekend plan”; transcript includes `星期五我哋喺屋企睇電視好好咁休息吓` and translates the plan as staying home to watch TV and rest. | Attests event-location `喺屋企睇電視` in a naturalistic teaching dialogue and a larger co-event sequence. | Pedagogical transcript; no independent construction analysis or exact lexical `留`. | `RETAIN_CONTEXTUAL_EVENT_LOCATION_ATTESTATION` |
-| `SRC-GLOSSIKA-W18-I078` | `ATTESTATION_ONLY` | `checked_in_source_inspected` | `data/pedagogical-corpus/glossika/GLOSSIKA-YUEHK-A1-W18-20260719/source.json`, I078 `我留喺屋企睇電視。`, Jyutping `ngo5 lau4 hai2 uk1 kei2 tai2 din6 si6.`, English “I'm staying home watching TV.” | Attests exact surface, order, source segmentation, Jyutping, translation, and register. | Does not independently establish attachment, SVC classification, productivity, or progressive aspect. | `RETAIN_AS_EXACT_TRIGGER` |
+| `SRC-WORDSHK-LAU4` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `留`, reading `lau4`, sense 1: remain/stay/reside in the same location without leaving. | Supports lexical identity, reading, verb category, and stay/remain meaning. | The cited locative example is `留低喺安全地方`, containing `留低`; it does not independently establish bare `留 + 喺`, construction syntax, or a relation to a following VP. | `RETAIN_LEXICAL_STAY_PROFILE_ONLY` |
+| `SRC-WORDSHK-BOU1KEK6` | `ATTESTATION_ONLY` | `dictionary_example_inspected` | Words.hk, entry `煲劇`, example `禮拜六日我鍾意留喺屋企煲劇。` | Close contextual attestation of bare `留喺屋企 + television-related activity`. | Isolated dictionary example; does not decide constituent attachment, valency, or serial-verb classification. | `RETAIN_BARE_LAU_HAI_CLOSE_ATTESTATION` |
+| `SRC-HKUST-WEEKEND-PLAN` | `ATTESTATION_ONLY` | `official_teaching_transcript_inspected` | HKUST Cantonese Listening Tasks, Unit 9.1 “Weekend plan”; transcript includes `星期五我哋喺屋企睇電視好好咁休息吓`. | Attests event-location `喺屋企睇電視` in a contextual teaching dialogue and a larger co-event sequence. | Pedagogical transcript; no independent construction analysis and no lexical `留` in the Cantonese string. | `RETAIN_CONTEXTUAL_EVENT_LOCATION_ATTESTATION` |
+| `SRC-GLOSSIKA-W18-I078` | `ATTESTATION_ONLY` | `checked_in_source_inspected` | `data/pedagogical-corpus/glossika/GLOSSIKA-YUEHK-A1-W18-20260719/source.json`, I078 `我留喺屋企睇電視。`, Jyutping `ngo5 lau4 hai2 uk1 kei2 tai2 din6 si6.`, English “I'm staying home watching TV.” | Attests exact surface, order, source segmentation, Jyutping, translation, and register. | Does not independently establish attachment, SVC classification, productivity, selected complement structure, or progressive aspect. | `RETAIN_AS_EXACT_TRIGGER` |
 | `PROJECT-AA80-IDENTITY` | `RUNTIME_OBSERVATION_ONLY` | `current_identity_registry_inspected` | `data/construction-identities.json`, AA80 `OvertPlaceExpressionWrapper`, profile `OvertHaiLocalizerAndPlaceExpressionAggregate`. | Shows the current wrapper preserves overt spatial material across several environments and explicitly does not determine role. | Parser representation has zero independent linguistic-evidence weight and cannot decide I078 attachment. | `ROLE_NEUTRAL_WRAPPER_ONLY` |
 | `PROJECT-AA80-NOTE` | `RUNTIME_OBSERVATION_ONLY` | `current_note_inspected` | `grammar/unsupported_generalization/LocativePlacePhrase.md`; current guidance requires decomposition into event location, predicate location, result/goal location, localizer expressions, and `喺度` ambiguity. | Records current repository boundary and protected compatibility state. | Test counts, runtime references, and status metadata do not prove the linguistic analysis. | `PRESERVE_DECOMPOSITION_BOUNDARY` |
 | `PROJECT-W18-F07-ROUTE` | `RUNTIME_OBSERVATION_ONLY` | `route_record_inspected` | Issue #481, route W18-F07. | Documents the unresolved mixed research/parser-audit dependency. | Routing has zero independent linguistic-evidence weight. | `RETAIN_AS_TRIGGER` |
@@ -29,13 +29,14 @@ The exact source remains attestation only. No parser, identity, status, corpus, 
 
 Qualifying evidence supports:
 
-1. `留 lau4` is a lexical verb meaning stay or remain in a place.
+1. `留 lau4` is a lexical verb with a stay/remain sense.
 2. `喺 + place + VP` is a documented preverbal event-location order.
 3. `subject + 喺 + place` without a following VP can form a static locative predicate.
 4. postverbal `V + 喺 + place` may express a resulting or participant location and must remain separate.
 5. `喺度 + VP` can be ambiguous between locative and progressive readings.
 6. Cantonese has a circumstance SVC subtype in which a first predicate supplies the circumstance of a second action.
-7. close contextual sources attest `留喺屋企 + activity` and `喺屋企睇電視`.
+
+Attestation-only evidence additionally supports occurrence of bare `留喺屋企 + activity` and `喺屋企睇電視` strings.
 
 ## Exact I078 limit
 
@@ -45,7 +46,9 @@ No inspected qualifying source directly analyzes:
 留 + 喺屋企 + 睇電視
 ```
 
-The direct sources establish the component structures and a close semantic relation. They do not select whether the PP attaches to `留`, `睇電視`, both, or a larger circumstance predicate.
+The direct sources establish component structures and a close semantic relation. They do not select whether the PP belongs inside a stay predicate, scopes over the following activity, is shared semantically, or participates in a larger circumstance relation.
+
+No source licenses an analysis in which lexical `留` selects the whole constituent `喺屋企睇電視` as a clausal complement.
 
 ## Unsupported conclusions
 
@@ -53,17 +56,18 @@ The evidence does not establish:
 
 - one productive `留喺 + place + VP` construction;
 - a mandatory circumstance-SVC analysis;
+- lexical `留` selecting a locative activity clause;
 - a hidden conjunction such as ‘and’ or ‘while’;
 - an unexpressed purpose relation;
 - overt progressive aspect in I078;
 - one semantic role for every AA80 place wrapper;
 - a hidden second subject;
-- unrestricted `留` valency across its other lexical senses;
+- unrestricted `留` valency across other lexical senses;
 - a new UUID or parser rule;
 - current runtime correctness.
 
 ## Repository consequence
 
-I078 should first receive a parser-output audit that preserves all overt components and permits unresolved attachment. A contextual corpus inventory should then test whether `留喺 + place + activity` has a stable distribution requiring an independent composition record.
+I078 should first receive a parser-output audit preserving all overt components and unresolved attachment. A contextual corpus inventory should then test whether bare `留喺 + place + activity` has a stable distribution requiring an independent composition record.
 
 No immutable source, parser, runtime, test, identity, status, corpus, survey, release, or deployment state is changed.

--- a/docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-SOURCE-INVENTORY-R1.md
+++ b/docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-SOURCE-INVENTORY-R1.md
@@ -1,0 +1,69 @@
+# ISSUE-650 留喺 locative-activity source inventory R1
+
+Parent issue: #650  
+Work claim: #651  
+Date: 2026-08-07
+
+## Scope
+
+This inventory evaluates Week 18 I078 `我留喺屋企睇電視。` by separating lexical `留`, locative `喺 + place`, following activity structure, and possible circumstance-SVC interpretation.
+
+The exact source remains attestation only. No parser, identity, status, corpus, survey, release, or deployment change is authorized.
+
+## Evidence ledger
+
+| source_id | evidence_grade | verification | citation_and_locator | what_it_supports | limit | disposition |
+|---|---|---|---|---|---|---|
+| `SRC-KWAN-2010-LOCATIVE` | `DIRECT_SCHOLARLY_CORE` | `journal_fulltext_inspected` | Stella Wing-Man Kwan. 2010. “The Placement of Locative Prepositional Phrases in Cantonese: Processing and Iconicity.” *Taiwan Journal of Linguistics* 8(2):163–198; journal pp.165–169, especially examples (1)–(2) and the preverbal/postverbal interpretation contrast. Repository source record: `grammar/unsupported_generalization/LocativePlacePhrase.md`. | Directly supports preverbal `喺 + place + V` as location of the action and contrasts postverbal `V + 喺 + place` resulting/participant location; gives `我喺屋企食早餐`. | Does not analyze lexical `留`, serial verbs, or the complete I078 attachment. | `RETAIN_EVENT_VS_RESULT_LOCATION_BOUNDARY` |
+| `SRC-WONG-ETAL-2023-HAI-CONSTRUCTION` | `DIRECT_SCHOLARLY_CORE` | `published_full_book_pdf_and_exact_pages_inspected` | Anita Mei-Yin Wong, with Candice Chi-Hang Cheung, Jessica Ming-Wai Lo, and Elaine Ka-Ho Wan. 2023. “Grammatical Analysis of Cantonese Samples.” Chapter 2 of *Understanding Development and Disorder in Cantonese using Language Sample Analysis*. Routledge. DOI `10.4324/9780367824013`; printed p.47 / PDF p.57, section 12.2. | Defines `喺` PP followed by a VP or appearing alone; gives `佢喺泳池游水`, `佢喺泳池`, and ambiguous `我喺度做功課`. | Descriptive coding framework; does not analyze `留喺 + place + VP` or select attachment in I078. | `RETAIN_HAI_PREDICATE_EVENT_AND_HAIDOU_BOUNDARIES` |
+| `SRC-WONG-ETAL-2023-CIRCUMSTANCE-SVC` | `DIRECT_SCHOLARLY_CORE` | `published_full_book_pdf_and_exact_page_inspected` | Same chapter; printed p.52 / PDF p.62, section 14.1 VIII “Circumstance,” example `搭地鐵 睇書` ‘read while taking the subway’. | Directly describes a circumstance SVC subtype in which the first verb describes the circumstance under which the second action takes place. | Close semantic profile only; the example lacks intervening `喺 + place` and does not establish I078 as a member or define all attachment properties. | `RETAIN_AS_CLOSE_RELATION_PROFILE` |
+| `SRC-WORDSHK-LAU4` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `留`, reading `lau4`, sense 1: remain/stay/reside in the same location without leaving; examples include `留低喺安全地方`. | Supports lexical identity, reading, verb category, stay/remain meaning, and compatibility with overt locative material. | Dictionary evidence does not establish construction syntax, productivity, or the relation to a following VP. | `RETAIN_LEXICAL_STAY_PROFILE` |
+| `SRC-WORDSHK-BOU1KEK6` | `ATTESTATION_ONLY` | `dictionary_example_inspected` | Words.hk, entry `煲劇`, example `禮拜六日我鍾意留喺屋企煲劇。` | Close contextual attestation of `留喺屋企 + television-related activity`. | Isolated dictionary example; does not decide constituent attachment or serial-verb classification. | `RETAIN_CLOSE_ATTESTATION` |
+| `SRC-HKUST-WEEKEND-PLAN` | `ATTESTATION_ONLY` | `official_teaching_transcript_inspected` | HKUST Cantonese Listening Tasks, Unit 9.1 “Weekend plan”; transcript includes `星期五我哋喺屋企睇電視好好咁休息吓` and translates the plan as staying home to watch TV and rest. | Attests event-location `喺屋企睇電視` in a naturalistic teaching dialogue and a larger co-event sequence. | Pedagogical transcript; no independent construction analysis or exact lexical `留`. | `RETAIN_CONTEXTUAL_EVENT_LOCATION_ATTESTATION` |
+| `SRC-GLOSSIKA-W18-I078` | `ATTESTATION_ONLY` | `checked_in_source_inspected` | `data/pedagogical-corpus/glossika/GLOSSIKA-YUEHK-A1-W18-20260719/source.json`, I078 `我留喺屋企睇電視。`, Jyutping `ngo5 lau4 hai2 uk1 kei2 tai2 din6 si6.`, English “I'm staying home watching TV.” | Attests exact surface, order, source segmentation, Jyutping, translation, and register. | Does not independently establish attachment, SVC classification, productivity, or progressive aspect. | `RETAIN_AS_EXACT_TRIGGER` |
+| `PROJECT-AA80-IDENTITY` | `RUNTIME_OBSERVATION_ONLY` | `current_identity_registry_inspected` | `data/construction-identities.json`, AA80 `OvertPlaceExpressionWrapper`, profile `OvertHaiLocalizerAndPlaceExpressionAggregate`. | Shows the current wrapper preserves overt spatial material across several environments and explicitly does not determine role. | Parser representation has zero independent linguistic-evidence weight and cannot decide I078 attachment. | `ROLE_NEUTRAL_WRAPPER_ONLY` |
+| `PROJECT-AA80-NOTE` | `RUNTIME_OBSERVATION_ONLY` | `current_note_inspected` | `grammar/unsupported_generalization/LocativePlacePhrase.md`; current guidance requires decomposition into event location, predicate location, result/goal location, localizer expressions, and `喺度` ambiguity. | Records current repository boundary and protected compatibility state. | Test counts, runtime references, and status metadata do not prove the linguistic analysis. | `PRESERVE_DECOMPOSITION_BOUNDARY` |
+| `PROJECT-W18-F07-ROUTE` | `RUNTIME_OBSERVATION_ONLY` | `route_record_inspected` | Issue #481, route W18-F07. | Documents the unresolved mixed research/parser-audit dependency. | Routing has zero independent linguistic-evidence weight. | `RETAIN_AS_TRIGGER` |
+
+## Directly supported propositions
+
+Qualifying evidence supports:
+
+1. `留 lau4` is a lexical verb meaning stay or remain in a place.
+2. `喺 + place + VP` is a documented preverbal event-location order.
+3. `subject + 喺 + place` without a following VP can form a static locative predicate.
+4. postverbal `V + 喺 + place` may express a resulting or participant location and must remain separate.
+5. `喺度 + VP` can be ambiguous between locative and progressive readings.
+6. Cantonese has a circumstance SVC subtype in which a first predicate supplies the circumstance of a second action.
+7. close contextual sources attest `留喺屋企 + activity` and `喺屋企睇電視`.
+
+## Exact I078 limit
+
+No inspected qualifying source directly analyzes:
+
+```text
+留 + 喺屋企 + 睇電視
+```
+
+The direct sources establish the component structures and a close semantic relation. They do not select whether the PP attaches to `留`, `睇電視`, both, or a larger circumstance predicate.
+
+## Unsupported conclusions
+
+The evidence does not establish:
+
+- one productive `留喺 + place + VP` construction;
+- a mandatory circumstance-SVC analysis;
+- a hidden conjunction such as ‘and’ or ‘while’;
+- an unexpressed purpose relation;
+- overt progressive aspect in I078;
+- one semantic role for every AA80 place wrapper;
+- a hidden second subject;
+- unrestricted `留` valency across its other lexical senses;
+- a new UUID or parser rule;
+- current runtime correctness.
+
+## Repository consequence
+
+I078 should first receive a parser-output audit that preserves all overt components and permits unresolved attachment. A contextual corpus inventory should then test whether `留喺 + place + activity` has a stable distribution requiring an independent composition record.
+
+No immutable source, parser, runtime, test, identity, status, corpus, survey, release, or deployment state is changed.


### PR DESCRIPTION
Closes #650

Work claim: #651

## Outcome

Resolves Week 18 F07 by separating lexical `留`, overt `喺 + place`, and the following activity VP while preserving unresolved attachment.

## Decisions

- `留 lau4` is lexically supported as stay/remain.
- Bare `留喺屋企 + activity` is contextually attested, not promoted as a construction.
- Preverbal `喺 + place + VP` is directly supported as event location.
- Static locative predicates, postverbal result locations, and `喺度` progressive ambiguity remain separate.
- Circumstance SVC research supplies a close semantic relation, not direct proof of the exact I078 parse.
- I078 is retained as supported components with unresolved attachment among `留`, `喺屋企`, and `睇電視`.
- The unsupported analysis of `留` selecting `喺屋企睇電視` as a clausal complement was removed.
- No hidden conjunction, purpose relation, progressive marker, or second subject is inserted.
- AA80 remains a role-neutral parser wrapper and cannot decide semantic attachment.
- No new UUID or direct implementation is authorized; the next actions are a parser-output audit and contextual corpus inventory.

## Changed files

- `docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-PROFILES-R1.md`
- `docs/research/ISSUE-650-LAU-HAI-LOCATIVE-ACTIVITY-SOURCE-INVENTORY-R1.md`

## Protected and unchanged

No immutable source value, parser/runtime code, test, generated output, version, construction identity/status, corpus classification, survey, panel, release, package, or deployment state changes.

Active AB33 and AA84 implementation scopes remain untouched.

## Validation

- Exact reviewed head: `847ea17110dbc112574c595063c718bc6b558296`.
- Exact comparison contains only the two claimed files and is current with `main`.
- Unsupported complement and lexical-evidence overstatement blockers were repaired and rereviewed.
- Research provenance: PASS, run 31146469398.
- Intake #650 and claim #651 agree on owner, revision, branch, and PR.

No blocker remains.