### PR TITLE
Audit 午夜／半夜 and 正午／中午 temporal lexicon

### DIFF
--- a/docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-LEXICON-AUDIT-R1.md
+++ b/docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-LEXICON-AUDIT-R1.md
@@ -22,18 +22,19 @@ The duplicate English gloss `midnight` materially compresses a learner-relevant 
 
 The duplicate English gloss `noon` is acceptable as a basic gloss for both `正午` and `中午`. Current checked lexicographic evidence explicitly defines `中午` as equivalent to `正午` at daytime twelve, while `正午` is the more exact “high noon / twelve o’clock in the daytime” expression. The available evidence does not justify a strong universal colloquial-versus-formal rule.
 
-The Week 18 `半夜 bun3 je6` reading is **not declared categorically wrong**. Current sources conflict in notation:
+The Week 18 `半夜 bun3 je6` reading is **not declared categorically wrong**. Current sources differ in pronunciation notation:
 
-- Words.hk gives the lexical entry as `bun3 je2`;
-- CantoDict records `bun3 je6/6*2`, explicitly preserving a tone-6 base and a changed-tone-2 representation;
-- direct changed-tone scholarship establishes the general Cantonese process of replacing a base tone with a high-rising or high-level tone in derived lexical environments, but the inspected article does not analyze `半夜` itself.
+- Words.hk gives `bun3 je2`;
+- CantoDict displays `bun3 je6/6*2`;
+- direct scholarship establishes Cantonese changed tone generally but does not analyze `半夜` in the inspected evidence.
 
 The safe disposition is therefore:
 
 ```text
 SOURCE_BUN3_JE6_PRESERVED;
-CURRENT_LEARNER_FACING_CHANGED_TONE_BUN3_JE2_ATTESTED;
-EXACT_VARIANT_DISTRIBUTION_NOT_ESTABLISHED
+HIGH_RISING_BUN3_JE2_SURFACE_ATTESTED;
+CHANGED_TONE_INTERPRETATION_COMPATIBLE_NOT_LEXEME_SPECIFICALLY_PROVEN;
+EXACT_VARIANT_DISTRIBUTION_AND_LEARNER_PREFERENCE_NOT_ESTABLISHED
 ```
 
 No immutable source, runtime lexicon, pronunciation table, construction identity, status, corpus classification, survey, release, or deployment state is changed.
@@ -55,19 +56,20 @@ This term can occur inside a temporal PP or time expression, as in a source exam
 
 Terminal result: `VALID_MIDNIGHT_CENTERED_NOUN`.
 
-### 半夜 `bun3 je2` or base/changed-tone notation
+### 半夜 and the `je6／je2` notation difference
 
-Words.hk classifies `半夜` as a noun and gives the pronunciation `bun3 je2`. Its definition covers the period after twelve at night until dawn, with English glosses including “midnight” and “late at night.”
+Words.hk classifies `半夜` as a noun, gives `bun3 je2`, and defines a period after twelve at night until dawn, with English glosses including “midnight” and “late at night.”
 
-This range is broader than the checked `午夜` definition. In many contexts, translating either term as “midnight” is possible, but the source gloss does not teach the difference between a clock-centered term and a broader late-night interval.
+This range is broader than the checked `午夜` definition. Translating either term as “midnight” can be possible in context, but the source gloss does not teach the clock-centered versus broader-interval distinction.
 
-CantoDict records `半夜` as `bun3 je6/6*2`. That notation is compatible with a base tone 6 and a changed-tone realization 2. It demonstrates that `bun3 je6` is not safely dismissible as an arbitrary error, while also showing that the source’s single unqualified reading is insufficient for a learner-facing pronunciation decision.
+CantoDict displays `半夜` as `bun3 je6/6*2`. The entry establishes that one dictionary preserves both tone-6 and tone-2-related notation for the second syllable. Combined with general changed-tone scholarship, this is compatible with a base-versus-changed-tone interpretation. The entry and inspected scholarship do not establish the exact lexeme-specific analysis, distribution, or preferred learner form.
 
 Terminal result:
 
 ```text
 VALID_BROADER_LATE_NIGHT_NOUN;
 SOURCE_GLOSS_UNDERSPECIFIED;
+HIGH_RISING_JE2_SURFACE_ATTESTED;
 PRONUNCIATION_VARIANT_REVIEW_REQUIRED
 ```
 
@@ -83,7 +85,7 @@ Terminal result: `VALID_EXACT_NOON_NOUN`.
 
 Words.hk defines `中午` as equivalent to `正午`, daytime twelve o’clock, with glosses “noon; midday.” The same entry records a separate Macau-specific lexical sense meaning “lunch,” abbreviated from `中午飯`.
 
-For ordinary Hong Kong Cantonese temporal use, the checked source does not establish a categorical semantic opposition between `中午` and `正午`. `中午` is compatible with a broader everyday “noon / midday” label, while `正午` explicitly encodes exact noon in the dictionary definitions, but frequency and register require corpus evidence.
+For ordinary Hong Kong Cantonese temporal use, the checked source does not establish a categorical semantic opposition between `中午` and `正午`. `中午` is compatible with an ordinary “noon / midday” label, while `正午` explicitly encodes exact noon in the dictionary definitions, but frequency and register require corpus evidence.
 
 Terminal result:
 
@@ -93,28 +95,29 @@ TEMPORAL_GLOSS_ACCEPTABLE;
 MACAU_LUNCH_SENSE_SEPARATE
 ```
 
-## Changed-tone boundary for 半夜
+## Changed-tone interpretation boundary
 
-Alderete, Chan, and Tanaka analyze Cantonese changed tone as morphological replacement of a base tone by a high-level or high-rising tone in certain derived environments. The article establishes:
+Alderete, Chan, and Tanaka analyze Cantonese changed tone as morphological replacement of a base tone by a high-level or high-rising tone in selected derived environments. The article establishes:
 
 - changed tone is a real Cantonese morphological phenomenon;
-- base and changed-tone information may both be relevant to lexical representation;
-- the process has lexical and constructional limits and cannot be applied mechanically to every compound.
+- lexical representations may need to distinguish base and derived tonal information;
+- the process has empirical limits and cannot be applied mechanically to every compound.
 
-The article does not list `半夜` in the inspected evidence used here. Therefore it supports interpretation of the dictionary notation but does not independently prove:
+The article does not list `半夜` in the inspected evidence used here. It therefore supports interpretation of the dictionary disagreement only at a general level and does not independently prove:
 
+- that `je2` in `半夜` is derived by that process;
 - that every speaker uses `bun3 je2`;
-- that `bun3 je6` is impossible;
-- that the alternation is optional in all registers;
-- that the source intended an underlying rather than spoken form;
+- that `bun3 je6` is impossible or citation-only;
+- that the alternation is optional in every register;
+- that the Week 18 source intended an underlying form;
 - that a global tone-change rule should be implemented.
 
 The exact lexeme-specific evidence remains dictionary-level:
 
-- one checked source foregrounds `bun3 je2`;
-- another preserves `je6/6*2`.
+- one checked source gives `bun3 je2`;
+- another displays `je6/6*2`.
 
-A corrected teaching derivative should foreground the currently attested spoken changed-tone form while recording the base/variant notation and source disagreement. It should not rewrite the immutable Week 18 row.
+A later lexical-design and contextual pronunciation review must decide learner-facing preference. This packet does not instruct a corrected derivative to foreground either form.
 
 ## Lexical-class and syntax boundary
 
@@ -144,11 +147,12 @@ Keep separate:
 
 The Week 18 source places all four terms in an A1 lesson, but source placement does not prove ordinary A1 frequency or register.
 
-Checked dictionaries establish lexical validity, not acquisition level. The available evidence supports these limited observations:
+Checked dictionaries establish lexical validity, not acquisition level. The available evidence supports only:
 
-- `午夜` and `正午` are exact clock-centered terms in their definitions;
-- `半夜` and `中午` have broader ordinary temporal ranges or uses;
-- a stronger claim that the first pair is formal and the second pair colloquial requires corpus or controlled register evidence.
+- `午夜` and `正午` have exact clock-centered definitions;
+- `半夜` has a broader late-night/post-midnight range;
+- `中午` overlaps with exact noon and has a separate regional lunch sense;
+- stronger formal/colloquial or frequency claims require corpus or controlled register evidence.
 
 No CEFR or learner-level reclassification is authorized.
 
@@ -168,7 +172,8 @@ NO_PRONUNCIATION_BLOCKER
 RETAIN_VALID_LEXEME;
 GLOSS_MIDNIGHT_TOO_NARROW_AS_SOLE_TEACHING_GLOSS;
 SOURCE_BUN3_JE6_PRESERVED;
-BUN3_JE2_CHANGED_TONE_ATTESTED;
+HIGH_RISING_BUN3_JE2_SURFACE_ATTESTED;
+CHANGED_TONE_ANALYSIS_COMPATIBLE_NOT_PROVEN_FOR_LEXEME;
 VARIANT_DISTRIBUTION_UNRESOLVED
 ```
 
@@ -190,13 +195,14 @@ MIDDAY_AND_MACAU_LUNCH_SENSES_RECORDED_SEPARATELY
 
 ## Repository consequence
 
-No current construction identity is needed for these lexical distinctions. The strongest later action is a source-preserving corrected teaching derivative or lexical annotation record that:
+No current construction identity is needed for these lexical distinctions. The strongest later action is a lexical-representation design audit or source-preserving annotation record that:
 
 1. distinguishes `午夜` from the broader `半夜` interval;
-2. records `半夜 bun3 je2` as a current learner-facing pronunciation while preserving the Week 18 `bun3 je6` source value and CantoDict base/changed-tone notation;
-3. treats `正午` and `中午` as overlapping noon terms without inventing a hard register split;
-4. keeps the Macau “lunch” sense of `中午` separate;
-5. does not alter runtime until a homograph/variant-aware lexical design is reviewed.
+2. preserves Week 18 `bun3 je6`, records current `bun3 je2` and CantoDict’s dual notation, and keeps the changed-tone interpretation explicitly provisional at lexeme level;
+3. determines learner-facing preference only after contextual pronunciation and register review;
+4. treats `正午` and `中午` as overlapping noon terms without inventing a hard register split;
+5. keeps the Macau “lunch” sense of `中午` separate;
+6. does not alter runtime until a variant-aware lexical design is reviewed.
 
 ## Terminal outcome
 
@@ -206,8 +212,9 @@ No current construction identity is needed for these lexical distinctions. The s
 - `正午` versus `中午`: `SUBSTANTIAL_TEMPORAL_OVERLAP_WITH_DIFFERENT_DEFINITIONAL_FOCUS`.
 - source duplicate “noon” gloss: `ACCEPTABLE_BASIC_GLOSS`.
 - `半夜 bun3 je6`: `PRESERVE_AS_SOURCE_READING_NOT_CATEGORICALLY_REJECTED`.
-- `半夜 bun3 je2`: `CURRENT_CHANGED_TONE_SURFACE_ATTESTED`.
-- exact pronunciation distribution: `UNRESOLVED`.
+- `半夜 bun3 je2`: `HIGH_RISING_SURFACE_ATTESTED`.
+- lexeme-specific changed-tone derivation: `COMPATIBLE_NOT_PROVEN`.
+- exact pronunciation distribution and learner preference: `UNRESOLVED`.
 - global changed-tone rule: `NOT_AUTHORIZED`.
 - source/runtime/status change: no.
 
@@ -216,13 +223,13 @@ No current construction identity is needed for these lexical distinctions. The s
 Open one bounded lexical-representation design audit before any runtime edit. It should determine whether the project’s lexicon can preserve:
 
 - immutable source reading;
-- citation/base tone;
-- changed-tone surface;
+- alternative dictionary surfaces and notations;
+- hypothesized base/derived relationships separately from directly attested pronunciation;
 - regional or register variants;
-- learner-facing preferred form;
+- learner-facing preferred form only after evidence review;
 - provenance per variant.
 
-A small corpus/register inventory should separately compare `午夜／半夜` and `正午／中午` in contextual Hong Kong Cantonese. It should measure time range and register without using raw frequency as proof of interchangeability.
+A small corpus/register and pronunciation inventory should separately compare `午夜／半夜` and `正午／中午` in contextual Hong Kong Cantonese. It should not use raw frequency as proof of interchangeability or use general changed-tone theory as lexeme-specific pronunciation proof.
 
 ## Protected-state confirmation
 

--- a/docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-LEXICON-AUDIT-R1.md
+++ b/docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-LEXICON-AUDIT-R1.md
@@ -1,0 +1,235 @@
+# ISSUE-653 midnight/noon temporal-lexicon audit R1
+
+Parent issue: #653  
+Work claim: #654  
+Date: 2026-08-07
+
+## Decision
+
+Retain all four Week 18 source entries as valid temporal nouns, but do not treat each English-gloss pair as lexical identity:
+
+| Source row | Source form | Terminal lexical disposition |
+|---|---|---|
+| I036 | `午夜 ng5 je6 — midnight` | `VALID_MIDNIGHT_CENTERED_TERM` |
+| I057 | `半夜 bun3 je6 — midnight` | `VALID_BROADER_LATE_NIGHT_OR_POST_MIDNIGHT_TERM_WITH_PRONUNCIATION_REVIEW_FLAG` |
+| I037 | `正午 zing3 ng5 — noon` | `VALID_EXACT_NOON_TERM` |
+| I058 | `中午 zung1 ng5 — noon` | `VALID_COMMON_NOON_OR_MIDDAY_TERM` |
+
+The duplicate English gloss `midnight` materially compresses a learner-relevant distinction:
+
+- `午夜` is centered on twelve o’clock at night or the time around midnight;
+- `半夜` can denote the later part of the night and is defined in a current Cantonese dictionary as the period after midnight until dawn.
+
+The duplicate English gloss `noon` is acceptable as a basic gloss for both `正午` and `中午`. Current checked lexicographic evidence explicitly defines `中午` as equivalent to `正午` at daytime twelve, while `正午` is the more exact “high noon / twelve o’clock in the daytime” expression. The available evidence does not justify a strong universal colloquial-versus-formal rule.
+
+The Week 18 `半夜 bun3 je6` reading is **not declared categorically wrong**. Current sources conflict in notation:
+
+- Words.hk gives the lexical entry as `bun3 je2`;
+- CantoDict records `bun3 je6/6*2`, explicitly preserving a tone-6 base and a changed-tone-2 representation;
+- direct changed-tone scholarship establishes the general Cantonese process of replacing a base tone with a high-rising or high-level tone in derived lexical environments, but the inspected article does not analyze `半夜` itself.
+
+The safe disposition is therefore:
+
+```text
+SOURCE_BUN3_JE6_PRESERVED;
+CURRENT_LEARNER_FACING_CHANGED_TONE_BUN3_JE2_ATTESTED;
+EXACT_VARIANT_DISTRIBUTION_NOT_ESTABLISHED
+```
+
+No immutable source, runtime lexicon, pronunciation table, construction identity, status, corpus classification, survey, release, or deployment state is changed.
+
+## Pair 1: 午夜 and 半夜
+
+### 午夜 `ng5 je6`
+
+Words.hk classifies `午夜` as a noun and defines it as the time around twelve o’clock at night, explicitly contrasting it with daytime `中午`.
+
+Supported lexical core:
+
+```text
+午夜
+nighttime twelve o’clock / around midnight
+```
+
+This term can occur inside a temporal PP or time expression, as in a source example equivalent to “at 12:20 a.m.” Its noun classification does not imply that Canto Span needs a distinct construction identity for temporal modification.
+
+Terminal result: `VALID_MIDNIGHT_CENTERED_NOUN`.
+
+### 半夜 `bun3 je2` or base/changed-tone notation
+
+Words.hk classifies `半夜` as a noun and gives the pronunciation `bun3 je2`. Its definition covers the period after twelve at night until dawn, with English glosses including “midnight” and “late at night.”
+
+This range is broader than the checked `午夜` definition. In many contexts, translating either term as “midnight” is possible, but the source gloss does not teach the difference between a clock-centered term and a broader late-night interval.
+
+CantoDict records `半夜` as `bun3 je6/6*2`. That notation is compatible with a base tone 6 and a changed-tone realization 2. It demonstrates that `bun3 je6` is not safely dismissible as an arbitrary error, while also showing that the source’s single unqualified reading is insufficient for a learner-facing pronunciation decision.
+
+Terminal result:
+
+```text
+VALID_BROADER_LATE_NIGHT_NOUN;
+SOURCE_GLOSS_UNDERSPECIFIED;
+PRONUNCIATION_VARIANT_REVIEW_REQUIRED
+```
+
+## Pair 2: 正午 and 中午
+
+### 正午 `zing3 ng5`
+
+Words.hk defines `正午` as daytime twelve o’clock and glosses it as “high noon; noon.” This is an exact clock-centered definition.
+
+Terminal result: `VALID_EXACT_NOON_NOUN`.
+
+### 中午 `zung1 ng5`
+
+Words.hk defines `中午` as equivalent to `正午`, daytime twelve o’clock, with glosses “noon; midday.” The same entry records a separate Macau-specific lexical sense meaning “lunch,” abbreviated from `中午飯`.
+
+For ordinary Hong Kong Cantonese temporal use, the checked source does not establish a categorical semantic opposition between `中午` and `正午`. `中午` is compatible with a broader everyday “noon / midday” label, while `正午` explicitly encodes exact noon in the dictionary definitions, but frequency and register require corpus evidence.
+
+Terminal result:
+
+```text
+VALID_COMMON_NOON_OR_MIDDAY_NOUN;
+TEMPORAL_GLOSS_ACCEPTABLE;
+MACAU_LUNCH_SENSE_SEPARATE
+```
+
+## Changed-tone boundary for 半夜
+
+Alderete, Chan, and Tanaka analyze Cantonese changed tone as morphological replacement of a base tone by a high-level or high-rising tone in certain derived environments. The article establishes:
+
+- changed tone is a real Cantonese morphological phenomenon;
+- base and changed-tone information may both be relevant to lexical representation;
+- the process has lexical and constructional limits and cannot be applied mechanically to every compound.
+
+The article does not list `半夜` in the inspected evidence used here. Therefore it supports interpretation of the dictionary notation but does not independently prove:
+
+- that every speaker uses `bun3 je2`;
+- that `bun3 je6` is impossible;
+- that the alternation is optional in all registers;
+- that the source intended an underlying rather than spoken form;
+- that a global tone-change rule should be implemented.
+
+The exact lexeme-specific evidence remains dictionary-level:
+
+- one checked source foregrounds `bun3 je2`;
+- another preserves `je6/6*2`.
+
+A corrected teaching derivative should foreground the currently attested spoken changed-tone form while recording the base/variant notation and source disagreement. It should not rewrite the immutable Week 18 row.
+
+## Lexical-class and syntax boundary
+
+All four checked Words.hk entries are nouns. Their use in time expressions can make the larger constituent function adverbially:
+
+```text
+喺午夜十二點……
+at 12 midnight …
+
+喺中午十二點……
+at 12 noon …
+```
+
+This does not transform the lexeme itself into a universal temporal adverb or justify one `TemporalPhrase` construction from dictionary examples alone.
+
+Keep separate:
+
+- lexical noun identity;
+- PP or bare-time placement in a clause;
+- exact clock expressions containing numerals and `點／時`;
+- duration nouns;
+- schedule nouns;
+- regional non-temporal lexical senses;
+- source pedagogical level or frequency.
+
+## Register and A1 boundary
+
+The Week 18 source places all four terms in an A1 lesson, but source placement does not prove ordinary A1 frequency or register.
+
+Checked dictionaries establish lexical validity, not acquisition level. The available evidence supports these limited observations:
+
+- `午夜` and `正午` are exact clock-centered terms in their definitions;
+- `半夜` and `中午` have broader ordinary temporal ranges or uses;
+- a stronger claim that the first pair is formal and the second pair colloquial requires corpus or controlled register evidence.
+
+No CEFR or learner-level reclassification is authorized.
+
+## Source-row dispositions
+
+### I036 午夜
+
+```text
+RETAIN_VALID_LEXEME;
+GLOSS_MIDNIGHT_ACCEPTABLE;
+NO_PRONUNCIATION_BLOCKER
+```
+
+### I057 半夜
+
+```text
+RETAIN_VALID_LEXEME;
+GLOSS_MIDNIGHT_TOO_NARROW_AS_SOLE_TEACHING_GLOSS;
+SOURCE_BUN3_JE6_PRESERVED;
+BUN3_JE2_CHANGED_TONE_ATTESTED;
+VARIANT_DISTRIBUTION_UNRESOLVED
+```
+
+### I037 正午
+
+```text
+RETAIN_VALID_LEXEME;
+GLOSS_NOON_ACCEPTABLE;
+EXACT_NOON_SCOPE_RECORDED
+```
+
+### I058 中午
+
+```text
+RETAIN_VALID_LEXEME;
+GLOSS_NOON_ACCEPTABLE;
+MIDDAY_AND_MACAU_LUNCH_SENSES_RECORDED_SEPARATELY
+```
+
+## Repository consequence
+
+No current construction identity is needed for these lexical distinctions. The strongest later action is a source-preserving corrected teaching derivative or lexical annotation record that:
+
+1. distinguishes `午夜` from the broader `半夜` interval;
+2. records `半夜 bun3 je2` as a current learner-facing pronunciation while preserving the Week 18 `bun3 je6` source value and CantoDict base/changed-tone notation;
+3. treats `正午` and `中午` as overlapping noon terms without inventing a hard register split;
+4. keeps the Macau “lunch” sense of `中午` separate;
+5. does not alter runtime until a homograph/variant-aware lexical design is reviewed.
+
+## Terminal outcome
+
+- all four forms: `VALID_LEXEMES`.
+- `午夜` versus `半夜`: `MEANINGFUL_SEMANTIC_RANGE_CONTRAST`.
+- source duplicate “midnight” gloss: `PEDAGOGICALLY_UNDERSPECIFIED`.
+- `正午` versus `中午`: `SUBSTANTIAL_TEMPORAL_OVERLAP_WITH_DIFFERENT_DEFINITIONAL_FOCUS`.
+- source duplicate “noon” gloss: `ACCEPTABLE_BASIC_GLOSS`.
+- `半夜 bun3 je6`: `PRESERVE_AS_SOURCE_READING_NOT_CATEGORICALLY_REJECTED`.
+- `半夜 bun3 je2`: `CURRENT_CHANGED_TONE_SURFACE_ATTESTED`.
+- exact pronunciation distribution: `UNRESOLVED`.
+- global changed-tone rule: `NOT_AUTHORIZED`.
+- source/runtime/status change: no.
+
+## Next separately claimed action
+
+Open one bounded lexical-representation design audit before any runtime edit. It should determine whether the project’s lexicon can preserve:
+
+- immutable source reading;
+- citation/base tone;
+- changed-tone surface;
+- regional or register variants;
+- learner-facing preferred form;
+- provenance per variant.
+
+A small corpus/register inventory should separately compare `午夜／半夜` and `正午／中午` in contextual Hong Kong Cantonese. It should measure time range and register without using raw frequency as proof of interchangeability.
+
+## Protected-state confirmation
+
+This packet changes no immutable source value, parser detector, runtime lexicon, pronunciation table, test, generated output, version, UUID, code, canonical name, linguistic status, readiness record, corpus classification, survey, panel result, held-out evidence, release, package, or deployment state.
+
+It does not modify active AB33 or AA84 scopes.
+
+## Source inventory
+
+See `docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-SOURCE-INVENTORY-R1.md`.

--- a/docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-SOURCE-INVENTORY-R1.md
+++ b/docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-SOURCE-INVENTORY-R1.md
@@ -6,7 +6,7 @@ Date: 2026-08-07
 
 ## Scope
 
-This inventory evaluates Week 18 I036 `午夜`, I037 `正午`, I057 `半夜`, and I058 `中午`. It separates lexical meaning, noun classification, pronunciation notation, changed tone, regional senses, and source-preserving consequences.
+This inventory evaluates Week 18 I036 `午夜`, I037 `正午`, I057 `半夜`, and I058 `中午`. It separates lexical meaning, noun classification, pronunciation notation, changed-tone interpretation, regional senses, and source-preserving consequences.
 
 No immutable source, runtime lexicon, pronunciation table, parser, identity, status, corpus, survey, release, or deployment change is authorized.
 
@@ -14,12 +14,12 @@ No immutable source, runtime lexicon, pronunciation table, parser, identity, sta
 
 | source_id | evidence_grade | verification | citation_and_locator | what_it_supports | limit | disposition |
 |---|---|---|---|---|---|---|
-| `SRC-WORDSHK-NG5-JE6` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `午夜`, reading `ng5 je6`, noun; definition: around twelve o’clock at night, used to distinguish midnight from daytime noon. | Supports lexical identity, reading, noun class, and midnight-centered meaning. | Dictionary evidence does not establish construction syntax, frequency, CEFR level, or a categorical register contrast with `半夜`. | `RETAIN_MIDNIGHT_CENTERED_LEXEME` |
-| `SRC-WORDSHK-BUN3-JE2` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `半夜`, reading `bun3 je2`, noun; definition: usually the period after midnight until dawn; English “midnight; late at night.” | Supports lexical identity, current changed-tone surface, noun class, and a broader late-night/post-midnight temporal range. | Does not document the base tone, speaker distribution, optionality, or relationship to the Week 18 `bun3 je6` notation. | `RETAIN_BROADER_NIGHT_RANGE_AND_JE2_ATTESTATION` |
-| `SRC-CANTODICT-BUN3-JE6-6STAR2` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_and_tone_notation_inspected` | CantoDict, entry `半夜`, Jyutping display `bun3 je6/6*2`, gloss “12 midnight”; site documentation states the asterisk convention marks changed-tone readings. | Supports a lexical representation preserving tone-6 and changed-tone-2 information for `夜` in this word. | Collaborative dictionary; the notation does not by itself establish which surface is preferred, obligatory, regional, or register-specific. | `RETAIN_BASE_CHANGED_TONE_NOTATION_CONFLICT` |
+| `SRC-WORDSHK-NG5-JE6` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `午夜`, reading `ng5 je6`, noun; definition: around twelve o’clock at night, used to distinguish midnight from daytime noon. | Supports lexical identity, reading, noun class, and midnight-centered meaning. | Does not establish construction syntax, frequency, CEFR level, or a categorical register contrast with `半夜`. | `RETAIN_MIDNIGHT_CENTERED_LEXEME` |
+| `SRC-WORDSHK-BUN3-JE2` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `半夜`, reading `bun3 je2`, noun; definition: usually the period after midnight until dawn; English “midnight; late at night.” | Supports lexical identity, a high-rising `je2` surface, noun class, and a broader late-night/post-midnight temporal range. | Does not label the surface as changed tone or document a base form, speaker distribution, optionality, or relationship to Week 18 `bun3 je6`. | `RETAIN_BROADER_NIGHT_RANGE_AND_JE2_SURFACE` |
+| `SRC-CANTODICT-BUN3-JE6-6STAR2` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | CantoDict, entry `半夜`, Jyutping display `bun3 je6/6*2`, gloss “12 midnight”; the entry page notes that CantoDict uses a special asterisk convention for certain readings. | Supports the existence of a dictionary notation containing both `je6` and `6*2` information for this lexeme. | The notation-convention page was not independently inspected in this packet. The entry does not by itself establish a base/derived analysis, surface preference, obligation, region, or register. | `RETAIN_DUAL_PRONUNCIATION_NOTATION` |
 | `SRC-WORDSHK-ZING3-NG5` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `正午`, reading `zing3 ng5`, noun; definition: twelve o’clock in the daytime; English “high noon; noon.” | Supports lexical identity, reading, noun class, and exact-noon meaning. | Does not establish frequency, formality, or categorical contrast with `中午`. | `RETAIN_EXACT_NOON_LEXEME` |
 | `SRC-WORDSHK-ZUNG1-NG5` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `中午`, reading `zung1 ng5`, noun; temporal sense defined as equivalent to `正午`, daytime twelve; English “noon; midday”; separate Macau sense “lunch.” | Supports lexical identity, reading, noun class, temporal overlap with `正午`, and a separate regional non-temporal sense. | Does not establish a universal colloquial/formal distinction or exact duration of “midday” in all contexts. | `RETAIN_COMMON_NOON_MIDDAY_AND_REGIONAL_SENSE_BOUNDARY` |
-| `SRC-ALDERETE-CHAN-TANAKA-2022-CHANGED-TONE` | `DIRECT_SCHOLARLY_CORE` | `publisher_metadata_abstract_and_article_scope_inspected` | John Alderete, Queenie Chan, and Shin-ichi Tanaka. 2022. “The Morphology of Cantonese ‘Changed Tone’: Extensions and Limitations.” *Gengo Kenkyu* 161:139–169. DOI `10.11435/gengo.161.0_139`. | Directly establishes Cantonese changed tone as morphological substitution of a base tone by high-level or high-rising tone in selected derived environments and emphasizes empirical limits. | The inspected source does not identify `半夜`; it cannot prove this lexeme’s exact alternation, optionality, or preferred surface. | `GENERAL_CHANGED_TONE_INTERPRETIVE_SUPPORT_ONLY` |
+| `SRC-ALDERETE-CHAN-TANAKA-2022-CHANGED-TONE` | `DIRECT_SCHOLARLY_CORE` | `publisher_metadata_abstract_and_article_scope_inspected` | John Alderete, Queenie Chan, and Shin-ichi Tanaka. 2022. “The Morphology of Cantonese ‘Changed Tone’: Extensions and Limitations.” *Gengo Kenkyu* 161:139–169. DOI `10.11435/gengo.161.0_139`. | Establishes Cantonese changed tone generally as morphological tonal substitution in selected derived environments and emphasizes empirical limits. | The inspected source does not identify `半夜`; it cannot prove this lexeme’s alternation, optionality, preferred surface, or relation between the two dictionary notations. | `GENERAL_CHANGED_TONE_INTERPRETIVE_SUPPORT_ONLY` |
 | `SRC-WONG-1982-TONE-CHANGE-LEAD` | `DISCOVERY_LEAD_ONLY` | `dissertation_metadata_and_abstract_inspected_fulltext_restricted` | Maurice Kuen-Shing Wong. 1982. *Tone Change in Cantonese*. PhD dissertation, University of Illinois Urbana-Champaign. | Identifies a broad synchronic, diachronic, lexical, and stylistic investigation of Cantonese tone change. | Full substantive text was not inspected; no claim about `半夜` or style distribution is imported. | `BIBLIOGRAPHIC_LEAD_ONLY` |
 | `SRC-GLOSSIKA-W18-I036-I037-I057-I058` | `ATTESTATION_ONLY` | `checked_in_source_inspected` | `data/pedagogical-corpus/glossika/GLOSSIKA-YUEHK-A1-W18-20260719/source.json`: I036 `午夜 ng5 je6 — midnight`; I037 `正午 zing3 ng5 — noon`; I057 `半夜 bun3 je6 — midnight`; I058 `中午 zung1 ng5 — noon`. | Attests exact source forms, readings, glosses, ordering, and lesson classification. | Pedagogical source; does not independently establish lexical range, pronunciation preference, register, or proficiency level. | `RETAIN_AS_EXACT_TRIGGER` |
 | `PROJECT-W18-F11-ROUTE` | `RUNTIME_OBSERVATION_ONLY` | `route_record_inspected` | Issue #481, route W18-F11. | Documents the retained temporal lexical/register dependency. | Routing has zero independent linguistic-evidence weight. | `RETAIN_AS_REPOSITORY_TRIGGER` |
@@ -34,25 +34,27 @@ The checked lexical sources support:
 4. `正午` identifies daytime twelve or high noon;
 5. `中午` temporally overlaps with `正午` and can be glossed noon/midday;
 6. `中午` has a separate Macau-specific “lunch” sense;
-7. `半夜 bun3 je2` is a current dictionary pronunciation;
-8. another dictionary preserves `bun3 je6/6*2`, linking tone 6 with a changed-tone-2 notation.
+7. `半夜 bun3 je2` is a current dictionary pronunciation surface;
+8. another dictionary displays `bun3 je6/6*2` for the lexeme.
 
-## Changed-tone inference limit
+## Changed-tone interpretation limit
 
-The direct changed-tone article supports the existence and morphological nature of the general process. It does not contain the lexeme `半夜` in the inspected evidence used for this packet.
+The direct changed-tone article supports the existence and morphological nature of the general process. It does not contain `半夜` in the inspected evidence used here.
 
-Therefore the combined evidence permits this inference only:
+The combined evidence therefore permits only this bounded inference:
 
 ```text
-The je6／je2 dictionary notation is compatible with a Cantonese base-versus-changed-tone analysis.
+The je6／je2-related dictionary notations are compatible with, but do not prove, a base-versus-changed-tone analysis for 半夜.
 ```
 
 It does not establish:
 
+- that `je2` in this lexeme is necessarily produced by changed-tone morphology;
 - which variant every speaker produces;
-- whether `je6` is a citation-only form;
+- whether `je6` is citation-only;
 - whether `je2` is obligatory in ordinary speech;
 - whether the variants encode semantic or register differences;
+- which form should be learner-facing;
 - whether a productive changed-tone rule should be applied by the parser or lexicon.
 
 ## Gloss dispositions
@@ -71,20 +73,21 @@ Accurate basic gloss. “High noon” or exact daytime twelve adds precision.
 
 ### `中午 — noon`
 
-Accurate basic temporal gloss. “Midday” is also supported. The Macau “lunch” sense must remain a separate lexical sense.
+Accurate basic temporal gloss. “Midday” is also supported. The Macau “lunch” sense remains separate.
 
 ## Pronunciation disposition for I057
 
-The source reading `bun3 je6` is preserved as immutable source data.
+The source reading `bun3 je6` remains immutable source data.
 
-The evidence state is:
+Evidence state:
 
 - `bun3 je2`: directly attested by Words.hk;
-- `bun3 je6/6*2`: directly attested by CantoDict;
+- `bun3 je6/6*2`: directly displayed by CantoDict;
 - changed-tone process: directly supported generally by scholarship;
-- exact lexeme-specific distribution: unresolved.
+- lexeme-specific changed-tone derivation: not directly established;
+- exact variant distribution and learner preference: unresolved.
 
-The correct project consequence is a pronunciation-review annotation, not an automatic source correction or global runtime replacement.
+The project consequence is a pronunciation-review annotation and later lexical-design decision, not source correction or runtime replacement.
 
 ## Unsupported conclusions
 
@@ -94,14 +97,15 @@ The evidence does not establish:
 - that `正午` and `中午` are never interchangeable;
 - a categorical formal-versus-colloquial split;
 - A1 suitability or frequency rankings;
-- a universal bare temporal-modifier syntax for all four nouns;
+- universal bare temporal-modifier syntax for all four nouns;
 - that source `bun3 je6` is simply erroneous;
-- that a global changed-tone rule can derive the learner-facing pronunciation safely;
+- that `bun3 je2` is definitively this lexeme’s changed-tone output;
+- that a global changed-tone rule can derive a learner-facing pronunciation safely;
 - a construction identity or parser rule;
 - current runtime lexicon correctness.
 
 ## Repository consequence
 
-The strongest next action is a bounded lexical-representation design audit capable of preserving source readings, base tones, changed-tone surfaces, regional senses, learner-facing preferences, and per-variant provenance. A separate corpus/register inventory should test usage differences before any frequency or formality label.
+The strongest next action is a bounded lexical-representation design audit capable of preserving source readings, directly attested pronunciation surfaces, hypothesized tone relationships, regional senses, later learner-facing preferences, and per-variant provenance. A separate corpus/register and pronunciation inventory should precede any preference label.
 
 No immutable source, parser, runtime lexicon, pronunciation table, test, identity, status, corpus, survey, release, or deployment state is changed.

--- a/docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-SOURCE-INVENTORY-R1.md
+++ b/docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-SOURCE-INVENTORY-R1.md
@@ -1,0 +1,107 @@
+# ISSUE-653 midnight/noon temporal source inventory R1
+
+Parent issue: #653  
+Work claim: #654  
+Date: 2026-08-07
+
+## Scope
+
+This inventory evaluates Week 18 I036 `午夜`, I037 `正午`, I057 `半夜`, and I058 `中午`. It separates lexical meaning, noun classification, pronunciation notation, changed tone, regional senses, and source-preserving consequences.
+
+No immutable source, runtime lexicon, pronunciation table, parser, identity, status, corpus, survey, release, or deployment change is authorized.
+
+## Evidence ledger
+
+| source_id | evidence_grade | verification | citation_and_locator | what_it_supports | limit | disposition |
+|---|---|---|---|---|---|---|
+| `SRC-WORDSHK-NG5-JE6` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `午夜`, reading `ng5 je6`, noun; definition: around twelve o’clock at night, used to distinguish midnight from daytime noon. | Supports lexical identity, reading, noun class, and midnight-centered meaning. | Dictionary evidence does not establish construction syntax, frequency, CEFR level, or a categorical register contrast with `半夜`. | `RETAIN_MIDNIGHT_CENTERED_LEXEME` |
+| `SRC-WORDSHK-BUN3-JE2` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `半夜`, reading `bun3 je2`, noun; definition: usually the period after midnight until dawn; English “midnight; late at night.” | Supports lexical identity, current changed-tone surface, noun class, and a broader late-night/post-midnight temporal range. | Does not document the base tone, speaker distribution, optionality, or relationship to the Week 18 `bun3 je6` notation. | `RETAIN_BROADER_NIGHT_RANGE_AND_JE2_ATTESTATION` |
+| `SRC-CANTODICT-BUN3-JE6-6STAR2` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_and_tone_notation_inspected` | CantoDict, entry `半夜`, Jyutping display `bun3 je6/6*2`, gloss “12 midnight”; site documentation states the asterisk convention marks changed-tone readings. | Supports a lexical representation preserving tone-6 and changed-tone-2 information for `夜` in this word. | Collaborative dictionary; the notation does not by itself establish which surface is preferred, obligatory, regional, or register-specific. | `RETAIN_BASE_CHANGED_TONE_NOTATION_CONFLICT` |
+| `SRC-WORDSHK-ZING3-NG5` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `正午`, reading `zing3 ng5`, noun; definition: twelve o’clock in the daytime; English “high noon; noon.” | Supports lexical identity, reading, noun class, and exact-noon meaning. | Does not establish frequency, formality, or categorical contrast with `中午`. | `RETAIN_EXACT_NOON_LEXEME` |
+| `SRC-WORDSHK-ZUNG1-NG5` | `LEXICAL_OR_PRONUNCIATION_ONLY` | `dictionary_entry_inspected` | Words.hk, entry `中午`, reading `zung1 ng5`, noun; temporal sense defined as equivalent to `正午`, daytime twelve; English “noon; midday”; separate Macau sense “lunch.” | Supports lexical identity, reading, noun class, temporal overlap with `正午`, and a separate regional non-temporal sense. | Does not establish a universal colloquial/formal distinction or exact duration of “midday” in all contexts. | `RETAIN_COMMON_NOON_MIDDAY_AND_REGIONAL_SENSE_BOUNDARY` |
+| `SRC-ALDERETE-CHAN-TANAKA-2022-CHANGED-TONE` | `DIRECT_SCHOLARLY_CORE` | `publisher_metadata_abstract_and_article_scope_inspected` | John Alderete, Queenie Chan, and Shin-ichi Tanaka. 2022. “The Morphology of Cantonese ‘Changed Tone’: Extensions and Limitations.” *Gengo Kenkyu* 161:139–169. DOI `10.11435/gengo.161.0_139`. | Directly establishes Cantonese changed tone as morphological substitution of a base tone by high-level or high-rising tone in selected derived environments and emphasizes empirical limits. | The inspected source does not identify `半夜`; it cannot prove this lexeme’s exact alternation, optionality, or preferred surface. | `GENERAL_CHANGED_TONE_INTERPRETIVE_SUPPORT_ONLY` |
+| `SRC-WONG-1982-TONE-CHANGE-LEAD` | `DISCOVERY_LEAD_ONLY` | `dissertation_metadata_and_abstract_inspected_fulltext_restricted` | Maurice Kuen-Shing Wong. 1982. *Tone Change in Cantonese*. PhD dissertation, University of Illinois Urbana-Champaign. | Identifies a broad synchronic, diachronic, lexical, and stylistic investigation of Cantonese tone change. | Full substantive text was not inspected; no claim about `半夜` or style distribution is imported. | `BIBLIOGRAPHIC_LEAD_ONLY` |
+| `SRC-GLOSSIKA-W18-I036-I037-I057-I058` | `ATTESTATION_ONLY` | `checked_in_source_inspected` | `data/pedagogical-corpus/glossika/GLOSSIKA-YUEHK-A1-W18-20260719/source.json`: I036 `午夜 ng5 je6 — midnight`; I037 `正午 zing3 ng5 — noon`; I057 `半夜 bun3 je6 — midnight`; I058 `中午 zung1 ng5 — noon`. | Attests exact source forms, readings, glosses, ordering, and lesson classification. | Pedagogical source; does not independently establish lexical range, pronunciation preference, register, or proficiency level. | `RETAIN_AS_EXACT_TRIGGER` |
+| `PROJECT-W18-F11-ROUTE` | `RUNTIME_OBSERVATION_ONLY` | `route_record_inspected` | Issue #481, route W18-F11. | Documents the retained temporal lexical/register dependency. | Routing has zero independent linguistic-evidence weight. | `RETAIN_AS_REPOSITORY_TRIGGER` |
+
+## Supported lexical propositions
+
+The checked lexical sources support:
+
+1. all four items are nouns;
+2. `午夜` identifies midnight or the time around nighttime twelve;
+3. `半夜` can cover the post-midnight-to-dawn period and late night more broadly;
+4. `正午` identifies daytime twelve or high noon;
+5. `中午` temporally overlaps with `正午` and can be glossed noon/midday;
+6. `中午` has a separate Macau-specific “lunch” sense;
+7. `半夜 bun3 je2` is a current dictionary pronunciation;
+8. another dictionary preserves `bun3 je6/6*2`, linking tone 6 with a changed-tone-2 notation.
+
+## Changed-tone inference limit
+
+The direct changed-tone article supports the existence and morphological nature of the general process. It does not contain the lexeme `半夜` in the inspected evidence used for this packet.
+
+Therefore the combined evidence permits this inference only:
+
+```text
+The je6／je2 dictionary notation is compatible with a Cantonese base-versus-changed-tone analysis.
+```
+
+It does not establish:
+
+- which variant every speaker produces;
+- whether `je6` is a citation-only form;
+- whether `je2` is obligatory in ordinary speech;
+- whether the variants encode semantic or register differences;
+- whether a productive changed-tone rule should be applied by the parser or lexicon.
+
+## Gloss dispositions
+
+### `午夜 — midnight`
+
+Accurate basic gloss. The dictionary definition adds “around nighttime twelve” and explicit contrast with noon.
+
+### `半夜 — midnight`
+
+Possible in some contexts but inadequate as the sole teaching gloss. It obscures “late at night” and the period after midnight until dawn.
+
+### `正午 — noon`
+
+Accurate basic gloss. “High noon” or exact daytime twelve adds precision.
+
+### `中午 — noon`
+
+Accurate basic temporal gloss. “Midday” is also supported. The Macau “lunch” sense must remain a separate lexical sense.
+
+## Pronunciation disposition for I057
+
+The source reading `bun3 je6` is preserved as immutable source data.
+
+The evidence state is:
+
+- `bun3 je2`: directly attested by Words.hk;
+- `bun3 je6/6*2`: directly attested by CantoDict;
+- changed-tone process: directly supported generally by scholarship;
+- exact lexeme-specific distribution: unresolved.
+
+The correct project consequence is a pronunciation-review annotation, not an automatic source correction or global runtime replacement.
+
+## Unsupported conclusions
+
+The evidence does not establish:
+
+- that `午夜` and `半夜` are exact synonyms;
+- that `正午` and `中午` are never interchangeable;
+- a categorical formal-versus-colloquial split;
+- A1 suitability or frequency rankings;
+- a universal bare temporal-modifier syntax for all four nouns;
+- that source `bun3 je6` is simply erroneous;
+- that a global changed-tone rule can derive the learner-facing pronunciation safely;
+- a construction identity or parser rule;
+- current runtime lexicon correctness.
+
+## Repository consequence
+
+The strongest next action is a bounded lexical-representation design audit capable of preserving source readings, base tones, changed-tone surfaces, regional senses, learner-facing preferences, and per-variant provenance. A separate corpus/register inventory should test usage differences before any frequency or formality label.
+
+No immutable source, parser, runtime lexicon, pronunciation table, test, identity, status, corpus, survey, release, or deployment state is changed.


### PR DESCRIPTION
Closes #653

Work claim: #654

## Outcome

Resolves the bounded Week 18 F11 day-boundary lexical route for `午夜／半夜` and `正午／中午`.

## Decisions

- All four source forms are valid temporal nouns.
- `午夜` is midnight-centered; `半夜` has a broader late-night or post-midnight range, so the duplicate English gloss is pedagogically underspecified.
- `正午` and `中午` substantially overlap at daytime twelve; the duplicate “noon” gloss is acceptable as a basic gloss.
- `中午` retains a separate Macau-specific “lunch” sense.
- Week 18 `半夜 bun3 je6` is preserved and not categorically rejected.
- Current dictionaries attest `bun3 je2` and display `bun3 je6/6*2`; scholarship supports changed tone generally but does not establish this lexeme's derivation or preferred surface.
- Learner-facing pronunciation preference remains unresolved pending contextual pronunciation and lexical-design review.
- No global changed-tone rule or runtime pronunciation replacement is authorized.

## Changed files

- `docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-LEXICON-AUDIT-R1.md`
- `docs/research/ISSUE-653-MIDNIGHT-NOON-TEMPORAL-SOURCE-INVENTORY-R1.md`

## Protected and unchanged

No immutable source value, parser/runtime code, runtime lexicon, pronunciation table, test, generated output, version, construction identity/status, corpus classification, survey, release, package, or deployment state changes.

Active AB33 and AA84 implementation scopes remain untouched.

## Validation

- Exact reviewed head: `a04ebcce7cf60b76489524ebb513e24c2f4c675d`.
- Exact comparison contains only the two claimed files and is current with `main`.
- The changed-tone and learner-preference overclaim was repaired and rereviewed.
- Research provenance: PASS, run 31147016040.
- Intake #653 and claim #654 agree on owner, revision, branch, and PR.

No blocker remains.