### PR TITLE
Expose parser slot provenance and structural sanity diagnostics

### DIFF
--- a/tests/tooling/parser-coverage/coverage.test.js
+++ b/tests/tooling/parser-coverage/coverage.test.js
@@ -7,7 +7,10 @@ const {
   aggregateCoverage,
   buildCoverageRecord,
   categoriesForSummary,
+  formatRecordDetails,
   recordsFromFullDiagnostics,
+  structuralSanityFindings,
+  uniqueRelativeSpan,
 } = require("../../../tools/parser-coverage-report");
 
 test("unknown lexical traces remain distinct from structural coverage", () => {
@@ -93,7 +96,20 @@ test("full diagnostics exports can be aggregated without rerunning the parser", 
             surface: "例子",
             depth: 0,
             trace: "generative_template",
-            trace_detail: { kind: "generative_template", template_family: "generative_template" },
+            trace_detail: {
+              kind: "generative_template",
+              template_family: "generative_template",
+              assigned_slots: ["subject", "predicate"],
+              surfaces: ["例", "子"],
+            },
+          },
+          {
+            kind: "token",
+            surface: "例",
+            depth: 1,
+            parent: "ExampleConstruction",
+            trace: "atomic_lexicon",
+            label: "who",
           },
         ],
       },
@@ -104,5 +120,160 @@ test("full diagnostics exports can be aggregated without rerunning the parser", 
   assert.equal(records[0].source_artifact, "sample.json");
   assert.equal(records[0].diagnostic_index, 4);
   assert.equal(records[0].construction_traces[0].construction, "ExampleConstruction");
+  assert.equal(records[0].construction_traces[0].slot_bindings[0].slot, "subject");
+  assert.deepEqual(records[0].construction_traces[0].slot_bindings[0].relative_span, {
+    status: "unique",
+    start: 0,
+    end: 1,
+  });
+  assert.equal(records[0].token_provenance[0].lexical_status, "known_lexicon");
   assert.equal(records[0].coverage_status, "COVERED");
+});
+
+test("parent-relative construction spans are exposed when uniquely locatable", () => {
+  const record = buildCoverageRecord(
+    {
+      source: "我食飯",
+      construction_count: 2,
+      top_constructions: ["SubjectPredicateClause"],
+      trace_summary: { generative_template: 2, atomic_lexicon: 3 },
+      template_family_summary: { generative_template: 2 },
+      root_span_coverage_status: "PASS",
+      root_top_construction_count: 1,
+      semantic_acceptance_status: "MANUAL_REVIEW_ELIGIBLE",
+    },
+    [
+      {
+        kind: "construction",
+        construction: "SubjectPredicateClause",
+        surface: "我食飯",
+        depth: 0,
+        trace: "generative_template",
+        trace_detail: {
+          kind: "generative_template",
+          template_family: "generative_template",
+          assigned_slots: ["subject", "predicate"],
+          surfaces: ["我", "食飯"],
+        },
+      },
+      {
+        kind: "construction",
+        construction: "ProductiveVO",
+        surface: "食飯",
+        depth: 1,
+        parent: "SubjectPredicateClause",
+        trace: "generative_template",
+        trace_detail: {
+          kind: "generative_template",
+          template_family: "generative_template",
+          assigned_slots: ["verb", "object"],
+          surfaces: ["食", "飯"],
+        },
+      },
+    ],
+  );
+  assert.deepEqual(record.construction_traces[1].parent_relative_span, {
+    status: "unique",
+    start: 1,
+    end: 3,
+  });
+  assert.equal(record.sanity_findings.length, 0);
+});
+
+test("structural sanity checks surface provenance inconsistencies", () => {
+  const summary = {
+    root_span_coverage_status: "PASS",
+    unwrapped_root_surfaces: ["尾"],
+  };
+  const findings = structuralSanityFindings(summary, [
+    {
+      construction: "ModalVP",
+      surface: "我要飲水",
+      depth: 0,
+      parent: "",
+      parent_surface: "",
+      parent_relative_span: { status: "root", start: 0, end: 4 },
+      trace_kind: "generative_template",
+      template_family: "",
+      assigned_slots: ["subject", "modal", "vp"],
+      slot_surfaces: ["我", "要"],
+      slot_bindings: [
+        { slot: "subject", surface: "我", relative_span: { status: "unique", start: 0, end: 1 } },
+        { slot: "modal", surface: "要", relative_span: { status: "unique", start: 1, end: 2 } },
+      ],
+    },
+  ]);
+  assert.deepEqual(
+    findings.map((finding) => finding.code).sort(),
+    [
+      "pass_with_unwrapped_root_surface",
+      "root_vp_binds_subject",
+      "slot_surface_count_mismatch",
+      "template_family_missing",
+    ].sort(),
+  );
+});
+
+test("child construction outside parent and slot surface outside construction are flagged", () => {
+  const findings = structuralSanityFindings({}, [
+    {
+      construction: "ChildVP",
+      surface: "飲水",
+      depth: 1,
+      parent: "ParentClause",
+      parent_surface: "我食飯",
+      parent_relative_span: { status: "not_found", start: null, end: null },
+      trace_kind: "generative_template",
+      template_family: "generative_template",
+      assigned_slots: ["verb"],
+      slot_surfaces: ["睇"],
+      slot_bindings: [
+        { slot: "verb", surface: "睇", relative_span: { status: "not_found", start: null, end: null } },
+      ],
+    },
+  ]);
+  assert.deepEqual(
+    findings.map((finding) => finding.code).sort(),
+    ["child_surface_outside_parent", "slot_surface_outside_construction"].sort(),
+  );
+});
+
+test("relative span helper refuses ambiguous repeated surfaces", () => {
+  assert.deepEqual(uniqueRelativeSpan("食食飯", "食"), {
+    status: "ambiguous",
+    start: null,
+    end: null,
+  });
+});
+
+test("detailed human output exposes slots and sanity findings", () => {
+  const record = buildCoverageRecord(
+    {
+      source: "我係老師",
+      construction_count: 1,
+      top_constructions: ["CopularIdentificationFrame"],
+      trace_summary: { generative_template: 1 },
+      template_family_summary: {},
+      root_span_coverage_status: "PASS",
+      root_top_construction_count: 1,
+      semantic_acceptance_status: "MANUAL_REVIEW_ELIGIBLE",
+    },
+    [
+      {
+        kind: "construction",
+        construction: "CopularIdentificationFrame",
+        surface: "我係老師",
+        depth: 0,
+        trace: "generative_template",
+        trace_detail: {
+          kind: "generative_template",
+          assigned_slots: ["subject", "copula", "predicate"],
+          surfaces: ["我", "係", "老師"],
+        },
+      },
+    ],
+  );
+  const text = formatRecordDetails(record);
+  assert(text.includes("slot subject = [我]"));
+  assert(text.includes("template_family_missing"));
 });

--- a/tests/tooling/parser-coverage/coverage.test.js
+++ b/tests/tooling/parser-coverage/coverage.test.js
@@ -8,6 +8,7 @@ const {
   buildCoverageRecord,
   categoriesForSummary,
   formatRecordDetails,
+  recordsForSentences,
   recordsFromFullDiagnostics,
   structuralSanityFindings,
   uniqueRelativeSpan,
@@ -276,4 +277,17 @@ test("detailed human output exposes slots and sanity findings", () => {
   const text = formatRecordDetails(record);
   assert(text.includes("slot subject = [我]"));
   assert(text.includes("template_family_missing"));
+});
+
+test("live source runtime exposes slot provenance for the basic smoke anomalies", () => {
+  const records = recordsForSentences(["我要飲水。", "我想睇電視。", "我係老師。"]).toSorted((a, b) => a.source.localeCompare(b.source));
+  const modal = records.find((record) => record.source === "我要飲水。");
+  const desiderative = records.find((record) => record.source === "我想睇電視。");
+  const copular = records.find((record) => record.source === "我係老師。");
+
+  assert(modal.construction_traces[0].slot_bindings.some((binding) => binding.slot === "subject"));
+  assert(modal.sanity_findings.some((finding) => finding.code === "root_vp_binds_subject"));
+  assert(desiderative.construction_traces[0].slot_bindings.some((binding) => binding.slot === "subject"));
+  assert(desiderative.sanity_findings.some((finding) => finding.code === "root_vp_binds_subject"));
+  assert(copular.sanity_findings.some((finding) => finding.code === "template_family_missing"));
 });

--- a/tools/parser-coverage-report.js
+++ b/tools/parser-coverage-report.js
@@ -6,7 +6,7 @@ const path = require("node:path");
 const { loadRuntimeApi } = require("./lib/runtime-api");
 
 const COVERAGE_SCHEMA = "canto-span-parser-coverage-report-v1";
-const RECORD_SCHEMA = "canto-span-parser-coverage-record-v1";
+const RECORD_SCHEMA = "canto-span-parser-coverage-record-v2";
 
 const ACTIONABLE_TRACE_KINDS = Object.freeze([
   "unknown_atomic",
@@ -40,20 +40,205 @@ function unique(values) {
   return [...new Set((values || []).filter(Boolean))];
 }
 
+function rowSurface(row = {}) {
+  return row.display_surface || row.surface || row.parser_surface || "";
+}
+
+function uniqueRelativeSpan(parentSurface = "", childSurface = "") {
+  const parent = String(parentSurface || "");
+  const child = String(childSurface || "");
+  if (!child) return { status: "empty_surface", start: null, end: null };
+  if (!parent) return { status: "no_parent_surface", start: null, end: null };
+
+  const first = parent.indexOf(child);
+  if (first < 0) return { status: "not_found", start: null, end: null };
+  const second = parent.indexOf(child, first + 1);
+  if (second >= 0) return { status: "ambiguous", start: null, end: null };
+  return { status: "unique", start: first, end: first + child.length };
+}
+
+function slotBindingsForTrace(detail = {}, constructionSurface = "") {
+  const slots = Array.isArray(detail.assigned_slots) ? detail.assigned_slots : [];
+  const surfaces = Array.isArray(detail.surfaces) ? detail.surfaces : [];
+  const length = Math.max(slots.length, surfaces.length);
+  const bindings = [];
+  for (let index = 0; index < length; index += 1) {
+    const surface = String(surfaces[index] || "");
+    bindings.push({
+      index,
+      slot: slots[index] || "",
+      surface,
+      relative_span: uniqueRelativeSpan(constructionSurface, surface),
+    });
+  }
+  return bindings;
+}
+
 function constructionTraceRows(finalRows = []) {
+  const traces = [];
+  const constructionStack = [];
+
+  for (const row of finalRows || []) {
+    if (!row || row.kind !== "construction") continue;
+    const depth = Number(row.depth || 0);
+    while (constructionStack.length && constructionStack[constructionStack.length - 1].depth >= depth) {
+      constructionStack.pop();
+    }
+
+    const parentRow = constructionStack.length ? constructionStack[constructionStack.length - 1] : null;
+    const detail = row.trace_detail || {};
+    const surface = rowSurface(row);
+    const traceKind = detail.kind || row.trace || "unspecified";
+    const slotBindings = slotBindingsForTrace(detail, surface);
+    const trace = {
+      surface,
+      construction: row.construction || row.internal_construction || row.type || "",
+      internal_construction: row.internal_construction || row.type || "",
+      depth,
+      parent: row.parent || "",
+      parent_surface: parentRow ? parentRow.surface : "",
+      parent_relative_span: parentRow ? uniqueRelativeSpan(parentRow.surface, surface) : {
+        status: "root",
+        start: 0,
+        end: surface.length,
+      },
+      trace_kind: traceKind,
+      template_family: detail.template_family || "",
+      rule: detail.rule || "",
+      template: Array.isArray(detail.template) ? detail.template : [],
+      assigned_slots: Array.isArray(detail.assigned_slots) ? [...detail.assigned_slots] : [],
+      slot_surfaces: Array.isArray(detail.surfaces) ? [...detail.surfaces] : [],
+      slot_bindings: slotBindings,
+    };
+    traces.push(trace);
+    constructionStack.push({ depth, surface, construction: trace.construction });
+  }
+  return traces;
+}
+
+function tokenProvenanceRows(finalRows = []) {
   return (finalRows || [])
-    .filter((row) => row && row.kind === "construction")
+    .filter((row) => row && row.kind === "token")
     .map((row) => {
       const detail = row.trace_detail || {};
+      const traceKind = detail.kind || row.trace || "unspecified";
+      let lexicalStatus = "other_traced_material";
+      if (traceKind === "unknown_atomic") lexicalStatus = "unknown";
+      else if (traceKind === "atomic_lexicon") lexicalStatus = "known_lexicon";
+      else if (traceKind === "punctuation_or_plain_text") lexicalStatus = "punctuation_or_plain_text";
+
       return {
-        surface: row.display_surface || row.surface || "",
-        construction: row.construction || row.internal_construction || row.type || "",
+        surface: rowSurface(row),
         depth: Number(row.depth || 0),
         parent: row.parent || "",
-        trace_kind: detail.kind || row.trace || "unspecified",
-        template_family: detail.template_family || "",
+        label: row.label || "",
+        role: row.role || "",
+        syntax: row.syntax || "",
+        jyutping: row.jyutping || "",
+        trace_kind: traceKind,
+        lexical_status: lexicalStatus,
+        slots: Array.isArray(row.slots) ? [...row.slots] : [],
       };
     });
+}
+
+function sanityFinding(code, severity, message, context = {}) {
+  return { code, severity, message, ...context };
+}
+
+function structuralSanityFindings(summary = {}, constructionTraces = []) {
+  const findings = [];
+
+  if (
+    summary.root_span_coverage_status === "PASS" &&
+    Array.isArray(summary.unwrapped_root_surfaces) &&
+    summary.unwrapped_root_surfaces.length
+  ) {
+    findings.push(sanityFinding(
+      "pass_with_unwrapped_root_surface",
+      "error",
+      "Root coverage is PASS even though unwrapped root surfaces remain.",
+      { surfaces: [...summary.unwrapped_root_surfaces] },
+    ));
+  }
+
+  for (const trace of constructionTraces) {
+    const slotCount = trace.assigned_slots.length;
+    const surfaceCount = trace.slot_surfaces.length;
+    if ((slotCount || surfaceCount) && slotCount !== surfaceCount) {
+      findings.push(sanityFinding(
+        "slot_surface_count_mismatch",
+        "error",
+        "Template trace has different assigned-slot and slot-surface counts.",
+        {
+          construction: trace.construction,
+          surface: trace.surface,
+          assigned_slot_count: slotCount,
+          slot_surface_count: surfaceCount,
+        },
+      ));
+    }
+
+    if (trace.trace_kind === "generative_template" && !trace.template_family) {
+      findings.push(sanityFinding(
+        "template_family_missing",
+        "warning",
+        "A generative-template trace does not expose a controlled template_family.",
+        { construction: trace.construction, surface: trace.surface },
+      ));
+    }
+
+    if (trace.depth > 0 && trace.parent_surface && trace.parent_relative_span.status === "not_found") {
+      findings.push(sanityFinding(
+        "child_surface_outside_parent",
+        "error",
+        "Construction surface cannot be located inside its parent construction surface.",
+        {
+          construction: trace.construction,
+          surface: trace.surface,
+          parent: trace.parent,
+          parent_surface: trace.parent_surface,
+        },
+      ));
+    }
+
+    for (const binding of trace.slot_bindings) {
+      if (binding.surface && binding.relative_span.status === "not_found") {
+        findings.push(sanityFinding(
+          "slot_surface_outside_construction",
+          "error",
+          "A bound slot surface cannot be located inside the construction surface.",
+          {
+            construction: trace.construction,
+            surface: trace.surface,
+            slot: binding.slot,
+            slot_surface: binding.surface,
+          },
+        ));
+      }
+    }
+
+    if (
+      trace.depth === 0 &&
+      /VP$/.test(trace.construction) &&
+      trace.assigned_slots.some((slot) => slot === "subject" || slot === "overt_subject")
+    ) {
+      findings.push(sanityFinding(
+        "root_vp_binds_subject",
+        "warning",
+        "A root construction named as a VP explicitly binds a subject slot; inspect whether the runtime label or span boundary is clause-sized.",
+        {
+          construction: trace.construction,
+          surface: trace.surface,
+          subject_bindings: trace.slot_bindings.filter((binding) => (
+            binding.slot === "subject" || binding.slot === "overt_subject"
+          )),
+        },
+      ));
+    }
+  }
+
+  return findings;
 }
 
 function categoriesForSummary(summary = {}) {
@@ -107,6 +292,10 @@ function coverageStatusForSummary(summary = {}, categories = categoriesForSummar
 
 function buildCoverageRecord(summary = {}, finalRows = [], metadata = {}) {
   const categories = categoriesForSummary(summary);
+  const constructionTraces = constructionTraceRows(finalRows);
+  const tokenProvenance = tokenProvenanceRows(finalRows);
+  const sanityFindings = structuralSanityFindings(summary, constructionTraces);
+
   return {
     schema: RECORD_SCHEMA,
     source: summary.source || metadata.source || "",
@@ -123,12 +312,14 @@ function buildCoverageRecord(summary = {}, finalRows = [], metadata = {}) {
     missing_argument_slots: summary.missing_argument_slots || [],
     trace_kind_counts: { ...(summary.trace_summary || {}) },
     template_family_counts: { ...(summary.template_family_summary || {}) },
-    construction_traces: constructionTraceRows(finalRows),
+    construction_traces: constructionTraces,
+    token_provenance: tokenProvenance,
+    sanity_findings: sanityFindings,
     source_artifact: metadata.source_artifact || "live_runtime",
     diagnostic_index: metadata.diagnostic_index,
     linguistic_confidence: null,
     evidence_weight: 0,
-    policy: "Implementation coverage/provenance only. Parser output, trace frequency, corpus frequency, and repeated matches do not establish linguistic support or confidence.",
+    policy: "Implementation coverage/provenance only. Parser output, trace frequency, corpus frequency, repeated matches, and sanity findings do not establish linguistic support or confidence.",
   };
 }
 
@@ -155,19 +346,35 @@ function aggregateCoverage(records = [], options = {}) {
   const templateFamilyCounts = {};
   const topConstructionCounts = {};
   const samplesByCategory = {};
+  const sanityFindingCounts = {};
+  const sanitySamples = {};
 
   for (const record of records) {
     statusCounts[record.coverage_status] = (statusCounts[record.coverage_status] || 0) + 1;
     mergeCounts(traceKindCounts, record.trace_kind_counts);
     mergeCounts(templateFamilyCounts, record.template_family_counts);
+
     for (const construction of record.top_constructions || []) {
       topConstructionCounts[construction] = (topConstructionCounts[construction] || 0) + 1;
     }
+
     for (const category of record.categories || []) {
       categoryCounts[category] = (categoryCounts[category] || 0) + 1;
       if (!samplesByCategory[category]) samplesByCategory[category] = [];
       if (samplesByCategory[category].length < sampleLimit) {
         samplesByCategory[category].push(record.source || record.parser_shadow_source || "");
+      }
+    }
+
+    for (const finding of record.sanity_findings || []) {
+      sanityFindingCounts[finding.code] = (sanityFindingCounts[finding.code] || 0) + 1;
+      if (!sanitySamples[finding.code]) sanitySamples[finding.code] = [];
+      if (sanitySamples[finding.code].length < sampleLimit) {
+        sanitySamples[finding.code].push({
+          source: record.source || record.parser_shadow_source || "",
+          construction: finding.construction || "",
+          surface: finding.surface || "",
+        });
       }
     }
   }
@@ -193,12 +400,14 @@ function aggregateCoverage(records = [], options = {}) {
     trace_kind_counts: traceKindCounts,
     template_family_counts: templateFamilyCounts,
     top_construction_counts: topConstructionCounts,
+    sanity_finding_counts: sanityFindingCounts,
+    sanity_samples: sanitySamples,
     architectural_debt_trace_counts: architecturalDebt,
     specialized_non_debt_trace_counts: specializedImplementation,
     samples_by_category: samplesByCategory,
     linguistic_confidence: null,
     evidence_weight: 0,
-    policy: "Counts describe deterministic parser implementation coverage only. They are prioritization signals, not linguistic evidence, productivity estimates, naturalness evidence, or confidence scores.",
+    policy: "Counts and sanity findings describe deterministic parser implementation behavior only. They are prioritization/debugging signals, not linguistic evidence, productivity estimates, naturalness evidence, or confidence scores.",
     records,
   };
 }
@@ -220,6 +429,7 @@ function parseArgs(argv) {
     files: [],
     diagnosticFiles: [],
     json: false,
+    details: false,
     sampleLimit: 3,
     help: false,
   };
@@ -229,6 +439,7 @@ function parseArgs(argv) {
     else if (arg === "--file" || arg === "-f") options.files.push(argv[++index] || "");
     else if (arg === "--diagnostics" || arg === "-d") options.diagnosticFiles.push(argv[++index] || "");
     else if (arg === "--samples") options.sampleLimit = Number(argv[++index] || 3);
+    else if (arg === "--details") options.details = true;
     else if (arg === "--json") options.json = true;
     else if (arg === "--help" || arg === "-h") options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
@@ -255,7 +466,55 @@ function formatCountMap(counts = {}, limit = 20) {
     .join("\n");
 }
 
-function formatHumanReport(report) {
+function formatSpan(span = {}) {
+  if (span.status === "root") return "root";
+  if (span.status === "unique") return `${span.start}:${span.end}`;
+  return span.status || "unknown";
+}
+
+function formatRecordDetails(record) {
+  const parts = [
+    `Sentence: ${record.source || record.parser_shadow_source || "(empty)"}`,
+    `  coverage: ${record.coverage_status}`,
+    `  root span: ${record.root_span_coverage_status}`,
+    "  constructions:",
+  ];
+
+  if (!record.construction_traces.length) {
+    parts.push("    (none)");
+  } else {
+    for (const trace of record.construction_traces) {
+      const indent = "    " + "  ".repeat(trace.depth);
+      const provenance = [trace.trace_kind, trace.template_family].filter(Boolean).join("/");
+      parts.push(`${indent}${trace.construction} [${trace.surface}] span=${formatSpan(trace.parent_relative_span)} trace=${provenance || "unspecified"}`);
+      for (const binding of trace.slot_bindings) {
+        parts.push(`${indent}  slot ${binding.slot || "(unlabeled)"} = [${binding.surface}] @ ${formatSpan(binding.relative_span)}`);
+      }
+    }
+  }
+
+  parts.push("  tokens:");
+  if (!record.token_provenance.length) {
+    parts.push("    (none)");
+  } else {
+    for (const token of record.token_provenance) {
+      parts.push(`    [${token.surface}] ${token.lexical_status} trace=${token.trace_kind}${token.label ? ` label=${token.label}` : ""}`);
+    }
+  }
+
+  parts.push("  sanity:");
+  if (!record.sanity_findings.length) {
+    parts.push("    none");
+  } else {
+    for (const finding of record.sanity_findings) {
+      parts.push(`    ${finding.severity.toUpperCase()} ${finding.code}: ${finding.message}`);
+    }
+  }
+
+  return parts.join("\n");
+}
+
+function formatHumanReport(report, options = {}) {
   const percent = report.analysis_count
     ? (100 * report.implementation_covered_fraction).toFixed(1)
     : "0.0";
@@ -269,6 +528,9 @@ function formatHumanReport(report) {
     "",
     "Coverage categories:",
     formatCountMap(report.category_counts) || "  (none)",
+    "",
+    "Structural sanity findings:",
+    formatCountMap(report.sanity_finding_counts) || "  (none)",
     "",
     "Trace kinds:",
     formatCountMap(report.trace_kind_counts) || "  (none)",
@@ -284,6 +546,10 @@ function formatHumanReport(report) {
     parts.push("", "Specialized implementation (not automatically debt):");
     for (const row of report.specialized_non_debt_trace_counts) parts.push(`  ${row.trace_kind}: ${row.count}`);
   }
+  if (options.details) {
+    parts.push("", "Per-sentence provenance:");
+    for (const record of report.records) parts.push("", formatRecordDetails(record));
+  }
   parts.push("", `Policy: ${report.policy}`);
   return parts.join("\n");
 }
@@ -291,16 +557,17 @@ function formatHumanReport(report) {
 function usage() {
   return [
     "Usage:",
-    "  node tools/parser-coverage-report.js --sentence \"我食咗飯。\" [--sentence ...] [--json]",
-    "  node tools/parser-coverage-report.js --file sentences.txt [--json]",
-    "  node tools/parser-coverage-report.js --diagnostics note.canto-span-full-diagnostics.json [--json]",
+    "  node tools/parser-coverage-report.js --sentence \"我食咗飯。\" [--sentence ...] [--details] [--json]",
+    "  node tools/parser-coverage-report.js --file sentences.txt [--details] [--json]",
+    "  node tools/parser-coverage-report.js --diagnostics note.canto-span-full-diagnostics.json [--details] [--json]",
     "",
     "Options:",
     "  -s, --sentence TEXT       Analyze one sentence with the current source runtime (repeatable).",
     "  -f, --file PATH           Analyze nonblank lines from a UTF-8 text file (repeatable).",
     "  -d, --diagnostics PATH    Aggregate an existing full-diagnostics JSON export (repeatable).",
-    "      --samples N           Keep up to N source examples per category in JSON output (default 3).",
-    "      --json                Emit machine-readable JSON instead of the compact text report.",
+    "      --samples N           Keep up to N source examples per category/finding in JSON output (default 3).",
+    "      --details             Include per-sentence construction tree, slot bindings, token provenance, and sanity findings.",
+    "      --json                Emit machine-readable JSON; detailed provenance is always present in records.",
     "  -h, --help                Show this help.",
   ].join("\n");
 }
@@ -323,7 +590,11 @@ function main(argv = process.argv.slice(2)) {
 
   if (!records.length) throw new Error("No input supplied. Use --sentence, --file, or --diagnostics.");
   const report = aggregateCoverage(records, { sampleLimit: options.sampleLimit });
-  process.stdout.write(options.json ? `${JSON.stringify(report, null, 2)}\n` : `${formatHumanReport(report)}\n`);
+  process.stdout.write(
+    options.json
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : `${formatHumanReport(report, { details: options.details })}\n`,
+  );
 }
 
 if (require.main === module) {
@@ -346,8 +617,13 @@ module.exports = {
   constructionTraceRows,
   coverageStatusForSummary,
   formatHumanReport,
+  formatRecordDetails,
   main,
   parseArgs,
   recordsForSentences,
   recordsFromFullDiagnostics,
+  slotBindingsForTrace,
+  structuralSanityFindings,
+  tokenProvenanceRows,
+  uniqueRelativeSpan,
 };


### PR DESCRIPTION
Closes #670

<!-- coordination-claim: #671 -->
Work claim: #671
Closes #671

## Outcome

Extend the existing external parser coverage auditor so successful parses expose actual runtime slot bindings, conservative surface spans, token provenance, and automatic structural sanity findings without changing parser recognition.

## What changed

- preserve `trace_detail.assigned_slots` and corresponding `trace_detail.surfaces` as explicit ordered `slot_bindings`;
- expose construction parent surfaces and unique parent-relative offsets without inventing offsets when a repeated surface is ambiguous;
- expose token-level lexical provenance (`known_lexicon`, `unknown`, punctuation/plain text, other traced material) from existing diagnostic rows;
- add sanity findings for slot/surface count mismatch, missing template family, child outside parent surface, slot surface outside construction, root VP binding an overt subject, and PASS coverage with residual root surfaces;
- aggregate sanity finding counts and samples;
- add `--details` human output with per-sentence tree, slot bindings, token provenance, and sanity findings;
- retain JSON detail in every record and keep evidence weight at zero;
- expand focused tests for slot bindings, spans, token provenance, sanity checks, ambiguous spans, detailed human output, and the real basic-smoke anomalies.

## Protected state

No `src/**`, `main.js`, runtime version, parser recognition, construction identity/status, linguistic evidence, corpus classification, survey/panel, release, or deployment state changed. #668, #629, and #631 remain separate.

## Validation

Exact reviewed head: `7a126fe7827a6ae50c98b8b262cd781543137912`.

- Runtime source-first validation: PASS, run 31287869280.
- Focused auditor tests run inside the standard runtime suite and PASS.
- Live source-runtime integration assertions confirm:
  - `我要飲水。` exposes a subject slot and triggers `root_vp_binds_subject`;
  - `我想睇電視。` exposes a subject slot and triggers `root_vp_binds_subject`;
  - `我係老師。` triggers `template_family_missing`.
- Exact PR diff reviewed: two development-tool/test files only; no runtime source or generated bundle changes.
- No review submissions or unresolved review threads.