### PR TITLE
Temporary detailed parser audit smoke run

### DIFF
--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -15,6 +15,7 @@ const commands = [
   ["glossika_week16_lexicon", path.join(root, "tests", "tooling", "lexicon", "glossika-week16-runtime-lexicon.test.js")],
   ["unit_word_evidence", path.join(root, "tests", "tooling", "runtime", "unit-word-evidence.test.js")],
   ["parser_coverage_auditor", path.join(root, "tests", "tooling", "parser-coverage", "coverage.test.js")],
+  ["parser_audit_smoke_10", path.join(root, "tests", "tooling", "parser-coverage", "audit-smoke-10.test.js")],
 ];
 const generatedPaths = [
   "validation/current/regression-suite.json",

--- a/tests/tooling/parser-coverage/audit-smoke-10.test.js
+++ b/tests/tooling/parser-coverage/audit-smoke-10.test.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+"use strict";
+
+const test = require("node:test");
+const {
+  aggregateCoverage,
+  recordsForSentences,
+} = require("../../../tools/parser-coverage-report");
+
+const PHRASES = [
+  "你好。",
+  "我食飯。",
+  "我食咗飯。",
+  "我係老師。",
+  "我有一本書。",
+  "我唔食飯。",
+  "我要飲水。",
+  "你食唔食飯？",
+  "佢喺屋企。",
+  "我想睇電視。",
+];
+
+test("temporary detailed audit smoke output for the original 10 phrases", () => {
+  const records = recordsForSentences(PHRASES);
+  const aggregate = aggregateCoverage(records, { sampleLimit: 10 });
+  const payload = {
+    aggregate: {
+      analysis_count: aggregate.analysis_count,
+      implementation_covered_count: aggregate.implementation_covered_count,
+      coverage_status_counts: aggregate.coverage_status_counts,
+      category_counts: aggregate.category_counts,
+      trace_kind_counts: aggregate.trace_kind_counts,
+      template_family_counts: aggregate.template_family_counts,
+      top_construction_counts: aggregate.top_construction_counts,
+      architectural_debt_trace_counts: aggregate.architectural_debt_trace_counts,
+      specialized_non_debt_trace_counts: aggregate.specialized_non_debt_trace_counts,
+      sanity_finding_counts: aggregate.sanity_finding_counts,
+      sanity_samples: aggregate.sanity_samples,
+    },
+    records: records.map((record) => ({
+      source: record.source,
+      coverage_status: record.coverage_status,
+      categories: record.categories,
+      top_constructions: record.top_constructions,
+      root_span_coverage_status: record.root_span_coverage_status,
+      construction_traces: record.construction_traces.map((trace) => ({
+        construction: trace.construction,
+        surface: trace.surface,
+        depth: trace.depth,
+        parent: trace.parent,
+        parent_surface: trace.parent_surface,
+        parent_relative_span: trace.parent_relative_span,
+        trace_kind: trace.trace_kind,
+        template_family: trace.template_family,
+        rule: trace.rule,
+        assigned_slots: trace.assigned_slots,
+        slot_bindings: trace.slot_bindings,
+      })),
+      token_provenance: record.token_provenance.map((token) => ({
+        surface: token.surface,
+        parent: token.parent,
+        label: token.label,
+        role: token.role,
+        trace_kind: token.trace_kind,
+        lexical_status: token.lexical_status,
+      })),
+      sanity_findings: record.sanity_findings,
+    })),
+  };
+
+  throw new Error(`AUDIT_SMOKE_10_JSON\n${JSON.stringify(payload, null, 2)}`);
+});


### PR DESCRIPTION
Ephemeral CI-only run of the merged parser coverage auditor against the same 10 basic Cantonese phrases used in the prior smoke test. The temporary test intentionally failed only after printing the detailed audit JSON so CI exposed the exact slot/span/token provenance and sanity findings. Results extracted successfully. Closed without merge.