### PR TITLE
Temporary enhanced parser audit smoke run

### DIFF
--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -16,6 +16,7 @@ const commands = [
   ["unit_word_evidence", path.join(root, "tests", "tooling", "runtime", "unit-word-evidence.test.js")],
   ["parser_coverage_auditor", path.join(root, "tests", "tooling", "parser-coverage", "coverage.test.js")],
   ["parser_coverage_enhanced", path.join(root, "tests", "tooling", "parser-coverage", "enhanced.test.js")],
+  ["same_ten_enhanced_smoke", path.join(root, "tests", "tooling", "parser-coverage", "same-ten-enhanced.smoke.js")],
 ];
 const generatedPaths = [
   "validation/current/regression-suite.json",

--- a/tests/tooling/parser-coverage/same-ten-enhanced.smoke.js
+++ b/tests/tooling/parser-coverage/same-ten-enhanced.smoke.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+"use strict";
+
+const { recordsForSentences, aggregateCoverage } = require("../../../tools/parser-coverage-enhanced");
+
+const sentences = [
+  "你好。",
+  "我食飯。",
+  "我食咗飯。",
+  "我係老師。",
+  "我有一本書。",
+  "我唔食飯。",
+  "我要飲水。",
+  "你食唔食飯？",
+  "佢喺屋企。",
+  "我想睇電視。",
+];
+
+const records = recordsForSentences(sentences);
+const report = aggregateCoverage(records);
+const compact = {
+  schema: "canto-span-same-ten-enhanced-smoke-v1",
+  analysis_count: report.analysis_count,
+  implementation_covered_count: report.implementation_covered_count,
+  coverage_status_counts: report.coverage_status_counts,
+  sanity_finding_counts: report.sanity_finding_counts,
+  architectural_debt_trace_counts: report.architectural_debt_trace_counts,
+  slot_span_resolution_counts: report.slot_span_resolution_counts,
+  unresolved_slot_span_count: report.unresolved_slot_span_count,
+  matcher_counts: report.matcher_counts,
+  records: records.map((record) => ({
+    source: record.source,
+    coverage_status: record.coverage_status,
+    root_span_coverage_status: record.root_span_coverage_status,
+    top_constructions: record.top_constructions,
+    sanity_findings: record.sanity_findings.map((finding) => finding.code),
+    constructions: record.construction_traces.map((trace) => ({
+      construction: trace.construction,
+      surface: trace.surface,
+      source_span: trace.source_span,
+      matcher_id: trace.matcher_id,
+      rule_descriptor: trace.rule_descriptor,
+      rule_descriptor_source: trace.rule_descriptor_source,
+      template_family: trace.template_family,
+      slots: trace.slot_bindings.map((binding) => ({
+        slot: binding.slot,
+        surface: binding.surface,
+        span: binding.relative_span,
+      })),
+    })),
+  })),
+};
+
+console.log(JSON.stringify(compact, null, 2));
+// Deliberate failure so tests/run-all.js prints stdout into the Actions log.
+process.exitCode = 1;


### PR DESCRIPTION
Ephemeral CI-only rerun of the same 10 basic Cantonese control phrases against merged enhanced parser auditor commit `92934c991b301104a65ba0d664b32555f3d5d170`. The smoke script intentionally exited nonzero only after printing the detailed report. All ordinary suites before the smoke output passed. Results: 10/10 COVERED, 43/43 slot spans resolved by ordered token sequence, 0 unresolved slot spans, sanity findings unchanged (`template_family_missing` x1, `root_vp_binds_subject` x2), and exact matcher fingerprints/rule descriptors captured. Closed without merge.