### PR TITLE
Temporary repo-wide parser architecture sweep

### DIFF
--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -16,6 +16,7 @@ const commands = [
   ["unit_word_evidence", path.join(root, "tests", "tooling", "runtime", "unit-word-evidence.test.js")],
   ["parser_coverage_auditor", path.join(root, "tests", "tooling", "parser-coverage", "coverage.test.js")],
   ["parser_coverage_enhanced", path.join(root, "tests", "tooling", "parser-coverage", "enhanced.test.js")],
+  ["repo_wide_parser_architecture_sweep", path.join(root, "tests", "tooling", "parser-coverage", "repo-wide-architecture-sweep.js")],
 ];
 const generatedPaths = [
   "validation/current/regression-suite.json",

--- a/tests/tooling/parser-coverage/repo-wide-architecture-sweep.js
+++ b/tests/tooling/parser-coverage/repo-wide-architecture-sweep.js
@@ -4,14 +4,15 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { loadRuntimeApi } = require("../../../tools/lib/runtime-api");
-const { enhanceCoverageRecord, aggregateCoverage, canonicalJson } = require("../../../tools/parser-coverage-enhanced");
+const { enhanceCoverageRecord, aggregateCoverage } = require("../../../tools/parser-coverage-enhanced");
+const traceMetadata = require("../../../src/runtime-resources/diagnostics/trace-metadata");
 
 const root = path.resolve(__dirname, "../../..");
 const api = loadRuntimeApi({ apiNames: ["analyzeLine", "diagnosticSummary", "diagnosticFinalRows"] });
-
-function readJson(relativePath) {
-  return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8"));
-}
+function readJson(relativePath) { return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8")); }
+function bump(obj, key, amount = 1) { obj[key] = (obj[key] || 0) + amount; }
+function addSet(map, key, value) { if (!map.has(key)) map.set(key, new Set()); map.get(key).add(value); }
+function example(map, key, value, limit = 4) { if (!map.has(key)) map.set(key, []); const a = map.get(key); if (!a.includes(value) && a.length < limit) a.push(value); }
 
 const corpus = new Map();
 function add(source, contextSource, origin) {
@@ -21,15 +22,12 @@ function add(source, contextSource, origin) {
   if (!corpus.has(key)) corpus.set(key, { source, context_source: context, origins: new Set() });
   corpus.get(key).origins.add(origin);
 }
-
 const regression = readJson("tests/fixtures/regression-snapshots.json");
 for (const row of regression.cases || []) add(row.source, row.context_source, "regression");
-
 const np = readJson("tests/fixtures/np-subsystem.json");
 for (const row of np.cases || []) add(row.surface, "", "np");
-
 const constructionDir = path.join(root, "tests", "constructions");
-for (const file of fs.readdirSync(constructionDir).filter((name) => name.endsWith(".json")).sort()) {
+for (const file of fs.readdirSync(constructionDir).filter((n) => n.endsWith(".json")).sort()) {
   const spec = JSON.parse(fs.readFileSync(path.join(constructionDir, file), "utf8"));
   for (const group of ["snapshot_cases", "focused_cases", "implementation_probe_cases", "np_cases"]) {
     for (const row of spec[group] || []) add(row.source, row.context_source, `construction:${spec.construction}:${group}`);
@@ -37,7 +35,7 @@ for (const file of fs.readdirSync(constructionDir).filter((name) => name.endsWit
 }
 
 const records = [];
-const parseFailures = [];
+const failures = [];
 for (const item of corpus.values()) {
   try {
     const analysis = api.analyzeLine(item.source, item.context_source || null);
@@ -48,157 +46,150 @@ for (const item of corpus.values()) {
     record.context_source = item.context_source;
     records.push(record);
   } catch (error) {
-    parseFailures.push({ source: item.source, context_source: item.context_source, error: error.message || String(error) });
+    failures.push({ source: item.source, context_source: item.context_source, error: error.message || String(error) });
   }
 }
+const aggregate = aggregateCoverage(records, { sampleLimit: 10 });
 
-const aggregate = aggregateCoverage(records, { sampleLimit: 20 });
 const observedLabels = new Set();
 const traceKindCounts = {};
 const familyCounts = {};
 const sanityCounts = {};
-const scopeCandidates = new Map();
-const missingFamilies = new Map();
+const scope = new Map();
+const missingFamily = new Map();
+const countMismatch = new Map();
+const emptySurface = new Map();
+const outsideSurface = new Map();
 const constructionMatchers = new Map();
 const labelRuleMatchers = new Map();
-const matcherConstructionLabels = new Map();
+const matcherLabels = new Map();
+const matcherDefs = new Map();
 const matcherExamples = new Map();
-const matcherDefinitions = new Map();
 const ruleSourceCounts = {};
 
-function bump(obj, key) { obj[key] = (obj[key] || 0) + 1; }
-function addMapSet(map, key, value) { if (!map.has(key)) map.set(key, new Set()); map.get(key).add(value); }
-function addExample(map, key, source, limit = 5) {
-  if (!map.has(key)) map.set(key, []);
-  const list = map.get(key);
-  if (!list.includes(source) && list.length < limit) list.push(source);
+function groupRow(map, key, construction, reason, source, matcher, extra = {}) {
+  if (!map.has(key)) map.set(key, { construction, reason, count: 0, matchers: new Set(), examples: [], ...extra });
+  const row = map.get(key);
+  row.count += 1;
+  if (matcher) row.matchers.add(matcher);
+  if (!row.examples.includes(source) && row.examples.length < 5) row.examples.push(source);
+  return row;
 }
 
 for (const record of records) {
   for (const finding of record.sanity_findings || []) bump(sanityCounts, finding.code || "unknown");
   for (const trace of record.construction_traces || []) {
     const label = trace.construction || trace.internal_construction || "unknown";
-    observedLabels.add(label);
-    bump(traceKindCounts, trace.trace_kind || "unknown");
-    bump(familyCounts, trace.template_family || "(missing)");
-    bump(ruleSourceCounts, trace.rule_descriptor_source || "unknown");
     const matcher = trace.matcher_id || "unavailable";
-    addMapSet(constructionMatchers, label, matcher);
-    addMapSet(matcherConstructionLabels, matcher, label);
-    addExample(matcherExamples, matcher, record.source);
-    if (trace.matcher_definition) matcherDefinitions.set(matcher, trace.matcher_definition);
     const rule = trace.rule_descriptor || "unavailable";
-    addMapSet(labelRuleMatchers, `${label}\u0000${rule}`, matcher);
+    const kind = trace.trace_kind || "unknown";
+    const family = trace.template_family || "(missing)";
+    observedLabels.add(label);
+    bump(traceKindCounts, kind);
+    bump(familyCounts, family);
+    bump(ruleSourceCounts, trace.rule_descriptor_source || "unknown");
+    addSet(constructionMatchers, label, matcher);
+    addSet(labelRuleMatchers, `${label}\u0000${rule}`, matcher);
+    addSet(matcherLabels, matcher, label);
+    matcherDefs.set(matcher, trace.matcher_definition || null);
+    example(matcherExamples, matcher, record.source);
 
-    const slots = (trace.slot_bindings || []).map((binding) => binding.slot).filter(Boolean);
-    let reason = "";
-    if (/VP$/.test(label) && slots.some((slot) => ["subject", "overt_subject", "topic"].includes(slot))) {
-      reason = "VP_label_binds_clause_level_subject_or_topic";
-    } else if (/NP$/.test(label) && slots.some((slot) => ["subject", "overt_subject", "predicate", "vp", "clause"].includes(slot))) {
-      reason = "NP_label_binds_clause_or_predicate_slot";
-    } else if (/Phrase$/.test(label) && slots.some((slot) => ["subject", "overt_subject"].includes(slot))) {
-      reason = "Phrase_label_binds_subject";
-    }
-    if (reason) {
-      const key = `${label}\u0000${reason}`;
-      if (!scopeCandidates.has(key)) scopeCandidates.set(key, { construction: label, reason, count: 0, slots: new Set(), matchers: new Set(), examples: [] });
-      const row = scopeCandidates.get(key);
-      row.count += 1;
-      slots.forEach((slot) => row.slots.add(slot));
-      row.matchers.add(matcher);
-      if (!row.examples.includes(record.source) && row.examples.length < 8) row.examples.push(record.source);
+    const slots = (trace.slot_bindings || []).map((b) => b.slot).filter(Boolean);
+    if (/VP$/.test(label) && slots.some((s) => ["subject", "overt_subject", "topic"].includes(s))) {
+      const row = groupRow(scope, label, label, "VP_label_binds_clause_level_subject_or_topic", record.source, matcher, { slots: new Set() });
+      slots.forEach((s) => row.slots.add(s));
+    } else if (/NP$/.test(label) && slots.some((s) => ["subject", "overt_subject", "predicate", "vp", "clause"].includes(s))) {
+      const row = groupRow(scope, label, label, "NP_label_binds_clause_or_predicate_slot", record.source, matcher, { slots: new Set() });
+      slots.forEach((s) => row.slots.add(s));
+    } else if (/Phrase$/.test(label) && slots.some((s) => ["subject", "overt_subject"].includes(s))) {
+      const row = groupRow(scope, label, label, "Phrase_label_binds_subject", record.source, matcher, { slots: new Set() });
+      slots.forEach((s) => row.slots.add(s));
     }
 
-    if (trace.trace_kind === "generative_template" && !trace.template_family) {
-      if (!missingFamilies.has(label)) missingFamilies.set(label, { construction: label, count: 0, matchers: new Set(), examples: [] });
-      const row = missingFamilies.get(label);
-      row.count += 1;
-      row.matchers.add(matcher);
-      if (!row.examples.includes(record.source) && row.examples.length < 8) row.examples.push(record.source);
+    if (kind === "generative_template" && !trace.template_family) {
+      groupRow(missingFamily, label, label, "generative_trace_missing_template_family", record.source, matcher);
+    }
+
+    const assigned = Array.isArray(trace.assigned_slots) ? trace.assigned_slots : [];
+    const surfaces = Array.isArray(trace.slot_surfaces) ? trace.slot_surfaces : [];
+    if (assigned.length !== surfaces.length) {
+      const row = groupRow(countMismatch, label, label, "assigned_slot_surface_count_mismatch", record.source, matcher, { shapes: new Set() });
+      row.shapes.add(`${assigned.length}:${surfaces.length}`);
+    }
+    for (const binding of trace.slot_bindings || []) {
+      if (!binding.surface) {
+        const row = groupRow(emptySurface, label, label, "empty_assigned_slot_surface", record.source, matcher, { slots: new Set() });
+        if (binding.slot) row.slots.add(binding.slot);
+      }
+      if (binding.surface && trace.surface && !trace.surface.includes(binding.surface)) {
+        const row = groupRow(outsideSurface, label, label, "slot_surface_not_contained_in_construction_surface", record.source, matcher, { slots: new Set() });
+        if (binding.slot) row.slots.add(binding.slot);
+      }
     }
   }
 }
 
-function serializeScope(row) {
-  return { ...row, slots: [...row.slots].sort(), matchers: [...row.matchers].sort() };
+function compactGroup(map, setKeys = []) {
+  return [...map.values()].map((row) => {
+    const out = { ...row, matchers: [...row.matchers].sort() };
+    for (const key of setKeys) if (out[key] instanceof Set) out[key] = [...out[key]].sort();
+    return out;
+  }).sort((a, b) => b.count - a.count || a.construction.localeCompare(b.construction));
 }
-function serializeMatcherGroup([label, set]) {
-  const matcherIds = [...set].sort();
-  return {
-    construction: label,
-    matcher_count: matcherIds.length,
-    matcher_ids: matcherIds,
-    definitions: matcherIds.map((id) => ({ matcher_id: id, definition: matcherDefinitions.get(id) || null, examples: matcherExamples.get(id) || [] })),
-  };
-}
-function serializeLabelRule([key, set]) {
+const hiddenVariants = [...labelRuleMatchers.entries()].filter(([, s]) => s.size > 1).map(([key, ids]) => {
   const [construction, rule_descriptor] = key.split("\u0000");
-  const matcherIds = [...set].sort();
   return {
     construction,
     rule_descriptor,
-    matcher_count: matcherIds.length,
-    variants: matcherIds.map((id) => ({ matcher_id: id, definition: matcherDefinitions.get(id) || null, examples: matcherExamples.get(id) || [] })),
+    matcher_count: ids.size,
+    variants: [...ids].sort().map((id) => ({ matcher_id: id, constraints: matcherDefs.get(id)?.constraints || {}, template_family: matcherDefs.get(id)?.template_family || "", examples: matcherExamples.get(id) || [] })),
   };
-}
+}).sort((a, b) => b.matcher_count - a.matcher_count || a.construction.localeCompare(b.construction));
+const multiMatcher = [...constructionMatchers.entries()].filter(([, s]) => s.size > 1).map(([construction, s]) => ({ construction, matcher_count: s.size })).sort((a, b) => b.matcher_count - a.matcher_count || a.construction.localeCompare(b.construction));
+const collisions = [...matcherLabels.entries()].filter(([, s]) => s.size > 1).map(([matcher_id, s]) => ({ matcher_id, constructions: [...s].sort() }));
 
-const multiMatcherLabels = [...constructionMatchers.entries()]
-  .filter(([, set]) => set.size > 1)
-  .map(serializeMatcherGroup)
-  .sort((a, b) => b.matcher_count - a.matcher_count || a.construction.localeCompare(b.construction));
+const registeredKinds = new Set((traceMetadata.parserDecisionTraceKindRegistry || []).map(([name]) => name));
+const registeredFamilies = new Set((traceMetadata.templateFamilyRegistry || []).map(([name]) => name));
+const unregisteredKinds = Object.entries(traceKindCounts).filter(([name]) => !registeredKinds.has(name)).map(([trace_kind, count]) => ({ trace_kind, count }));
+const unregisteredFamilies = Object.entries(familyCounts).filter(([name]) => name !== "(missing)" && !registeredFamilies.has(name)).map(([template_family, count]) => ({ template_family, count }));
 
-const hiddenMatcherVariants = [...labelRuleMatchers.entries()]
-  .filter(([, set]) => set.size > 1)
-  .map(serializeLabelRule)
-  .sort((a, b) => b.matcher_count - a.matcher_count || a.construction.localeCompare(b.construction));
-
-const matcherCollisions = [...matcherConstructionLabels.entries()]
-  .filter(([, set]) => set.size > 1)
-  .map(([matcher_id, labels]) => ({ matcher_id, constructions: [...labels].sort(), examples: matcherExamples.get(matcher_id) || [] }));
-
-const policyPath = path.join(root, "src", "runtime-resources", "diagnostics", "trace-metadata.js");
-const policyText = fs.readFileSync(policyPath, "utf8");
-const policyPatterns = [
-  /eventual_target:\s*"([^"]+)"/g,
-  /eventually be promoted to fully generative POS-targeting templates/g,
-  /preserve_construction_template_vs_generative_template_until_all_grammar_is_generative/g,
-  /Move construction-function fallback into a governed template or classify it as intentionally non-template/g,
-];
-const staticPolicyHits = [];
-for (const pattern of policyPatterns) {
-  for (const match of policyText.matchAll(pattern)) staticPolicyHits.push(match[0]);
-}
+const policyText = fs.readFileSync(path.join(root, "src/runtime-resources/diagnostics/trace-metadata.js"), "utf8");
+const staticPolicyHits = [
+  "eventual_target: \"all productive grammar should become generative_template once the parser can target POS/slots rather than individual vocabulary\"",
+  "preserve_construction_template_vs_generative_template_until_all_grammar_is_generative",
+  "eventually be promoted to fully generative POS-targeting templates",
+  "Move construction-function fallback into a governed template or classify it as intentionally non-template",
+].filter((text) => policyText.includes(text));
 
 const output = {
-  schema: "canto-span-repo-wide-parser-architecture-sweep-v1",
+  schema: "canto-span-repo-wide-parser-architecture-sweep-compact-v2",
   runtime_version: api.runtimeVersion,
-  corpus: {
-    regression_case_count: (regression.cases || []).length,
-    np_case_count: (np.cases || []).length,
-    unique_source_context_pairs: corpus.size,
-    analyzed: records.length,
-    parse_failures: parseFailures.length,
-  },
+  corpus: { regression_cases: (regression.cases || []).length, np_cases: (np.cases || []).length, unique_source_context_pairs: corpus.size, analyzed: records.length, parse_failures: failures.length },
   aggregate: {
     coverage_status_counts: aggregate.coverage_status_counts,
-    root_span_coverage_status_counts: aggregate.root_span_coverage_status_counts,
     sanity_finding_counts: sanityCounts,
     unresolved_slot_span_count: aggregate.unresolved_slot_span_count,
     slot_span_resolution_counts: aggregate.slot_span_resolution_counts,
-    architectural_debt_trace_counts: aggregate.architectural_debt_trace_counts,
     observed_construction_count: observedLabels.size,
     trace_kind_counts: traceKindCounts,
     template_family_counts: familyCounts,
     rule_descriptor_source_counts: ruleSourceCounts,
+    architectural_debt_trace_counts: aggregate.architectural_debt_trace_counts,
   },
-  strong_scope_mismatch_candidates: [...scopeCandidates.values()].map(serializeScope).sort((a, b) => b.count - a.count || a.construction.localeCompare(b.construction)),
-  generative_traces_missing_template_family: [...missingFamilies.values()].map((row) => ({ ...row, matchers: [...row.matchers].sort() })).sort((a, b) => b.count - a.count || a.construction.localeCompare(b.construction)),
-  same_label_same_visible_rule_multiple_matchers: hiddenMatcherVariants,
-  labels_with_multiple_matchers: multiMatcherLabels,
-  matcher_id_cross_label_collisions: matcherCollisions,
-  static_diagnostic_policy_hits: [...new Set(staticPolicyHits)],
-  parse_failures: parseFailures.slice(0, 20),
+  grouped: {
+    scope_mismatches: compactGroup(scope, ["slots"]),
+    slot_surface_count_mismatches: compactGroup(countMismatch, ["shapes"]),
+    empty_slot_surfaces: compactGroup(emptySurface, ["slots"]),
+    slot_surfaces_outside_construction: compactGroup(outsideSurface, ["slots"]),
+    missing_template_family: compactGroup(missingFamily),
+    same_label_same_visible_rule_multiple_matchers: hiddenVariants,
+    labels_with_multiple_matchers: multiMatcher,
+    matcher_id_cross_label_collisions: collisions,
+    unregistered_trace_kinds: unregisteredKinds,
+    unregistered_template_families: unregisteredFamilies,
+  },
+  static_diagnostic_policy_hits: staticPolicyHits,
+  parse_failures: failures.slice(0, 10),
 };
-
 console.log(JSON.stringify(output, null, 2));
 process.exit(1);

--- a/tests/tooling/parser-coverage/repo-wide-architecture-sweep.js
+++ b/tests/tooling/parser-coverage/repo-wide-architecture-sweep.js
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { loadRuntimeApi } = require("../../../tools/lib/runtime-api");
+const { enhanceCoverageRecord, aggregateCoverage, canonicalJson } = require("../../../tools/parser-coverage-enhanced");
+
+const root = path.resolve(__dirname, "../../..");
+const api = loadRuntimeApi({ apiNames: ["analyzeLine", "diagnosticSummary", "diagnosticFinalRows"] });
+
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8"));
+}
+
+const corpus = new Map();
+function add(source, contextSource, origin) {
+  if (!source || typeof source !== "string") return;
+  const context = contextSource || "";
+  const key = `${context}\u0000${source}`;
+  if (!corpus.has(key)) corpus.set(key, { source, context_source: context, origins: new Set() });
+  corpus.get(key).origins.add(origin);
+}
+
+const regression = readJson("tests/fixtures/regression-snapshots.json");
+for (const row of regression.cases || []) add(row.source, row.context_source, "regression");
+
+const np = readJson("tests/fixtures/np-subsystem.json");
+for (const row of np.cases || []) add(row.surface, "", "np");
+
+const constructionDir = path.join(root, "tests", "constructions");
+for (const file of fs.readdirSync(constructionDir).filter((name) => name.endsWith(".json")).sort()) {
+  const spec = JSON.parse(fs.readFileSync(path.join(constructionDir, file), "utf8"));
+  for (const group of ["snapshot_cases", "focused_cases", "implementation_probe_cases", "np_cases"]) {
+    for (const row of spec[group] || []) add(row.source, row.context_source, `construction:${spec.construction}:${group}`);
+  }
+}
+
+const records = [];
+const parseFailures = [];
+for (const item of corpus.values()) {
+  try {
+    const analysis = api.analyzeLine(item.source, item.context_source || null);
+    const record = enhanceCoverageRecord(api.diagnosticSummary(analysis), api.diagnosticFinalRows(analysis), {
+      source: item.source,
+      source_artifact: [...item.origins].sort().join(","),
+    });
+    record.context_source = item.context_source;
+    records.push(record);
+  } catch (error) {
+    parseFailures.push({ source: item.source, context_source: item.context_source, error: error.message || String(error) });
+  }
+}
+
+const aggregate = aggregateCoverage(records, { sampleLimit: 20 });
+const observedLabels = new Set();
+const traceKindCounts = {};
+const familyCounts = {};
+const sanityCounts = {};
+const scopeCandidates = new Map();
+const missingFamilies = new Map();
+const constructionMatchers = new Map();
+const labelRuleMatchers = new Map();
+const matcherConstructionLabels = new Map();
+const matcherExamples = new Map();
+const matcherDefinitions = new Map();
+const ruleSourceCounts = {};
+
+function bump(obj, key) { obj[key] = (obj[key] || 0) + 1; }
+function addMapSet(map, key, value) { if (!map.has(key)) map.set(key, new Set()); map.get(key).add(value); }
+function addExample(map, key, source, limit = 5) {
+  if (!map.has(key)) map.set(key, []);
+  const list = map.get(key);
+  if (!list.includes(source) && list.length < limit) list.push(source);
+}
+
+for (const record of records) {
+  for (const finding of record.sanity_findings || []) bump(sanityCounts, finding.code || "unknown");
+  for (const trace of record.construction_traces || []) {
+    const label = trace.construction || trace.internal_construction || "unknown";
+    observedLabels.add(label);
+    bump(traceKindCounts, trace.trace_kind || "unknown");
+    bump(familyCounts, trace.template_family || "(missing)");
+    bump(ruleSourceCounts, trace.rule_descriptor_source || "unknown");
+    const matcher = trace.matcher_id || "unavailable";
+    addMapSet(constructionMatchers, label, matcher);
+    addMapSet(matcherConstructionLabels, matcher, label);
+    addExample(matcherExamples, matcher, record.source);
+    if (trace.matcher_definition) matcherDefinitions.set(matcher, trace.matcher_definition);
+    const rule = trace.rule_descriptor || "unavailable";
+    addMapSet(labelRuleMatchers, `${label}\u0000${rule}`, matcher);
+
+    const slots = (trace.slot_bindings || []).map((binding) => binding.slot).filter(Boolean);
+    let reason = "";
+    if (/VP$/.test(label) && slots.some((slot) => ["subject", "overt_subject", "topic"].includes(slot))) {
+      reason = "VP_label_binds_clause_level_subject_or_topic";
+    } else if (/NP$/.test(label) && slots.some((slot) => ["subject", "overt_subject", "predicate", "vp", "clause"].includes(slot))) {
+      reason = "NP_label_binds_clause_or_predicate_slot";
+    } else if (/Phrase$/.test(label) && slots.some((slot) => ["subject", "overt_subject"].includes(slot))) {
+      reason = "Phrase_label_binds_subject";
+    }
+    if (reason) {
+      const key = `${label}\u0000${reason}`;
+      if (!scopeCandidates.has(key)) scopeCandidates.set(key, { construction: label, reason, count: 0, slots: new Set(), matchers: new Set(), examples: [] });
+      const row = scopeCandidates.get(key);
+      row.count += 1;
+      slots.forEach((slot) => row.slots.add(slot));
+      row.matchers.add(matcher);
+      if (!row.examples.includes(record.source) && row.examples.length < 8) row.examples.push(record.source);
+    }
+
+    if (trace.trace_kind === "generative_template" && !trace.template_family) {
+      if (!missingFamilies.has(label)) missingFamilies.set(label, { construction: label, count: 0, matchers: new Set(), examples: [] });
+      const row = missingFamilies.get(label);
+      row.count += 1;
+      row.matchers.add(matcher);
+      if (!row.examples.includes(record.source) && row.examples.length < 8) row.examples.push(record.source);
+    }
+  }
+}
+
+function serializeScope(row) {
+  return { ...row, slots: [...row.slots].sort(), matchers: [...row.matchers].sort() };
+}
+function serializeMatcherGroup([label, set]) {
+  const matcherIds = [...set].sort();
+  return {
+    construction: label,
+    matcher_count: matcherIds.length,
+    matcher_ids: matcherIds,
+    definitions: matcherIds.map((id) => ({ matcher_id: id, definition: matcherDefinitions.get(id) || null, examples: matcherExamples.get(id) || [] })),
+  };
+}
+function serializeLabelRule([key, set]) {
+  const [construction, rule_descriptor] = key.split("\u0000");
+  const matcherIds = [...set].sort();
+  return {
+    construction,
+    rule_descriptor,
+    matcher_count: matcherIds.length,
+    variants: matcherIds.map((id) => ({ matcher_id: id, definition: matcherDefinitions.get(id) || null, examples: matcherExamples.get(id) || [] })),
+  };
+}
+
+const multiMatcherLabels = [...constructionMatchers.entries()]
+  .filter(([, set]) => set.size > 1)
+  .map(serializeMatcherGroup)
+  .sort((a, b) => b.matcher_count - a.matcher_count || a.construction.localeCompare(b.construction));
+
+const hiddenMatcherVariants = [...labelRuleMatchers.entries()]
+  .filter(([, set]) => set.size > 1)
+  .map(serializeLabelRule)
+  .sort((a, b) => b.matcher_count - a.matcher_count || a.construction.localeCompare(b.construction));
+
+const matcherCollisions = [...matcherConstructionLabels.entries()]
+  .filter(([, set]) => set.size > 1)
+  .map(([matcher_id, labels]) => ({ matcher_id, constructions: [...labels].sort(), examples: matcherExamples.get(matcher_id) || [] }));
+
+const policyPath = path.join(root, "src", "runtime-resources", "diagnostics", "trace-metadata.js");
+const policyText = fs.readFileSync(policyPath, "utf8");
+const policyPatterns = [
+  /eventual_target:\s*"([^"]+)"/g,
+  /eventually be promoted to fully generative POS-targeting templates/g,
+  /preserve_construction_template_vs_generative_template_until_all_grammar_is_generative/g,
+  /Move construction-function fallback into a governed template or classify it as intentionally non-template/g,
+];
+const staticPolicyHits = [];
+for (const pattern of policyPatterns) {
+  for (const match of policyText.matchAll(pattern)) staticPolicyHits.push(match[0]);
+}
+
+const output = {
+  schema: "canto-span-repo-wide-parser-architecture-sweep-v1",
+  runtime_version: api.runtimeVersion,
+  corpus: {
+    regression_case_count: (regression.cases || []).length,
+    np_case_count: (np.cases || []).length,
+    unique_source_context_pairs: corpus.size,
+    analyzed: records.length,
+    parse_failures: parseFailures.length,
+  },
+  aggregate: {
+    coverage_status_counts: aggregate.coverage_status_counts,
+    root_span_coverage_status_counts: aggregate.root_span_coverage_status_counts,
+    sanity_finding_counts: sanityCounts,
+    unresolved_slot_span_count: aggregate.unresolved_slot_span_count,
+    slot_span_resolution_counts: aggregate.slot_span_resolution_counts,
+    architectural_debt_trace_counts: aggregate.architectural_debt_trace_counts,
+    observed_construction_count: observedLabels.size,
+    trace_kind_counts: traceKindCounts,
+    template_family_counts: familyCounts,
+    rule_descriptor_source_counts: ruleSourceCounts,
+  },
+  strong_scope_mismatch_candidates: [...scopeCandidates.values()].map(serializeScope).sort((a, b) => b.count - a.count || a.construction.localeCompare(b.construction)),
+  generative_traces_missing_template_family: [...missingFamilies.values()].map((row) => ({ ...row, matchers: [...row.matchers].sort() })).sort((a, b) => b.count - a.count || a.construction.localeCompare(b.construction)),
+  same_label_same_visible_rule_multiple_matchers: hiddenMatcherVariants,
+  labels_with_multiple_matchers: multiMatcherLabels,
+  matcher_id_cross_label_collisions: matcherCollisions,
+  static_diagnostic_policy_hits: [...new Set(staticPolicyHits)],
+  parse_failures: parseFailures.slice(0, 20),
+};
+
+console.log(JSON.stringify(output, null, 2));
+process.exit(1);


### PR DESCRIPTION
Ephemeral CI-only repo-wide architecture/provenance sweep against merged enhanced auditor commit `92934c991b301104a65ba0d664b32555f3d5d170`. This PR is diagnostic only and must not be merged.

## Corpus
- 551 regression cases
- 43 NP cases
- all per-construction snapshot/focused/implementation-probe/NP cases
- 807 unique `(context, source)` pairs after deduplication
- 807 analyzed; 0 parse crashes
- 132 construction labels exercised

## Main findings

### 1. Clause-sized VP labels
Four construction labels bind an overt clause-level subject while being named `*VP`:
- DesiderativeVP: 13 live occurrences
- ModalVP: 12
- MannerAdverbialVP: 2
- PreferenceVP: 2

These should be reviewed as one structural-scope family rather than patched individually.

### 2. Trace binding contract is not universally one-to-one
151 `assigned_slots`/`surfaces` count mismatches and 133 empty slot surfaces are concentrated in a small set of trace producers, especially:
- ClauseRelationMember: 93 count mismatches / 93 empty bindings
- IntendedFunctionRelation: 13 count mismatches
- RelativeClauseNP, SubjectPredicateClause, IntransitiveVP, TransitiveVP, StativePredicate and controlled cognition traces

Conclusion: parallel `assigned_slots` + `surfaces` arrays are not a reliable universal provenance interface. This is primarily a trace-schema problem, not 151 separate grammar defects.

### 3. Metadata/registry drift
- 27 generative-template traces lack `template_family`, across 15 construction labels.
- live trace kind `source_linked_runtime_matcher` occurs 4 times but is absent from the controlled trace-kind registry.
- live family values `first_syllable_preference_a_not_a` and `copular_a_not_a_bounded_complement` are absent from the controlled template-family registry.
- `CoordinatedNP` demonstrates that missing family metadata alone can split otherwise identical matcher fingerprints.

### 4. Hidden matcher variants
Six same-label/same-visible-rule groups have multiple fingerprints because controlled constraints differ or metadata drifts:
- OpinionStanceFrame: 3
- SubjectPredicateClause: 3
- CoordinatedNP: 2
- DemonstrativeClassifierNP: 2
- HeadNP: 2
- TransitiveVP: 2

Most constrained variants appear legitimate, but the human-readable rule descriptor does not expose the variant key. Fingerprint collision check found 0 cross-label collisions.

### 5. Two source/display normalization edge cases
Only two slot surfaces were outside their construction surface:
- LexicalGiveRelation: `给你水。`
- NamingClause: `我叫 Chris。`
These should be rechecked after a structured source/parser/display binding contract is introduced rather than treated immediately as grammar bugs.

### 6. Diagnostic policy still assumes universal generative migration
Static runtime diagnostics still contain the universal target that all productive grammar should eventually become `generative_template`, plus related migration wording. This conflicts with the current architecture allowing governed specialized detectors. Existing issue #668 covers this policy reconciliation.

## Proposed coordinated program
1. Define one canonical trace schema: controlled trace kind/family, explicit human-readable matcher variant/rule ID, structured slot bindings, source/parser/display span provenance, and structural scope/category.
2. Update shared trace-emission helpers and retain legacy arrays only as compatibility fields.
3. Migrate all trace producers by producer family, not construction-by-construction.
4. Repair trace-kind/family registry drift and centralize metadata population.
5. Resolve all four clause-sized `*VP` constructions together under an explicit structural-scope invariant.
6. Reconcile #668 after the taxonomy is final.
7. Update the external auditor to consume structured bindings and explicit variants; parallel-array mismatches become compatibility diagnostics during migration.
8. Add a permanent repo-wide architecture audit gate: zero unregistered trace kinds/families, zero missing required family metadata, zero unexplained clause-sized VP labels, zero conflicting fingerprints for one authored variant ID, and zero unresolved binding-contract anomalies except explicit exemptions.

All ordinary regression, NP, construction, lexicon, original auditor, and enhanced-auditor suites passed before the intentionally failing sweep-output command. The sweep intentionally exits nonzero to expose the report in Actions.