### PR TITLE
Enforce regression debt ratchet in runtime CI

### DIFF
--- a/.github/workflows/runtime-source-first.yml
+++ b/.github/workflows/runtime-source-first.yml
@@ -7,6 +7,7 @@ on:
       - "tests/**"
       - "tools/build-runtime.js"
       - "tools/verify-current-state.js"
+      - "tools/verify-regression-ratchet.js"
       - "config/verification-profiles.json"
       - "package.json"
       - "package-lock.json"
@@ -18,6 +19,7 @@ on:
       - "tests/**"
       - "tools/build-runtime.js"
       - "tools/verify-current-state.js"
+      - "tools/verify-regression-ratchet.js"
       - "config/verification-profiles.json"
       - "package.json"
       - "package-lock.json"
@@ -33,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -41,3 +45,44 @@ jobs:
         run: npm ci
       - name: Run runtime verification profile
         run: npm run verify:runtime
+      - name: Enforce stable-identity regression debt ratchet
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          BASE_SHA=""
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            BASE_SHA="$PR_BASE_SHA"
+          elif [[ "$EVENT_NAME" == "push" && -n "$PUSH_BASE_SHA" && "$PUSH_BASE_SHA" != "0000000000000000000000000000000000000000" ]]; then
+            BASE_SHA="$PUSH_BASE_SHA"
+          else
+            BASE_SHA="$(git rev-parse HEAD^ 2>/dev/null || true)"
+          fi
+
+          if [[ -z "$BASE_SHA" ]]; then
+            echo "No baseline commit is available for this event; runtime profile completed but ratchet comparison was not run."
+            exit 0
+          fi
+
+          BASE_DIR="$RUNNER_TEMP/canto-span-ratchet-base"
+          rm -rf "$BASE_DIR"
+          git worktree add --detach "$BASE_DIR" "$BASE_SHA"
+          cleanup() {
+            git worktree remove --force "$BASE_DIR" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          (cd "$BASE_DIR" && node tests/run-regression.js >"$RUNNER_TEMP/baseline-regression.stdout" 2>"$RUNNER_TEMP/baseline-regression.stderr" || true)
+          node tests/run-regression.js >"$RUNNER_TEMP/candidate-regression.stdout" 2>"$RUNNER_TEMP/candidate-regression.stderr" || true
+
+          test -f "$BASE_DIR/validation/current/regression-suite.json"
+          test -f "validation/current/regression-suite.json"
+
+          node tools/verify-regression-ratchet.js \
+            --baseline-result "$BASE_DIR/validation/current/regression-suite.json" \
+            --candidate-result "validation/current/regression-suite.json" \
+            --baseline-fixture "$BASE_DIR/tests/fixtures/regression-snapshots.json" \
+            --candidate-fixture "tests/fixtures/regression-snapshots.json"

--- a/.github/workflows/runtime-source-first.yml
+++ b/.github/workflows/runtime-source-first.yml
@@ -8,6 +8,7 @@ on:
       - "tools/build-runtime.js"
       - "tools/verify-current-state.js"
       - "tools/verify-regression-ratchet.js"
+      - "tools/ratchet-unobservable-baseline.js"
       - "config/verification-profiles.json"
       - "package.json"
       - "package-lock.json"
@@ -20,6 +21,7 @@ on:
       - "tools/build-runtime.js"
       - "tools/verify-current-state.js"
       - "tools/verify-regression-ratchet.js"
+      - "tools/ratchet-unobservable-baseline.js"
       - "config/verification-profiles.json"
       - "package.json"
       - "package-lock.json"
@@ -83,23 +85,71 @@ jobs:
             "validation/current/np-subsystem-results.json" \
             "validation/current/construction-tests.json"
 
-          (cd "$BASE_DIR" && node tests/run-regression.js >"$RUNNER_TEMP/baseline-regression.stdout" 2>"$RUNNER_TEMP/baseline-regression.stderr" || true)
-          (cd "$BASE_DIR" && node tests/run-np-subsystem.js >"$RUNNER_TEMP/baseline-np.stdout" 2>"$RUNNER_TEMP/baseline-np.stderr" || true)
-          (cd "$BASE_DIR" && node tests/run-constructions.js >"$RUNNER_TEMP/baseline-constructions.stdout" 2>"$RUNNER_TEMP/baseline-constructions.stderr" || true)
+          run_baseline() {
+            local label="$1"
+            shift
+            set +e
+            (cd "$BASE_DIR" && "$@") >"$RUNNER_TEMP/baseline-$label.stdout" 2>"$RUNNER_TEMP/baseline-$label.stderr"
+            local exit_code=$?
+            set -e
+            printf '%s\n' "$exit_code" >"$RUNNER_TEMP/baseline-$label.exit"
+          }
+
+          run_baseline regression node tests/run-regression.js
+          run_baseline np node tests/run-np-subsystem.js
+          run_baseline constructions node tests/run-constructions.js
 
           node tests/run-regression.js >"$RUNNER_TEMP/candidate-regression.stdout" 2>"$RUNNER_TEMP/candidate-regression.stderr" || true
           node tests/run-np-subsystem.js >"$RUNNER_TEMP/candidate-np.stdout" 2>"$RUNNER_TEMP/candidate-np.stderr" || true
           node tests/run-constructions.js >"$RUNNER_TEMP/candidate-constructions.stdout" 2>"$RUNNER_TEMP/candidate-constructions.stderr" || true
 
-          for report in \
+          synthesize_baseline_if_unobservable() {
+            local suite="$1"
+            local label="$2"
+            local report="$3"
+            local universe="$4"
+            if [[ -f "$report" ]]; then
+              return 0
+            fi
+            local exit_code
+            exit_code="$(cat "$RUNNER_TEMP/baseline-$label.exit")"
+            if [[ "$exit_code" == "0" ]]; then
+              echo "Baseline suite exited successfully but did not produce required report: $report" >&2
+              exit 1
+            fi
+            local reason_file="$RUNNER_TEMP/baseline-$label.reason"
+            {
+              echo "baseline_exit_code=$exit_code"
+              cat "$RUNNER_TEMP/baseline-$label.stderr"
+              cat "$RUNNER_TEMP/baseline-$label.stdout"
+            } >"$reason_file"
+            echo "Baseline $suite suite is unobservable at $BASE_SHA; conservatively materializing every unchanged case as failed."
+            node tools/ratchet-unobservable-baseline.js \
+              --suite "$suite" \
+              --universe "$universe" \
+              --output "$report" \
+              --reason-file "$reason_file" >/dev/null
+          }
+
+          synthesize_baseline_if_unobservable \
+            regression regression \
             "$BASE_DIR/validation/current/regression-suite.json" \
+            "$BASE_DIR/tests/fixtures/regression-snapshots.json"
+          synthesize_baseline_if_unobservable \
+            np_subsystem np \
             "$BASE_DIR/validation/current/np-subsystem-results.json" \
+            "$BASE_DIR/tests/fixtures/np-subsystem.json"
+          synthesize_baseline_if_unobservable \
+            construction_files constructions \
             "$BASE_DIR/validation/current/construction-tests.json" \
+            "$BASE_DIR/tests/constructions"
+
+          for report in \
             "validation/current/regression-suite.json" \
             "validation/current/np-subsystem-results.json" \
             "validation/current/construction-tests.json"; do
             if [[ ! -f "$report" ]]; then
-              echo "Debt-bearing suite did not produce required report: $report" >&2
+              echo "Candidate debt-bearing suite did not produce required report: $report" >&2
               exit 1
             fi
           done

--- a/.github/workflows/runtime-source-first.yml
+++ b/.github/workflows/runtime-source-first.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm ci
       - name: Run runtime verification profile
         run: npm run verify:runtime
-      - name: Enforce stable-identity regression debt ratchet
+      - name: Enforce inherited runtime debt ratchets
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -63,7 +63,7 @@ jobs:
           fi
 
           if [[ -z "$BASE_SHA" ]]; then
-            echo "No baseline commit is available for this event; runtime profile completed but ratchet comparison was not run."
+            echo "No baseline commit is available for this event; runtime profile completed but debt-ratchet comparison was not run."
             exit 0
           fi
 
@@ -75,14 +75,52 @@ jobs:
           }
           trap cleanup EXIT
 
-          (cd "$BASE_DIR" && node tests/run-regression.js >"$RUNNER_TEMP/baseline-regression.stdout" 2>"$RUNNER_TEMP/baseline-regression.stderr" || true)
-          node tests/run-regression.js >"$RUNNER_TEMP/candidate-regression.stdout" 2>"$RUNNER_TEMP/candidate-regression.stderr" || true
+          rm -f \
+            "$BASE_DIR/validation/current/regression-suite.json" \
+            "$BASE_DIR/validation/current/np-subsystem-results.json" \
+            "$BASE_DIR/validation/current/construction-tests.json" \
+            "validation/current/regression-suite.json" \
+            "validation/current/np-subsystem-results.json" \
+            "validation/current/construction-tests.json"
 
-          test -f "$BASE_DIR/validation/current/regression-suite.json"
-          test -f "validation/current/regression-suite.json"
+          (cd "$BASE_DIR" && node tests/run-regression.js >"$RUNNER_TEMP/baseline-regression.stdout" 2>"$RUNNER_TEMP/baseline-regression.stderr" || true)
+          (cd "$BASE_DIR" && node tests/run-np-subsystem.js >"$RUNNER_TEMP/baseline-np.stdout" 2>"$RUNNER_TEMP/baseline-np.stderr" || true)
+          (cd "$BASE_DIR" && node tests/run-constructions.js >"$RUNNER_TEMP/baseline-constructions.stdout" 2>"$RUNNER_TEMP/baseline-constructions.stderr" || true)
+
+          node tests/run-regression.js >"$RUNNER_TEMP/candidate-regression.stdout" 2>"$RUNNER_TEMP/candidate-regression.stderr" || true
+          node tests/run-np-subsystem.js >"$RUNNER_TEMP/candidate-np.stdout" 2>"$RUNNER_TEMP/candidate-np.stderr" || true
+          node tests/run-constructions.js >"$RUNNER_TEMP/candidate-constructions.stdout" 2>"$RUNNER_TEMP/candidate-constructions.stderr" || true
+
+          for report in \
+            "$BASE_DIR/validation/current/regression-suite.json" \
+            "$BASE_DIR/validation/current/np-subsystem-results.json" \
+            "$BASE_DIR/validation/current/construction-tests.json" \
+            "validation/current/regression-suite.json" \
+            "validation/current/np-subsystem-results.json" \
+            "validation/current/construction-tests.json"; do
+            if [[ ! -f "$report" ]]; then
+              echo "Debt-bearing suite did not produce required report: $report" >&2
+              exit 1
+            fi
+          done
 
           node tools/verify-regression-ratchet.js \
+            --suite regression \
             --baseline-result "$BASE_DIR/validation/current/regression-suite.json" \
             --candidate-result "validation/current/regression-suite.json" \
-            --baseline-fixture "$BASE_DIR/tests/fixtures/regression-snapshots.json" \
-            --candidate-fixture "tests/fixtures/regression-snapshots.json"
+            --baseline-universe "$BASE_DIR/tests/fixtures/regression-snapshots.json" \
+            --candidate-universe "tests/fixtures/regression-snapshots.json"
+
+          node tools/verify-regression-ratchet.js \
+            --suite np_subsystem \
+            --baseline-result "$BASE_DIR/validation/current/np-subsystem-results.json" \
+            --candidate-result "validation/current/np-subsystem-results.json" \
+            --baseline-universe "$BASE_DIR/tests/fixtures/np-subsystem.json" \
+            --candidate-universe "tests/fixtures/np-subsystem.json"
+
+          node tools/verify-regression-ratchet.js \
+            --suite construction_files \
+            --baseline-result "$BASE_DIR/validation/current/construction-tests.json" \
+            --candidate-result "validation/current/construction-tests.json" \
+            --baseline-universe "$BASE_DIR/tests/constructions" \
+            --candidate-universe "tests/constructions"

--- a/config/verification-profiles.json
+++ b/config/verification-profiles.json
@@ -94,9 +94,9 @@
       },
       {
         "id": "runtime-tests",
-        "command": ["node", "tests/run-all.js", "--allow-regression-debt"],
-        "reason": "Run the complete runtime suite while preserving inherited regression failures as visible debt; the runtime workflow separately enforces the dynamic stable-identity ratchet against the actual base commit.",
-        "run_when": "Runtime source, runtime resources, executable fixtures, lexicon data, runtime tests, or regression-ratchet tooling change."
+        "command": ["node", "tests/run-all.js", "--allow-inherited-debt"],
+        "reason": "Run the complete runtime suite while preserving the three known inherited-red aggregate suites as visible debt; the runtime workflow separately enforces dynamic stable-identity and test-contract ratchets for each against the actual base commit. All focused runtime tests remain blocking.",
+        "run_when": "Runtime source, runtime resources, executable fixtures, lexicon data, runtime tests, or debt-ratchet tooling change."
       },
       {
         "id": "generated-runtime",

--- a/config/verification-profiles.json
+++ b/config/verification-profiles.json
@@ -94,9 +94,9 @@
       },
       {
         "id": "runtime-tests",
-        "command": ["node", "tests/run-all.js"],
-        "reason": "Protect parser behavior and executable construction expectations across the canonical runtime test suite.",
-        "run_when": "Runtime source, runtime resources, executable fixtures, lexicon data, or runtime tests change."
+        "command": ["node", "tests/run-all.js", "--allow-regression-debt"],
+        "reason": "Run the complete runtime suite while preserving inherited regression failures as visible debt; the runtime workflow separately enforces the dynamic stable-identity ratchet against the actual base commit.",
+        "run_when": "Runtime source, runtime resources, executable fixtures, lexicon data, runtime tests, or regression-ratchet tooling change."
       },
       {
         "id": "generated-runtime",

--- a/main.js
+++ b/main.js
@@ -7582,8 +7582,8 @@ var require_token_features = __commonJS({
           label,
           syntax,
           pos: overrides.pos || entry.pos || "",
-          semantic: Array.isArray(entry.semantic) ? entry.semantic : [],
-          verb_class: Array.isArray(entry.verb_class) ? entry.verb_class : [],
+          semantic: Array.isArray(entry.semantic) ? [...entry.semantic] : [],
+          verb_class: Array.isArray(entry.verb_class) ? [...entry.verb_class] : [],
           particle_class: entry.particle_class || ""
         };
         if (!features.pos) {
@@ -9885,15 +9885,18 @@ var require_clauses = __commonJS({
         children.push(acceptabilityFocusClone(match.focus));
         children.push(acceptabilityDakClone(match.dak));
         if (match.particle) children.push(acceptabilityParticleClone(match.particle));
+        const traceTemplate = subjectPredicateChild ? ["predicate!", "focus_adverb!", "acceptability_predicate!", "particle?"] : ["subject?", "predicate!", "focus_adverb!", "acceptability_predicate!", "particle?"];
+        const assignedSlots = subjectPredicateChild ? ["predicate", "focus_adverb", "acceptability_predicate", ...match.particle ? ["particle"] : []] : [...match.subject ? ["subject"] : [], "predicate", "focus_adverb", "acceptability_predicate", ...match.particle ? ["particle"] : []];
         return construction2("AcceptabilityClause", "Acceptability", children, {
           slots: ["acceptability_clause", "acceptability", "focus_adverb", "acceptability_predicate", "predicate", "clause"],
           note: "Bounded action-feasibility clause: an overt action predicate followed by 都得 and an optional final particle. Wh/free-choice 都得 remains outside this node. When a subject + transparent predicate is present, preserve it as a child clause for learner visibility.",
           trace: traceInfo2("generative_template", {
             construction_type: "AcceptabilityClause",
+            template_family: "generative_template",
             retired_label_alias: "PermissionAcceptabilityClause",
             acceptability_subtype: "action_feasibility",
-            template: ["subject?", "predicate!", "focus_adverb!", "acceptability_predicate!", "particle?"],
-            assigned_slots: ["subject", "predicate", "focus_adverb", "acceptability_predicate", "particle"],
+            template: traceTemplate,
+            assigned_slots: assignedSlots,
             rule: "subject? + overt action predicate + focus adverb 都 + acceptability predicate 得 + optional final particle",
             pattern: match.particle ? "subject? + predicate + 都 + 得 + final_particle" : "subject? + predicate + 都 + 得",
             reason: "Checked source evidence directly supports action material followed by 都得 as feasible. The matcher requires that overt host and leaves wh/free-choice 都得 for separate analysis.",

--- a/src/parser/detectors/acceptability/clauses.js
+++ b/src/parser/detectors/acceptability/clauses.js
@@ -152,15 +152,22 @@ function makeAcceptabilityClause(match) {
   children.push(acceptabilityFocusClone(match.focus));
   children.push(acceptabilityDakClone(match.dak));
   if (match.particle) children.push(acceptabilityParticleClone(match.particle));
+  const traceTemplate = subjectPredicateChild
+    ? ["predicate!", "focus_adverb!", "acceptability_predicate!", "particle?"]
+    : ["subject?", "predicate!", "focus_adverb!", "acceptability_predicate!", "particle?"];
+  const assignedSlots = subjectPredicateChild
+    ? ["predicate", "focus_adverb", "acceptability_predicate", ...(match.particle ? ["particle"] : [])]
+    : [...(match.subject ? ["subject"] : []), "predicate", "focus_adverb", "acceptability_predicate", ...(match.particle ? ["particle"] : [])];
   return construction("AcceptabilityClause", "Acceptability", children, {
     slots: ["acceptability_clause", "acceptability", "focus_adverb", "acceptability_predicate", "predicate", "clause"],
     note: "Bounded action-feasibility clause: an overt action predicate followed by 都得 and an optional final particle. Wh/free-choice 都得 remains outside this node. When a subject + transparent predicate is present, preserve it as a child clause for learner visibility.",
     trace: traceInfo("generative_template", {
       construction_type: "AcceptabilityClause",
+      template_family: "generative_template",
       retired_label_alias: "PermissionAcceptabilityClause",
       acceptability_subtype: "action_feasibility",
-      template: ["subject?", "predicate!", "focus_adverb!", "acceptability_predicate!", "particle?"],
-      assigned_slots: ["subject", "predicate", "focus_adverb", "acceptability_predicate", "particle"],
+      template: traceTemplate,
+      assigned_slots: assignedSlots,
       rule: "subject? + overt action predicate + focus adverb 都 + acceptability predicate 得 + optional final particle",
       pattern: match.particle ? "subject? + predicate + 都 + 得 + final_particle" : "subject? + predicate + 都 + 得",
       reason: "Checked source evidence directly supports action material followed by 都得 as feasible. The matcher requires that overt host and leaves wh/free-choice 都得 for separate analysis.",

--- a/src/parser/features/token-features.js
+++ b/src/parser/features/token-features.js
@@ -90,8 +90,8 @@ module.exports = function createTokenFeaturePrimitives(dependencies = {}) {
       label,
       syntax,
       pos: overrides.pos || entry.pos || "",
-      semantic: Array.isArray(entry.semantic) ? entry.semantic : [],
-      verb_class: Array.isArray(entry.verb_class) ? entry.verb_class : [],
+      semantic: Array.isArray(entry.semantic) ? [...entry.semantic] : [],
+      verb_class: Array.isArray(entry.verb_class) ? [...entry.verb_class] : [],
       particle_class: entry.particle_class || "",
     };
 

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -8,6 +8,7 @@ const { loadRuntimeApi } = require("./lib/runtime-api");
 
 const root = path.resolve(__dirname, "..");
 const api = loadRuntimeApi();
+const allowRegressionDebt = process.argv.includes("--allow-regression-debt");
 const commands = [
   ["regression", path.join(root, "tests", "run-regression.js")],
   ["np_subsystem", path.join(root, "tests", "run-np-subsystem.js")],
@@ -29,6 +30,7 @@ const commands = [
   ["parser_coverage_enhanced", path.join(root, "tests", "tooling", "parser-coverage", "enhanced.test.js")],
   ["parser_architecture_audit", path.join(root, "tests", "tooling", "parser-coverage", "architecture-audit.test.js")],
   ["parser_work_prioritizer", path.join(root, "tests", "tooling", "parser-coverage", "prioritizer.test.js")],
+  ["regression_ratchet_verifier", path.join(root, "tests", "tooling", "runtime", "regression-ratchet-verifier.test.js")],
 ];
 const generatedPaths = [
   "validation/current/regression-suite.json",
@@ -46,17 +48,25 @@ const originalGeneratedFiles = new Map(
 );
 const results = [];
 let failed = false;
+let regressionDebtObserved = false;
 
 try {
   for (const [name, script] of commands) {
     const run = spawnSync(process.execPath, [script], { cwd: root, encoding: "utf8" });
+    const debtAllowed = name === "regression" && allowRegressionDebt && run.status !== 0;
     const result = {
       name,
       exit_code: run.status,
       signal: run.signal || "",
-      status: run.status === 0 ? "PASS" : "FAIL",
+      status: debtAllowed ? "DEBT" : (run.status === 0 ? "PASS" : "FAIL"),
     };
-    if (run.status !== 0) {
+    if (debtAllowed) {
+      regressionDebtObserved = true;
+      result.debt_allowed = true;
+      result.stdout = run.stdout || "";
+      result.stderr = run.stderr || "";
+      process.stderr.write(`\n[${name}] inherited debt reported; stable-identity ratchet must be checked separately\n${result.stdout}${result.stderr}`);
+    } else if (run.status !== 0) {
       failed = true;
       result.stdout = run.stdout || "";
       result.stderr = run.stderr || "";
@@ -78,7 +88,8 @@ try {
 console.log(JSON.stringify({
   schema: "canto-span-standard-test-suite-summary-v2",
   runtime_version: api.runtimeVersion,
-  status: failed ? "FAIL" : "PASS",
+  status: failed ? "FAIL" : (regressionDebtObserved ? "PASS_WITH_REGRESSION_DEBT" : "PASS"),
+  regression_debt_requires_external_ratchet: regressionDebtObserved,
   commands: results,
   generated_outputs_restored: generatedPaths,
 }, null, 2));

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -50,6 +50,22 @@ const results = [];
 let failed = false;
 let regressionDebtObserved = false;
 
+function readRegressionDebtSummary() {
+  const reportPath = path.join(root, "validation", "current", "regression-suite.json");
+  if (!fs.existsSync(reportPath)) return null;
+  try {
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    return {
+      total: Number.isInteger(report.total) ? report.total : null,
+      passed: Number.isInteger(report.passed) ? report.passed : null,
+      failed: Number.isInteger(report.failed) ? report.failed : null,
+      strict_ready: Boolean(report.strict_ready),
+    };
+  } catch {
+    return null;
+  }
+}
+
 try {
   for (const [name, script] of commands) {
     const run = spawnSync(process.execPath, [script], { cwd: root, encoding: "utf8" });
@@ -63,9 +79,8 @@ try {
     if (debtAllowed) {
       regressionDebtObserved = true;
       result.debt_allowed = true;
-      result.stdout = run.stdout || "";
-      result.stderr = run.stderr || "";
-      process.stderr.write(`\n[${name}] inherited debt reported; stable-identity ratchet must be checked separately\n${result.stdout}${result.stderr}`);
+      result.debt_summary = readRegressionDebtSummary();
+      process.stderr.write(`\n[${name}] inherited debt reported; stable-identity ratchet must be checked separately\n`);
     } else if (run.status !== 0) {
       failed = true;
       result.stdout = run.stdout || "";

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -58,7 +58,8 @@ function readCurrentDebtSummary(name) {
   if (!fs.existsSync(reportPath)) return null;
   try {
     const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-    if (report.status !== "FAIL" || !Number.isInteger(report.failed) || report.failed <= 0) return null;
+    if (!Number.isInteger(report.failed) || report.failed <= 0) return null;
+    if (report.status !== undefined && report.status !== "FAIL") return null;
     return {
       total: Number.isInteger(report.total) ? report.total : (Number.isInteger(report.executable_reference_count) ? report.executable_reference_count : null),
       passed: Number.isInteger(report.passed) ? report.passed : null,

--- a/tests/run-all.js
+++ b/tests/run-all.js
@@ -8,7 +8,7 @@ const { loadRuntimeApi } = require("./lib/runtime-api");
 
 const root = path.resolve(__dirname, "..");
 const api = loadRuntimeApi();
-const allowRegressionDebt = process.argv.includes("--allow-regression-debt");
+const allowInheritedDebt = process.argv.includes("--allow-inherited-debt");
 const commands = [
   ["regression", path.join(root, "tests", "run-regression.js")],
   ["np_subsystem", path.join(root, "tests", "run-np-subsystem.js")],
@@ -32,11 +32,12 @@ const commands = [
   ["parser_work_prioritizer", path.join(root, "tests", "tooling", "parser-coverage", "prioritizer.test.js")],
   ["regression_ratchet_verifier", path.join(root, "tests", "tooling", "runtime", "regression-ratchet-verifier.test.js")],
 ];
-const generatedPaths = [
-  "validation/current/regression-suite.json",
-  "validation/current/np-subsystem-results.json",
-  "validation/current/construction-tests.json",
-];
+const debtReports = Object.freeze({
+  regression: "validation/current/regression-suite.json",
+  np_subsystem: "validation/current/np-subsystem-results.json",
+  construction_files: "validation/current/construction-tests.json",
+});
+const generatedPaths = Object.values(debtReports);
 const originalGeneratedFiles = new Map(
   generatedPaths.map((relativePath) => {
     const absolutePath = path.join(root, relativePath);
@@ -48,18 +49,20 @@ const originalGeneratedFiles = new Map(
 );
 const results = [];
 let failed = false;
-let regressionDebtObserved = false;
+let inheritedDebtObserved = false;
 
-function readRegressionDebtSummary() {
-  const reportPath = path.join(root, "validation", "current", "regression-suite.json");
+function readCurrentDebtSummary(name) {
+  const relativePath = debtReports[name];
+  if (!relativePath) return null;
+  const reportPath = path.join(root, relativePath);
   if (!fs.existsSync(reportPath)) return null;
   try {
     const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    if (report.status !== "FAIL" || !Number.isInteger(report.failed) || report.failed <= 0) return null;
     return {
-      total: Number.isInteger(report.total) ? report.total : null,
+      total: Number.isInteger(report.total) ? report.total : (Number.isInteger(report.executable_reference_count) ? report.executable_reference_count : null),
       passed: Number.isInteger(report.passed) ? report.passed : null,
-      failed: Number.isInteger(report.failed) ? report.failed : null,
-      strict_ready: Boolean(report.strict_ready),
+      failed: report.failed,
     };
   } catch {
     return null;
@@ -68,8 +71,12 @@ function readRegressionDebtSummary() {
 
 try {
   for (const [name, script] of commands) {
+    const debtReportPath = debtReports[name] ? path.join(root, debtReports[name]) : null;
+    if (allowInheritedDebt && debtReportPath) fs.rmSync(debtReportPath, { force: true });
+
     const run = spawnSync(process.execPath, [script], { cwd: root, encoding: "utf8" });
-    const debtAllowed = name === "regression" && allowRegressionDebt && run.status !== 0;
+    const debtSummary = allowInheritedDebt && run.status !== 0 ? readCurrentDebtSummary(name) : null;
+    const debtAllowed = Boolean(debtSummary);
     const result = {
       name,
       exit_code: run.status,
@@ -77,10 +84,10 @@ try {
       status: debtAllowed ? "DEBT" : (run.status === 0 ? "PASS" : "FAIL"),
     };
     if (debtAllowed) {
-      regressionDebtObserved = true;
+      inheritedDebtObserved = true;
       result.debt_allowed = true;
-      result.debt_summary = readRegressionDebtSummary();
-      process.stderr.write(`\n[${name}] inherited debt reported; stable-identity ratchet must be checked separately\n`);
+      result.debt_summary = debtSummary;
+      process.stderr.write(`\n[${name}] inherited debt reported; the workflow must compare its stable identities and test contract against the live baseline\n`);
     } else if (run.status !== 0) {
       failed = true;
       result.stdout = run.stdout || "";
@@ -103,8 +110,8 @@ try {
 console.log(JSON.stringify({
   schema: "canto-span-standard-test-suite-summary-v2",
   runtime_version: api.runtimeVersion,
-  status: failed ? "FAIL" : (regressionDebtObserved ? "PASS_WITH_REGRESSION_DEBT" : "PASS"),
-  regression_debt_requires_external_ratchet: regressionDebtObserved,
+  status: failed ? "FAIL" : (inheritedDebtObserved ? "PASS_WITH_INHERITED_DEBT" : "PASS"),
+  inherited_debt_requires_external_ratchet: inheritedDebtObserved,
   commands: results,
   generated_outputs_restored: generatedPaths,
 }, null, 2));

--- a/tests/tooling/runtime/regression-ratchet-verifier.test.js
+++ b/tests/tooling/runtime/regression-ratchet-verifier.test.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert/strict");
+const test = require("node:test");
+const { compareRatchet } = require("../../../tools/verify-regression-ratchet");
+
+function fixture(cases, exclusions = []) {
+  return {
+    cases: cases.map(([source, context_source = ""]) => ({ source, context_source })),
+    current_focused_exclusions: exclusions,
+  };
+}
+
+function result(failures) {
+  return {
+    runtime_version: "test",
+    failed: failures.length,
+    failures: failures.map(([source, context_source = ""]) => ({ source, context_source })),
+  };
+}
+
+const stableCases = [
+  ["A。", ""],
+  ["B。", ""],
+  ["C。", "context"],
+];
+
+test("subset candidate failures pass and resolved debt is reported", () => {
+  const report = compareRatchet({
+    baselineResult: result([["A。"], ["B。"]]),
+    candidateResult: result([["B。"]]),
+    baselineFixture: fixture(stableCases),
+    candidateFixture: fixture(stableCases),
+  });
+
+  assert.equal(report.status, "PASS");
+  assert.equal(report.comparison.new_failure_count, 0);
+  assert.equal(report.comparison.resolved_failure_count, 1);
+  assert.deepEqual(report.comparison.resolved_failures, [{ source: "A。", context_source: "" }]);
+});
+
+test("equal raw failure count still fails when one stable identity is swapped", () => {
+  const report = compareRatchet({
+    baselineResult: result([["A。"]]),
+    candidateResult: result([["B。"]]),
+    baselineFixture: fixture(stableCases),
+    candidateFixture: fixture(stableCases),
+  });
+
+  assert.equal(report.status, "FAIL");
+  assert.equal(report.baseline.failure_count, report.candidate.failure_count);
+  assert.equal(report.comparison.new_failure_count, 1);
+  assert.equal(report.comparison.resolved_failure_count, 1);
+  assert.ok(report.blockers.includes("new_stable_regression_failure_identity"));
+});
+
+test("test-universe drift blocks automatic ratchet acceptance", () => {
+  const report = compareRatchet({
+    baselineResult: result([["A。"]]),
+    candidateResult: result([]),
+    baselineFixture: fixture(stableCases),
+    candidateFixture: fixture([["A。"], ["B。"], ["D。"]]),
+  });
+
+  assert.equal(report.status, "FAIL");
+  assert.equal(report.comparison.removed_case_count, 1);
+  assert.equal(report.comparison.added_case_count, 1);
+  assert.ok(report.blockers.includes("regression_test_contract_changed_requires_explicit_review"));
+});
+
+test("strict reduction rejects an unchanged inherited failure set", () => {
+  const report = compareRatchet({
+    baselineResult: result([["A。"]]),
+    candidateResult: result([["A。"]]),
+    baselineFixture: fixture(stableCases),
+    candidateFixture: fixture(stableCases),
+    requireStrictReduction: true,
+  });
+
+  assert.equal(report.status, "FAIL");
+  assert.equal(report.comparison.new_failure_count, 0);
+  assert.equal(report.comparison.resolved_failure_count, 0);
+  assert.ok(report.blockers.includes("strict_regression_debt_reduction_required"));
+});
+
+test("strict reduction passes when at least one inherited failure disappears", () => {
+  const report = compareRatchet({
+    baselineResult: result([["A。"], ["B。"]]),
+    candidateResult: result([["B。"]]),
+    baselineFixture: fixture(stableCases),
+    candidateFixture: fixture(stableCases),
+    requireStrictReduction: true,
+  });
+
+  assert.equal(report.status, "PASS");
+  assert.equal(report.comparison.resolved_failure_count, 1);
+});

--- a/tests/tooling/runtime/regression-ratchet-verifier.test.js
+++ b/tests/tooling/runtime/regression-ratchet-verifier.test.js
@@ -3,16 +3,13 @@
 
 const assert = require("assert/strict");
 const test = require("node:test");
-const { compareRatchet } = require("../../../tools/verify-regression-ratchet");
+const { compareSuiteRatchet } = require("../../../tools/verify-regression-ratchet");
 
-function fixture(cases, exclusions = []) {
-  return {
-    cases: cases.map(([source, context_source = ""]) => ({ source, context_source })),
-    current_focused_exclusions: exclusions,
-  };
+function regressionFixture(cases) {
+  return { cases, current_focused_exclusions: [] };
 }
 
-function result(failures) {
+function regressionResult(failures) {
   return {
     runtime_version: "test",
     failed: failures.length,
@@ -20,18 +17,49 @@ function result(failures) {
   };
 }
 
-const stableCases = [
-  ["A。", ""],
-  ["B。", ""],
-  ["C。", "context"],
+function npFixture(cases) {
+  return { cases };
+}
+
+function npResult(ids) {
+  return {
+    runtime_version: "test",
+    failed: ids.length,
+    failures: ids.map((id) => ({ id })),
+  };
+}
+
+function constructionSpecs(cases) {
+  return [{
+    construction: "DemoConstruction",
+    snapshot_cases: cases.snapshot || [],
+    focused_cases: cases.focused || [],
+    implementation_probe_cases: cases.probes || [],
+    np_cases: cases.np || [],
+  }];
+}
+
+function constructionResult(failures) {
+  return {
+    runtime_version: "test",
+    failed: failures.length,
+    failures,
+  };
+}
+
+const regressionCases = [
+  { source: "A。", context_source: "", expected: "alpha" },
+  { source: "B。", context_source: "", expected: "beta" },
+  { source: "C。", context_source: "context", expected: "gamma" },
 ];
 
-test("subset candidate failures pass and resolved debt is reported", () => {
-  const report = compareRatchet({
-    baselineResult: result([["A。"], ["B。"]]),
-    candidateResult: result([["B。"]]),
-    baselineFixture: fixture(stableCases),
-    candidateFixture: fixture(stableCases),
+test("regression subset candidate failures pass and resolved debt is reported", () => {
+  const report = compareSuiteRatchet({
+    suite: "regression",
+    baselineResult: regressionResult([["A。"], ["B。"]]),
+    candidateResult: regressionResult([["B。"]]),
+    baselineUniverse: regressionFixture(regressionCases),
+    candidateUniverse: regressionFixture(regressionCases),
   });
 
   assert.equal(report.status, "PASS");
@@ -40,59 +68,141 @@ test("subset candidate failures pass and resolved debt is reported", () => {
   assert.deepEqual(report.comparison.resolved_failures, [{ source: "A。", context_source: "" }]);
 });
 
-test("equal raw failure count still fails when one stable identity is swapped", () => {
-  const report = compareRatchet({
-    baselineResult: result([["A。"]]),
-    candidateResult: result([["B。"]]),
-    baselineFixture: fixture(stableCases),
-    candidateFixture: fixture(stableCases),
+test("equal raw regression failure count still fails when one stable identity is swapped", () => {
+  const report = compareSuiteRatchet({
+    suite: "regression",
+    baselineResult: regressionResult([["A。"]]),
+    candidateResult: regressionResult([["B。"]]),
+    baselineUniverse: regressionFixture(regressionCases),
+    candidateUniverse: regressionFixture(regressionCases),
   });
 
   assert.equal(report.status, "FAIL");
   assert.equal(report.baseline.failure_count, report.candidate.failure_count);
   assert.equal(report.comparison.new_failure_count, 1);
   assert.equal(report.comparison.resolved_failure_count, 1);
-  assert.ok(report.blockers.includes("new_stable_regression_failure_identity"));
+  assert.ok(report.blockers.includes("new_stable_failure_identity"));
 });
 
-test("test-universe drift blocks automatic ratchet acceptance", () => {
-  const report = compareRatchet({
-    baselineResult: result([["A。"]]),
-    candidateResult: result([]),
-    baselineFixture: fixture(stableCases),
-    candidateFixture: fixture([["A。"], ["B。"], ["D。"]]),
+test("same regression identity with changed executable contract blocks automatic acceptance", () => {
+  const changed = regressionCases.map((row) => ({ ...row }));
+  changed[0].expected = "changed";
+  const report = compareSuiteRatchet({
+    suite: "regression",
+    baselineResult: regressionResult([["A。"]]),
+    candidateResult: regressionResult([]),
+    baselineUniverse: regressionFixture(regressionCases),
+    candidateUniverse: regressionFixture(changed),
   });
 
   assert.equal(report.status, "FAIL");
-  assert.equal(report.comparison.removed_case_count, 1);
-  assert.equal(report.comparison.added_case_count, 1);
-  assert.ok(report.blockers.includes("regression_test_contract_changed_requires_explicit_review"));
+  assert.equal(report.comparison.changed_case_count, 1);
+  assert.ok(report.blockers.includes("test_contract_changed_requires_explicit_review"));
 });
 
-test("strict reduction rejects an unchanged inherited failure set", () => {
-  const report = compareRatchet({
-    baselineResult: result([["A。"]]),
-    candidateResult: result([["A。"]]),
-    baselineFixture: fixture(stableCases),
-    candidateFixture: fixture(stableCases),
+test("strict regression reduction rejects an unchanged inherited failure set", () => {
+  const report = compareSuiteRatchet({
+    suite: "regression",
+    baselineResult: regressionResult([["A。"]]),
+    candidateResult: regressionResult([["A。"]]),
+    baselineUniverse: regressionFixture(regressionCases),
+    candidateUniverse: regressionFixture(regressionCases),
     requireStrictReduction: true,
   });
 
   assert.equal(report.status, "FAIL");
   assert.equal(report.comparison.new_failure_count, 0);
   assert.equal(report.comparison.resolved_failure_count, 0);
-  assert.ok(report.blockers.includes("strict_regression_debt_reduction_required"));
+  assert.ok(report.blockers.includes("strict_debt_reduction_required"));
 });
 
-test("strict reduction passes when at least one inherited failure disappears", () => {
-  const report = compareRatchet({
-    baselineResult: result([["A。"], ["B。"]]),
-    candidateResult: result([["B。"]]),
-    baselineFixture: fixture(stableCases),
-    candidateFixture: fixture(stableCases),
-    requireStrictReduction: true,
+test("NP subsystem uses stable fixture ids and accepts a true subset", () => {
+  const matrix = npFixture([
+    { id: "NP-A", surface: "A。", expected_internal: "A" },
+    { id: "NP-B", surface: "B。", expected_internal: "B" },
+  ]);
+  const report = compareSuiteRatchet({
+    suite: "np_subsystem",
+    baselineResult: npResult(["NP-A", "NP-B"]),
+    candidateResult: npResult(["NP-B"]),
+    baselineUniverse: matrix,
+    candidateUniverse: matrix,
   });
 
   assert.equal(report.status, "PASS");
-  assert.equal(report.comparison.resolved_failure_count, 1);
+  assert.deepEqual(report.comparison.resolved_failures, [{ id: "NP-A" }]);
+});
+
+test("NP subsystem blocks new failure ids and same-id fixture changes", () => {
+  const baseline = npFixture([
+    { id: "NP-A", surface: "A。", expected_internal: "A" },
+    { id: "NP-B", surface: "B。", expected_internal: "B" },
+  ]);
+  const candidate = npFixture([
+    { id: "NP-A", surface: "A。", expected_internal: "changed" },
+    { id: "NP-B", surface: "B。", expected_internal: "B" },
+  ]);
+  const report = compareSuiteRatchet({
+    suite: "np_subsystem",
+    baselineResult: npResult(["NP-A"]),
+    candidateResult: npResult(["NP-A", "NP-B"]),
+    baselineUniverse: baseline,
+    candidateUniverse: candidate,
+  });
+
+  assert.equal(report.status, "FAIL");
+  assert.equal(report.comparison.new_failure_count, 1);
+  assert.equal(report.comparison.changed_case_count, 1);
+  assert.ok(report.blockers.includes("new_stable_failure_identity"));
+  assert.ok(report.blockers.includes("test_contract_changed_requires_explicit_review"));
+});
+
+test("construction suite keys executions by construction, case id, and category", () => {
+  const specs = constructionSpecs({
+    snapshot: [{ case_id: "C-A", source: "A。" }],
+    focused: [{ case_id: "C-B", source: "B。", assertion: "construction_present" }],
+  });
+  const baselineFailures = [
+    { construction: "DemoConstruction", case_id: "C-A", category: "exact_snapshot_positive" },
+    { construction: "DemoConstruction", case_id: "C-B", category: "focused_positive_or_boundary" },
+  ];
+  const candidateFailures = [baselineFailures[1]];
+  const report = compareSuiteRatchet({
+    suite: "construction_files",
+    baselineResult: constructionResult(baselineFailures),
+    candidateResult: constructionResult(candidateFailures),
+    baselineUniverse: specs,
+    candidateUniverse: specs,
+  });
+
+  assert.equal(report.status, "PASS");
+  assert.deepEqual(report.comparison.resolved_failures, [{
+    construction: "DemoConstruction",
+    case_id: "C-A",
+    category: "exact_snapshot_positive",
+  }]);
+});
+
+test("construction suite blocks test-universe drift and modified same-id assertions", () => {
+  const baseline = constructionSpecs({
+    focused: [{ case_id: "C-A", source: "A。", assertion: "construction_present" }],
+  });
+  const candidate = constructionSpecs({
+    focused: [
+      { case_id: "C-A", source: "A。", assertion: "construction_absent" },
+      { case_id: "C-B", source: "B。", assertion: "construction_present" },
+    ],
+  });
+  const report = compareSuiteRatchet({
+    suite: "construction_files",
+    baselineResult: constructionResult([]),
+    candidateResult: constructionResult([]),
+    baselineUniverse: baseline,
+    candidateUniverse: candidate,
+  });
+
+  assert.equal(report.status, "FAIL");
+  assert.equal(report.comparison.added_case_count, 1);
+  assert.equal(report.comparison.changed_case_count, 1);
+  assert.ok(report.blockers.includes("test_contract_changed_requires_explicit_review"));
 });

--- a/tests/tooling/runtime/regression-ratchet-verifier.test.js
+++ b/tests/tooling/runtime/regression-ratchet-verifier.test.js
@@ -2,8 +2,12 @@
 "use strict";
 
 const assert = require("assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 const test = require("node:test");
 const { compareSuiteRatchet } = require("../../../tools/verify-regression-ratchet");
+const { materializeUnobservableBaseline } = require("../../../tools/ratchet-unobservable-baseline");
 
 function regressionFixture(cases) {
   return { cases, current_focused_exclusions: [] };
@@ -114,6 +118,35 @@ test("strict regression reduction rejects an unchanged inherited failure set", (
   assert.equal(report.comparison.new_failure_count, 0);
   assert.equal(report.comparison.resolved_failure_count, 0);
   assert.ok(report.blockers.includes("strict_debt_reduction_required"));
+});
+
+test("conservative unobservable regression baseline materializes every unchanged case as failed", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "canto-span-ratchet-"));
+  const fixturePath = path.join(tempDir, "regression.json");
+  try {
+    fs.writeFileSync(fixturePath, JSON.stringify(regressionFixture(regressionCases)));
+    const report = materializeUnobservableBaseline({
+      suite: "regression",
+      universePath: fixturePath,
+      reason: "baseline crashed before report",
+    });
+
+    assert.equal(report.synthetic_unobservable_baseline, true);
+    assert.equal(report.status, "FAIL");
+    assert.equal(report.total, regressionCases.length);
+    assert.equal(report.passed, 0);
+    assert.equal(report.failed, regressionCases.length);
+    assert.deepEqual(
+      report.failures.map(({ source, context_source, error }) => ({ source, context_source, error })),
+      regressionCases.map(({ source, context_source = "" }) => ({
+        source,
+        context_source,
+        error: "baseline_suite_unobservable",
+      })),
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("NP subsystem uses stable fixture ids and accepts a true subset", () => {

--- a/tests/tooling/runtime/token-features-immutability.test.js
+++ b/tests/tooling/runtime/token-features-immutability.test.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("assert/strict");
+const test = require("node:test");
+const createTokenFeaturePrimitives = require("../../../src/parser/features/token-features");
+
+const primitives = createTokenFeaturePrimitives({
+  normalizeLearnerLabel(label) {
+    return label || "neutral";
+  },
+  cleanSlots(slots = []) {
+    return [...new Set(slots)].sort();
+  },
+});
+
+test("inferTokenFeatures owns mutable semantic working state", () => {
+  const semantic = Object.freeze([]);
+  const entry = Object.freeze({
+    label: "where",
+    pos: "np",
+    syntax: "place noun",
+    semantic,
+    verb_class: Object.freeze([]),
+  });
+
+  const features = primitives.inferTokenFeatures("香港", entry);
+
+  assert.deepEqual(features.semantic, ["place"]);
+  assert.deepEqual(entry.semantic, []);
+  assert.notStrictEqual(features.semantic, semantic);
+});
+
+test("inferTokenFeatures owns mutable verb-class working state", () => {
+  const verbClass = Object.freeze([]);
+  const entry = Object.freeze({
+    label: "doing",
+    pos: "verb",
+    syntax: "movement_direction",
+    semantic: Object.freeze([]),
+    verb_class: verbClass,
+  });
+
+  const features = primitives.inferTokenFeatures("去", entry);
+
+  assert.deepEqual(features.verb_class, ["movement"]);
+  assert.deepEqual(entry.verb_class, []);
+  assert.notStrictEqual(features.verb_class, verbClass);
+});

--- a/tools/ratchet-unobservable-baseline.js
+++ b/tools/ratchet-unobservable-baseline.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const {
+  constructionContractFromSpecs,
+  npContract,
+  regressionContract,
+} = require("./verify-regression-ratchet");
+
+const SUITES = new Set(["regression", "np_subsystem", "construction_files"]);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(path.resolve(filePath), "utf8"));
+}
+
+function readConstructionSpecs(directoryPath) {
+  const absolute = path.resolve(directoryPath);
+  return fs.readdirSync(absolute)
+    .filter((name) => name.endsWith(".json"))
+    .sort()
+    .map((name) => readJson(path.join(absolute, name)));
+}
+
+function contractForSuite(suite, universePath) {
+  if (suite === "regression") return regressionContract(readJson(universePath));
+  if (suite === "np_subsystem") return npContract(readJson(universePath));
+  if (suite === "construction_files") return constructionContractFromSpecs(readConstructionSpecs(universePath));
+  throw new Error(`unsupported debt suite ${suite}`);
+}
+
+function materializeUnobservableBaseline({ suite, universePath, reason = "" }) {
+  if (!SUITES.has(suite)) throw new Error(`unsupported debt suite ${suite}`);
+  const cases = contractForSuite(suite, universePath);
+  const failures = [...cases.values()].map(({ display }) => ({
+    ...display,
+    error: "baseline_suite_unobservable",
+  }));
+  return {
+    schema: "canto-span-unobservable-baseline-result-v1",
+    runtime_version: "",
+    synthetic_unobservable_baseline: true,
+    failure_reason: String(reason || "baseline suite exited nonzero before producing a result").slice(0, 2000),
+    total: cases.size,
+    passed: 0,
+    failed: cases.size,
+    status: "FAIL",
+    failures,
+  };
+}
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : null;
+}
+
+function main() {
+  const suite = argValue("--suite");
+  const universePath = argValue("--universe");
+  const outputPath = argValue("--output");
+  const reasonFilePath = argValue("--reason-file");
+  const missing = [
+    ["--suite", suite],
+    ["--universe", universePath],
+    ["--output", outputPath],
+  ].filter(([, value]) => !value).map(([name]) => name);
+  if (missing.length) {
+    console.error(`Missing required arguments: ${missing.join(", ")}`);
+    process.exit(2);
+  }
+
+  try {
+    const reason = reasonFilePath && fs.existsSync(path.resolve(reasonFilePath))
+      ? fs.readFileSync(path.resolve(reasonFilePath), "utf8")
+      : "baseline suite exited nonzero before producing a result";
+    const report = materializeUnobservableBaseline({ suite, universePath, reason });
+    const serialized = JSON.stringify(report, null, 2) + "\n";
+    fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+    fs.writeFileSync(path.resolve(outputPath), serialized);
+    process.stdout.write(serialized);
+  } catch (error) {
+    console.error(error && error.stack ? error.stack : String(error));
+    process.exit(2);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { materializeUnobservableBaseline };

--- a/tools/verify-regression-ratchet.js
+++ b/tools/verify-regression-ratchet.js
@@ -4,20 +4,25 @@
 const fs = require("fs");
 const path = require("path");
 
-function identity(source, contextSource = "") {
-  return JSON.stringify([String(source || ""), String(contextSource || "")]);
+const SUITES = new Set(["regression", "np_subsystem", "construction_files"]);
+
+function stableKey(parts) {
+  return JSON.stringify(parts.map((part) => String(part ?? "")));
 }
 
-function decodeIdentity(key) {
-  const [source, context_source] = JSON.parse(key);
-  return { source, context_source };
+function canonicalJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
 }
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(path.resolve(filePath), "utf8"));
 }
 
-function excludedByFixture(testCase, exclusions) {
+function excludedRegressionCase(testCase, exclusions) {
   return exclusions.some((entry) => {
     if (typeof entry === "string") return testCase.source === entry;
     if (!entry || entry.source !== testCase.source) return false;
@@ -26,64 +31,162 @@ function excludedByFixture(testCase, exclusions) {
   });
 }
 
-function fixtureIdentitySet(fixture) {
+function addContractRow(rows, key, display, contract, label) {
+  if (rows.has(key)) throw new Error(`${label} contains duplicate stable identity ${key}`);
+  rows.set(key, { display, fingerprint: canonicalJson(contract) });
+}
+
+function regressionContract(fixture) {
   if (!fixture || !Array.isArray(fixture.cases)) throw new Error("regression fixture must contain cases[]");
   const exclusions = Array.isArray(fixture.current_focused_exclusions) ? fixture.current_focused_exclusions : [];
-  const identities = [];
+  const rows = new Map();
   for (const testCase of fixture.cases) {
     if (!testCase || typeof testCase.source !== "string") throw new Error("every regression fixture case must have a source string");
-    if (excludedByFixture(testCase, exclusions)) continue;
-    identities.push(identity(testCase.source, testCase.context_source || ""));
+    if (excludedRegressionCase(testCase, exclusions)) continue;
+    const display = { source: testCase.source, context_source: String(testCase.context_source || "") };
+    addContractRow(rows, stableKey([display.source, display.context_source]), display, testCase, "regression fixture");
   }
-  const unique = new Set(identities);
-  if (unique.size !== identities.length) throw new Error("regression fixture contains duplicate stable (source, context_source) identities");
-  return unique;
+  return rows;
 }
 
-function resultFailureSet(result, label) {
-  if (!result || !Array.isArray(result.failures)) throw new Error(`${label} regression result must contain failures[]`);
-  const failures = result.failures.map((row) => {
-    if (!row || typeof row.source !== "string") throw new Error(`${label} failure row must contain a source string`);
-    return identity(row.source, row.context_source || "");
-  });
-  const unique = new Set(failures);
-  if (unique.size !== failures.length) throw new Error(`${label} regression result contains duplicate failure identities`);
-  if (Number.isInteger(result.failed) && result.failed !== failures.length) {
-    throw new Error(`${label} regression result failed count does not match failures[] length`);
+function npContract(matrix) {
+  if (!matrix || !Array.isArray(matrix.cases)) throw new Error("NP subsystem fixture must contain cases[]");
+  const rows = new Map();
+  for (const testCase of matrix.cases) {
+    if (!testCase || typeof testCase.id !== "string" || !testCase.id) throw new Error("every NP subsystem case must have an id");
+    const display = { id: testCase.id };
+    addContractRow(rows, stableKey([testCase.id]), display, testCase, "NP subsystem fixture");
   }
-  return unique;
+  return rows;
 }
 
-function sortedDecoded(keys) {
-  return [...keys].sort().map(decodeIdentity);
+const CONSTRUCTION_CASE_GROUPS = Object.freeze([
+  ["snapshot_cases", "exact_snapshot_positive"],
+  ["focused_cases", "focused_positive_or_boundary"],
+  ["implementation_probe_cases", "implementation_reachability_zero_evidence_weight"],
+  ["np_cases", "np_subsystem"],
+]);
+
+function constructionContractFromSpecs(specs) {
+  const rows = new Map();
+  for (const spec of specs) {
+    if (!spec || typeof spec.construction !== "string" || !spec.construction) throw new Error("construction spec requires construction");
+    for (const [field, category] of CONSTRUCTION_CASE_GROUPS) {
+      const cases = Array.isArray(spec[field]) ? spec[field] : [];
+      for (const testCase of cases) {
+        if (!testCase || typeof testCase.case_id !== "string" || !testCase.case_id) {
+          throw new Error(`${spec.construction} ${field} case requires case_id`);
+        }
+        const display = { construction: spec.construction, case_id: testCase.case_id, category };
+        addContractRow(
+          rows,
+          stableKey([spec.construction, testCase.case_id, category]),
+          display,
+          testCase,
+          "construction test specs",
+        );
+      }
+    }
+  }
+  return rows;
 }
 
-function difference(left, right) {
-  return new Set([...left].filter((key) => !right.has(key)));
+function readConstructionSpecs(directoryPath) {
+  const absolute = path.resolve(directoryPath);
+  const files = fs.readdirSync(absolute).filter((name) => name.endsWith(".json")).sort();
+  return files.map((name) => readJson(path.join(absolute, name)));
 }
 
-function compareRatchet({ baselineResult, candidateResult, baselineFixture, candidateFixture, requireStrictReduction = false }) {
-  const baselineCases = fixtureIdentitySet(baselineFixture);
-  const candidateCases = fixtureIdentitySet(candidateFixture);
-  const baselineFailures = resultFailureSet(baselineResult, "baseline");
-  const candidateFailures = resultFailureSet(candidateResult, "candidate");
+function contractForSuite(suite, universeSource) {
+  if (suite === "regression") return regressionContract(universeSource);
+  if (suite === "np_subsystem") return npContract(universeSource);
+  if (suite === "construction_files") return constructionContractFromSpecs(universeSource);
+  throw new Error(`unsupported debt suite ${suite}`);
+}
 
-  const baselineOrphans = difference(baselineFailures, baselineCases);
-  const candidateOrphans = difference(candidateFailures, candidateCases);
-  const removedCases = difference(baselineCases, candidateCases);
-  const addedCases = difference(candidateCases, baselineCases);
-  const newFailures = difference(candidateFailures, baselineFailures);
-  const resolvedFailures = difference(baselineFailures, candidateFailures);
+function failureIdentity(suite, row, label) {
+  if (!row || typeof row !== "object") throw new Error(`${label} failure row must be an object`);
+  if (suite === "regression") {
+    if (typeof row.source !== "string") throw new Error(`${label} regression failure requires source`);
+    return {
+      key: stableKey([row.source, row.context_source || ""]),
+      display: { source: row.source, context_source: String(row.context_source || "") },
+    };
+  }
+  if (suite === "np_subsystem") {
+    if (typeof row.id !== "string" || !row.id) throw new Error(`${label} NP failure requires id`);
+    return { key: stableKey([row.id]), display: { id: row.id } };
+  }
+  if (suite === "construction_files") {
+    for (const key of ["construction", "case_id", "category"]) {
+      if (typeof row[key] !== "string" || !row[key]) throw new Error(`${label} construction failure requires ${key}`);
+    }
+    return {
+      key: stableKey([row.construction, row.case_id, row.category]),
+      display: { construction: row.construction, case_id: row.case_id, category: row.category },
+    };
+  }
+  throw new Error(`unsupported debt suite ${suite}`);
+}
+
+function resultFailureMap(suite, result, label) {
+  if (!result || !Array.isArray(result.failures)) throw new Error(`${label} ${suite} result must contain failures[]`);
+  const rows = new Map();
+  for (const row of result.failures) {
+    const { key, display } = failureIdentity(suite, row, label);
+    if (rows.has(key)) throw new Error(`${label} ${suite} result contains duplicate failure identity ${key}`);
+    rows.set(key, display);
+  }
+  if (Number.isInteger(result.failed) && result.failed !== rows.size) {
+    throw new Error(`${label} ${suite} result failed count does not match failures[] length`);
+  }
+  return rows;
+}
+
+function differenceKeys(left, right) {
+  return new Set([...left.keys()].filter((key) => !right.has(key)));
+}
+
+function changedContractKeys(baseline, candidate) {
+  return new Set([...baseline.keys()].filter((key) => candidate.has(key) && baseline.get(key).fingerprint !== candidate.get(key).fingerprint));
+}
+
+function displays(keys, primary, fallback = null) {
+  return [...keys].sort().map((key) => (primary.get(key) || (fallback && fallback.get(key)) || { display: { identity: key } }).display || primary.get(key) || fallback.get(key));
+}
+
+function compareSuiteRatchet({
+  suite,
+  baselineResult,
+  candidateResult,
+  baselineUniverse,
+  candidateUniverse,
+  requireStrictReduction = false,
+}) {
+  if (!SUITES.has(suite)) throw new Error(`unsupported debt suite ${suite}`);
+  const baselineCases = contractForSuite(suite, baselineUniverse);
+  const candidateCases = contractForSuite(suite, candidateUniverse);
+  const baselineFailures = resultFailureMap(suite, baselineResult, "baseline");
+  const candidateFailures = resultFailureMap(suite, candidateResult, "candidate");
+
+  const baselineOrphans = differenceKeys(baselineFailures, baselineCases);
+  const candidateOrphans = differenceKeys(candidateFailures, candidateCases);
+  const removedCases = differenceKeys(baselineCases, candidateCases);
+  const addedCases = differenceKeys(candidateCases, baselineCases);
+  const changedCases = changedContractKeys(baselineCases, candidateCases);
+  const newFailures = differenceKeys(candidateFailures, baselineFailures);
+  const resolvedFailures = differenceKeys(baselineFailures, candidateFailures);
 
   const blockers = [];
   if (baselineOrphans.size) blockers.push("baseline_result_contains_failure_outside_baseline_case_universe");
   if (candidateOrphans.size) blockers.push("candidate_result_contains_failure_outside_candidate_case_universe");
-  if (removedCases.size || addedCases.size) blockers.push("regression_test_contract_changed_requires_explicit_review");
-  if (newFailures.size) blockers.push("new_stable_regression_failure_identity");
-  if (requireStrictReduction && resolvedFailures.size === 0) blockers.push("strict_regression_debt_reduction_required");
+  if (removedCases.size || addedCases.size || changedCases.size) blockers.push("test_contract_changed_requires_explicit_review");
+  if (newFailures.size) blockers.push("new_stable_failure_identity");
+  if (requireStrictReduction && resolvedFailures.size === 0) blockers.push("strict_debt_reduction_required");
 
   return {
-    schema: "canto-span-regression-debt-ratchet-v1",
+    schema: "canto-span-runtime-debt-ratchet-v1",
+    suite,
     status: blockers.length ? "FAIL" : "PASS",
     require_strict_reduction: Boolean(requireStrictReduction),
     baseline: {
@@ -101,12 +204,14 @@ function compareRatchet({ baselineResult, candidateResult, baselineFixture, cand
       resolved_failure_count: resolvedFailures.size,
       removed_case_count: removedCases.size,
       added_case_count: addedCases.size,
-      new_failures: sortedDecoded(newFailures),
-      resolved_failures: sortedDecoded(resolvedFailures),
-      removed_cases: sortedDecoded(removedCases),
-      added_cases: sortedDecoded(addedCases),
-      baseline_orphan_failures: sortedDecoded(baselineOrphans),
-      candidate_orphan_failures: sortedDecoded(candidateOrphans),
+      changed_case_count: changedCases.size,
+      new_failures: displays(newFailures, candidateFailures),
+      resolved_failures: displays(resolvedFailures, baselineFailures),
+      removed_cases: displays(removedCases, baselineCases),
+      added_cases: displays(addedCases, candidateCases),
+      changed_cases: displays(changedCases, candidateCases, baselineCases),
+      baseline_orphan_failures: displays(baselineOrphans, baselineFailures),
+      candidate_orphan_failures: displays(candidateOrphans, candidateFailures),
     },
     blockers,
   };
@@ -117,17 +222,23 @@ function argValue(name) {
   return index >= 0 ? process.argv[index + 1] : null;
 }
 
+function loadUniverse(suite, sourcePath) {
+  return suite === "construction_files" ? readConstructionSpecs(sourcePath) : readJson(sourcePath);
+}
+
 function main() {
+  const suite = argValue("--suite");
   const baselineResultPath = argValue("--baseline-result");
   const candidateResultPath = argValue("--candidate-result");
-  const baselineFixturePath = argValue("--baseline-fixture");
-  const candidateFixturePath = argValue("--candidate-fixture");
+  const baselineUniversePath = argValue("--baseline-universe");
+  const candidateUniversePath = argValue("--candidate-universe");
   const outputPath = argValue("--output");
   const missing = [
+    ["--suite", suite],
     ["--baseline-result", baselineResultPath],
     ["--candidate-result", candidateResultPath],
-    ["--baseline-fixture", baselineFixturePath],
-    ["--candidate-fixture", candidateFixturePath],
+    ["--baseline-universe", baselineUniversePath],
+    ["--candidate-universe", candidateUniversePath],
   ].filter(([, value]) => !value).map(([name]) => name);
   if (missing.length) {
     console.error(`Missing required arguments: ${missing.join(", ")}`);
@@ -136,11 +247,12 @@ function main() {
 
   let report;
   try {
-    report = compareRatchet({
+    report = compareSuiteRatchet({
+      suite,
       baselineResult: readJson(baselineResultPath),
       candidateResult: readJson(candidateResultPath),
-      baselineFixture: readJson(baselineFixturePath),
-      candidateFixture: readJson(candidateFixturePath),
+      baselineUniverse: loadUniverse(suite, baselineUniversePath),
+      candidateUniverse: loadUniverse(suite, candidateUniversePath),
       requireStrictReduction: process.argv.includes("--require-strict-reduction"),
     });
   } catch (error) {
@@ -160,8 +272,10 @@ function main() {
 if (require.main === module) main();
 
 module.exports = {
-  compareRatchet,
-  fixtureIdentitySet,
-  identity,
-  resultFailureSet,
+  canonicalJson,
+  compareSuiteRatchet,
+  constructionContractFromSpecs,
+  npContract,
+  regressionContract,
+  stableKey,
 };

--- a/tools/verify-regression-ratchet.js
+++ b/tools/verify-regression-ratchet.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+function identity(source, contextSource = "") {
+  return JSON.stringify([String(source || ""), String(contextSource || "")]);
+}
+
+function decodeIdentity(key) {
+  const [source, context_source] = JSON.parse(key);
+  return { source, context_source };
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(path.resolve(filePath), "utf8"));
+}
+
+function excludedByFixture(testCase, exclusions) {
+  return exclusions.some((entry) => {
+    if (typeof entry === "string") return testCase.source === entry;
+    if (!entry || entry.source !== testCase.source) return false;
+    if (entry.context_source === undefined) return true;
+    return String(testCase.context_source || "") === String(entry.context_source || "");
+  });
+}
+
+function fixtureIdentitySet(fixture) {
+  if (!fixture || !Array.isArray(fixture.cases)) throw new Error("regression fixture must contain cases[]");
+  const exclusions = Array.isArray(fixture.current_focused_exclusions) ? fixture.current_focused_exclusions : [];
+  const identities = [];
+  for (const testCase of fixture.cases) {
+    if (!testCase || typeof testCase.source !== "string") throw new Error("every regression fixture case must have a source string");
+    if (excludedByFixture(testCase, exclusions)) continue;
+    identities.push(identity(testCase.source, testCase.context_source || ""));
+  }
+  const unique = new Set(identities);
+  if (unique.size !== identities.length) throw new Error("regression fixture contains duplicate stable (source, context_source) identities");
+  return unique;
+}
+
+function resultFailureSet(result, label) {
+  if (!result || !Array.isArray(result.failures)) throw new Error(`${label} regression result must contain failures[]`);
+  const failures = result.failures.map((row) => {
+    if (!row || typeof row.source !== "string") throw new Error(`${label} failure row must contain a source string`);
+    return identity(row.source, row.context_source || "");
+  });
+  const unique = new Set(failures);
+  if (unique.size !== failures.length) throw new Error(`${label} regression result contains duplicate failure identities`);
+  if (Number.isInteger(result.failed) && result.failed !== failures.length) {
+    throw new Error(`${label} regression result failed count does not match failures[] length`);
+  }
+  return unique;
+}
+
+function sortedDecoded(keys) {
+  return [...keys].sort().map(decodeIdentity);
+}
+
+function difference(left, right) {
+  return new Set([...left].filter((key) => !right.has(key)));
+}
+
+function compareRatchet({ baselineResult, candidateResult, baselineFixture, candidateFixture, requireStrictReduction = false }) {
+  const baselineCases = fixtureIdentitySet(baselineFixture);
+  const candidateCases = fixtureIdentitySet(candidateFixture);
+  const baselineFailures = resultFailureSet(baselineResult, "baseline");
+  const candidateFailures = resultFailureSet(candidateResult, "candidate");
+
+  const baselineOrphans = difference(baselineFailures, baselineCases);
+  const candidateOrphans = difference(candidateFailures, candidateCases);
+  const removedCases = difference(baselineCases, candidateCases);
+  const addedCases = difference(candidateCases, baselineCases);
+  const newFailures = difference(candidateFailures, baselineFailures);
+  const resolvedFailures = difference(baselineFailures, candidateFailures);
+
+  const blockers = [];
+  if (baselineOrphans.size) blockers.push("baseline_result_contains_failure_outside_baseline_case_universe");
+  if (candidateOrphans.size) blockers.push("candidate_result_contains_failure_outside_candidate_case_universe");
+  if (removedCases.size || addedCases.size) blockers.push("regression_test_contract_changed_requires_explicit_review");
+  if (newFailures.size) blockers.push("new_stable_regression_failure_identity");
+  if (requireStrictReduction && resolvedFailures.size === 0) blockers.push("strict_regression_debt_reduction_required");
+
+  return {
+    schema: "canto-span-regression-debt-ratchet-v1",
+    status: blockers.length ? "FAIL" : "PASS",
+    require_strict_reduction: Boolean(requireStrictReduction),
+    baseline: {
+      case_count: baselineCases.size,
+      failure_count: baselineFailures.size,
+      runtime_version: baselineResult.runtime_version || "",
+    },
+    candidate: {
+      case_count: candidateCases.size,
+      failure_count: candidateFailures.size,
+      runtime_version: candidateResult.runtime_version || "",
+    },
+    comparison: {
+      new_failure_count: newFailures.size,
+      resolved_failure_count: resolvedFailures.size,
+      removed_case_count: removedCases.size,
+      added_case_count: addedCases.size,
+      new_failures: sortedDecoded(newFailures),
+      resolved_failures: sortedDecoded(resolvedFailures),
+      removed_cases: sortedDecoded(removedCases),
+      added_cases: sortedDecoded(addedCases),
+      baseline_orphan_failures: sortedDecoded(baselineOrphans),
+      candidate_orphan_failures: sortedDecoded(candidateOrphans),
+    },
+    blockers,
+  };
+}
+
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : null;
+}
+
+function main() {
+  const baselineResultPath = argValue("--baseline-result");
+  const candidateResultPath = argValue("--candidate-result");
+  const baselineFixturePath = argValue("--baseline-fixture");
+  const candidateFixturePath = argValue("--candidate-fixture");
+  const outputPath = argValue("--output");
+  const missing = [
+    ["--baseline-result", baselineResultPath],
+    ["--candidate-result", candidateResultPath],
+    ["--baseline-fixture", baselineFixturePath],
+    ["--candidate-fixture", candidateFixturePath],
+  ].filter(([, value]) => !value).map(([name]) => name);
+  if (missing.length) {
+    console.error(`Missing required arguments: ${missing.join(", ")}`);
+    process.exit(2);
+  }
+
+  let report;
+  try {
+    report = compareRatchet({
+      baselineResult: readJson(baselineResultPath),
+      candidateResult: readJson(candidateResultPath),
+      baselineFixture: readJson(baselineFixturePath),
+      candidateFixture: readJson(candidateFixturePath),
+      requireStrictReduction: process.argv.includes("--require-strict-reduction"),
+    });
+  } catch (error) {
+    console.error(error && error.stack ? error.stack : String(error));
+    process.exit(2);
+  }
+
+  const serialized = JSON.stringify(report, null, 2) + "\n";
+  if (outputPath) {
+    fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+    fs.writeFileSync(path.resolve(outputPath), serialized);
+  }
+  process.stdout.write(serialized);
+  if (report.status !== "PASS") process.exit(1);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  compareRatchet,
+  fixtureIdentitySet,
+  identity,
+  resultFailureSet,
+};


### PR DESCRIPTION
<!-- coordination-claim: #853 -->
Work claim: #853
Closes #853
Closes #852

## Outcome

Makes the repository-wide regression-debt policy executable for runtime changes without storing a volatile baseline snapshot, and includes the two prerequisite mechanical runtime repairs exposed while validating the gate.

## Behavior

- `tests/run-regression.js`, `tests/run-np-subsystem.js`, and `tests/run-constructions.js` remain strict when invoked directly.
- `tests/run-all.js --allow-inherited-debt` may report inherited debt for the three known aggregate debt suites while all focused/runtime architecture tests remain blocking.
- `tools/verify-regression-ratchet.js` compares stable failure identities and executable test contracts for `regression`, `np_subsystem`, and `construction_files` against the actual base commit.
- New failure identities, test-contract drift, malformed/orphan identities, missing candidate reports, and requested-but-unmet strict reduction block acceptance.
- If a baseline suite exits nonzero before producing a report, `tools/ratchet-unobservable-baseline.js` conservatively materializes every unchanged case as failed; candidate reports are never synthesized.
- `inferTokenFeatures()` clones lexical `semantic` and `verb_class` arrays before inference mutation.
- The existing `AcceptabilityClause` matcher keeps its linguistic behavior while its trace declares `generative_template` and reports only realized assigned slots.
- Focused tests cover subset acceptance, identity swaps, contract drift, strict reduction, conservative unobservable-baseline materialization, and frozen lexical feature arrays.

## Changed files

- `.github/workflows/runtime-source-first.yml`
- `config/verification-profiles.json`
- `main.js`
- `src/parser/detectors/acceptability/clauses.js`
- `src/parser/features/token-features.js`
- `tests/run-all.js`
- `tests/tooling/runtime/regression-ratchet-verifier.test.js`
- `tests/tooling/runtime/token-features-immutability.test.js`
- `tools/ratchet-unobservable-baseline.js`
- `tools/verify-regression-ratchet.js`

## Protected / unchanged

No runtime lexical content, regression fixture expectation, construction identity/status, linguistic evidence, survey/corpus state, release state, or volatile project-state snapshot changed. The AcceptabilityClause change is trace-contract metadata for the existing matcher; the token-feature repair is mechanical ownership of mutable inference arrays.

## Validation

Reviewed exact head: `ca661230aab4e9549671bf4d1edc16c59e637420`.

- Research provenance: PASS.
- Full diagnostic verification: PASS.
- Runtime source-first validation (pull_request, base `291c6175e6887e5d3a6f02ef31c063ddb622a581`): PASS.
- Runtime source-first validation (push): PASS.
- Branch is 0 commits behind current `main`.
- No pull-request reviews or unresolved review threads.
- No competing open pull request in the repository.

The previously missing focused test for conservative unobservable-baseline handling was added at this exact head and passed the full exact-head validation.