### PR TITLE
Protect constitutional doctrine tests with reviewed SHA gates

### DIFF
--- a/.github/workflows/full-diagnostic-verification.yml
+++ b/.github/workflows/full-diagnostic-verification.yml
@@ -4,18 +4,28 @@ on:
   push:
     paths:
       - "config/verification-profiles.json"
+      - "config/protected-tests.json"
+      - "schemas/protected-test-registry.schema.json"
       - "tools/verify-current-state.js"
+      - "tools/verify-protected-tests.js"
+      - "tools/verify-protected-test-review.js"
       - "tests/tooling/verification/**"
       - "package.json"
       - "package-lock.json"
+      - ".github/workflows/protected-test-review.yml"
       - ".github/workflows/full-diagnostic-verification.yml"
   pull_request:
     paths:
       - "config/verification-profiles.json"
+      - "config/protected-tests.json"
+      - "schemas/protected-test-registry.schema.json"
       - "tools/verify-current-state.js"
+      - "tools/verify-protected-tests.js"
+      - "tools/verify-protected-test-review.js"
       - "tests/tooling/verification/**"
       - "package.json"
       - "package-lock.json"
+      - ".github/workflows/protected-test-review.yml"
       - ".github/workflows/full-diagnostic-verification.yml"
   workflow_dispatch:
 
@@ -33,8 +43,8 @@ jobs:
           package-manager-cache: false
       - name: Install build dependencies
         run: npm ci
-      - name: Test verification orchestration
-        run: npm run test:verification-orchestration
+      - name: Test verification and protected-test governance
+        run: node --test tests/tooling/verification/*.test.js
       - name: Run full diagnostic sweep
         continue-on-error: true
         run: npm run verify:all -- --keep-going --output /tmp/full-verification.json

--- a/.github/workflows/protected-test-review.yml
+++ b/.github/workflows/protected-test-review.yml
@@ -2,7 +2,7 @@ name: Protected doctrine-test review
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   pull_request_review:
     types: [submitted, edited, dismissed]
 

--- a/.github/workflows/protected-test-review.yml
+++ b/.github/workflows/protected-test-review.yml
@@ -34,6 +34,7 @@ jobs:
               analyzeProtectedChanges,
               evaluateReviewGate,
               evaluateUserOverride,
+              validateReviewApiCompleteness,
             } = require("./tools/verify-protected-test-review");
 
             const pr = context.payload.pull_request;
@@ -49,6 +50,21 @@ jobs:
 
             const baseRepo = splitRepo(pr.base.repo.full_name);
             const headRepo = splitRepo(pr.head.repo.full_name);
+
+            const prDetails = await github.rest.pulls.get({
+              ...baseRepo,
+              pull_number: pr.number,
+            });
+            const completenessFailures = validateReviewApiCompleteness({
+              commitCount: prDetails.data.commits,
+              changedFileCount: prDetails.data.changed_files,
+            });
+            if (completenessFailures.length) {
+              core.setFailed(
+                `Protected-review PR enumeration cannot be proven complete: ${JSON.stringify(completenessFailures)}`
+              );
+              return;
+            }
 
             async function getBytes(repoRef, filePath, ref, required = true) {
               try {

--- a/.github/workflows/protected-test-review.yml
+++ b/.github/workflows/protected-test-review.yml
@@ -1,0 +1,206 @@
+name: Protected doctrine-test review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  protected-test-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted base
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Evaluate protected doctrine-test changes from trusted base code
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const {
+              sha256,
+              validateRegistry,
+            } = require("./tools/verify-protected-tests");
+            const {
+              REGISTRY_PATH,
+              analyzeProtectedChanges,
+              evaluateReviewGate,
+              evaluateUserOverride,
+            } = require("./tools/verify-protected-test-review");
+
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.setFailed("Protected-test review requires a pull_request payload.");
+              return;
+            }
+
+            function splitRepo(fullName) {
+              const [owner, repo] = fullName.split("/");
+              return { owner, repo };
+            }
+
+            const baseRepo = splitRepo(pr.base.repo.full_name);
+            const headRepo = splitRepo(pr.head.repo.full_name);
+
+            async function getBytes(repoRef, filePath, ref, required = true) {
+              try {
+                const response = await github.rest.repos.getContent({
+                  ...repoRef,
+                  path: filePath,
+                  ref,
+                });
+                if (Array.isArray(response.data) || response.data.type !== "file" || !response.data.content) {
+                  throw new Error(`${filePath} did not resolve to a file`);
+                }
+                return Buffer.from(response.data.content.replace(/\n/g, ""), "base64");
+              } catch (error) {
+                if (!required && error.status === 404) return null;
+                throw error;
+              }
+            }
+
+            async function getRegistry(repoRef, ref, side) {
+              const bytes = await getBytes(repoRef, REGISTRY_PATH, ref, true);
+              let parsed;
+              try {
+                parsed = JSON.parse(bytes.toString("utf8"));
+              } catch (error) {
+                throw new Error(`${side} protected-test registry is not valid JSON: ${error.message}`);
+              }
+              const failures = validateRegistry(parsed);
+              if (failures.length) {
+                throw new Error(`${side} protected-test registry is invalid: ${JSON.stringify(failures)}`);
+              }
+              return parsed;
+            }
+
+            let baseRegistry;
+            let headRegistry;
+            try {
+              baseRegistry = await getRegistry(baseRepo, pr.base.sha, "base");
+              headRegistry = await getRegistry(headRepo, pr.head.sha, "head");
+            } catch (error) {
+              core.setFailed(error.message);
+              return;
+            }
+
+            const headHashFailures = [];
+            for (const entry of headRegistry.tests) {
+              const bytes = await getBytes(headRepo, entry.path, pr.head.sha, false);
+              if (!bytes) {
+                headHashFailures.push({ path: entry.path, code: "protected_test_missing" });
+                continue;
+              }
+              const actual = sha256(bytes);
+              if (actual !== entry.sha256) {
+                headHashFailures.push({
+                  path: entry.path,
+                  code: "PROTECTED_TEST_REVIEW_REQUIRED",
+                  expected_sha256: entry.sha256,
+                  actual_sha256: actual,
+                });
+              }
+            }
+            if (headHashFailures.length) {
+              core.setFailed(`Head protected-test SHA verification failed: ${JSON.stringify(headHashFailures)}`);
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              ...baseRepo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const analysis = analyzeProtectedChanges({ baseRegistry, headRegistry, files });
+            if (analysis.status !== "PASS") {
+              core.setFailed(`Protected-change analysis failed closed: ${JSON.stringify(analysis.failures)}`);
+              return;
+            }
+            if (!analysis.required_paths.length) {
+              core.notice("No protected doctrine-test or protected-test control-plane change detected.");
+              return;
+            }
+
+            const prCommits = await github.paginate(github.rest.pulls.listCommits, {
+              ...baseRepo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const commits = [];
+            for (const commit of prCommits) {
+              const commitFiles = [];
+              for (let page = 1; page <= 30; page += 1) {
+                const response = await github.request("GET /repos/{owner}/{repo}/commits/{ref}", {
+                  ...headRepo,
+                  ref: commit.sha,
+                  per_page: 100,
+                  page,
+                });
+                const batch = response.data.files || [];
+                commitFiles.push(...batch);
+                if (batch.length < 100) break;
+                if (page === 30) {
+                  core.setFailed(`Commit ${commit.sha} exceeds the fail-closed protected-review file pagination limit.`);
+                  return;
+                }
+              }
+              commits.push({ sha: commit.sha, files: commitFiles });
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              ...baseRepo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const decision = evaluateReviewGate({
+              requiredPaths: analysis.required_paths,
+              registryChanged: analysis.registry_changed,
+              commits,
+              reviews,
+            });
+            if (decision.status !== "PASS") {
+              const template = {
+                schema: "canto-span-protected-test-review-v1",
+                decision: "approve",
+                basis: "doctrine_review",
+                paths: analysis.required_paths,
+                registry_changed: analysis.registry_changed,
+                reason: "Explain why the protected doctrine/control-plane change is justified independently of making tests pass.",
+              };
+              core.setFailed(
+                `${decision.code}: latest protected change requires a fresh structured PR review. `
+                + `Required paths: ${JSON.stringify(analysis.required_paths)}. `
+                + `Review block: \`\`\`protected-test-review\n${JSON.stringify(template)}\n\`\`\``
+              );
+              return;
+            }
+
+            if (decision.review && decision.review.basis === "user_override") {
+              if (!analysis.affected_protected_paths.length) {
+                core.setFailed("User override cannot authorize a control-plane-only change; use doctrine_review.");
+                return;
+              }
+              const issue = await github.rest.issues.get({
+                ...baseRepo,
+                issue_number: decision.review.authorization_issue,
+              });
+              const override = evaluateUserOverride(issue.data.body || "", analysis.affected_protected_paths);
+              if (override.status !== "PASS") {
+                core.setFailed(
+                  `${override.code}: issue #${decision.review.authorization_issue} must contain an explicit exact-path protected-test-override record.`
+                );
+                return;
+              }
+            }
+
+            core.notice(
+              `Protected-test review accepted at ${decision.review.commit_id} for ${analysis.required_paths.join(", ")}.`
+            );

--- a/config/protected-tests.json
+++ b/config/protected-tests.json
@@ -3,7 +3,7 @@
   "tests": [
     {
       "path": "tests/tooling/runtime/regression-ratchet-verifier.test.js",
-      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "sha256": "40000b8210240eae98e34a7e16cc73ecd44b708bc916f2494313f64b5914b799",
       "reason": "Enforces the repository-wide monotonic regression-debt doctrine: stable failure identities may not expand or be hidden by changing the executable test contract.",
       "scope": "runtime",
       "protection_class": "constitutional_doctrine",
@@ -13,7 +13,7 @@
     },
     {
       "path": "tests/tooling/verification/protected-tests.test.js",
-      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "sha256": "2544482b9617ac42745c9d8eec82532ffb5d871cea14f9cc73be31a4ed224b46",
       "reason": "Enforces the protected-test constitutional doctrine itself: no SHA laundering, no stale review, exact-path review coverage, and no inferred user override.",
       "scope": "governance",
       "protection_class": "constitutional_doctrine",
@@ -23,7 +23,7 @@
     },
     {
       "path": "tests/tooling/verification/verification-profiles.test.js",
-      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "sha256": "9005a8c0e1fb4b7a86131bbab7c3a338466f2c979ba2c8b7059d71d07fc723f6",
       "reason": "Enforces fail-closed canonical verification orchestration so registered profiles cannot be silently omitted, duplicated, renamed, or partially executed.",
       "scope": "governance",
       "protection_class": "constitutional_doctrine",

--- a/config/protected-tests.json
+++ b/config/protected-tests.json
@@ -13,8 +13,8 @@
     },
     {
       "path": "tests/tooling/verification/protected-tests.test.js",
-      "sha256": "ece52a4203af5984c90a9cd9c01d10c54ea0f65ba206ef6f545daa423eaef310",
-      "reason": "Enforces the protected-test constitutional doctrine itself: no SHA laundering, no stale review, exact-path control-plane coverage, viable single-author review semantics, and no inferred user override.",
+      "sha256": "fed3ccc972b84227434748324b0a4b2ef0363aa670634cbd8ad819c0eecf5a4b",
+      "reason": "Enforces the protected-test constitutional doctrine itself: no SHA laundering, no stale review including base-retarget freshness, exact-path control-plane coverage, viable single-author review semantics, and no inferred user override.",
       "scope": "governance",
       "protection_class": "constitutional_doctrine",
       "expected_change_frequency": "rare-to-never",

--- a/config/protected-tests.json
+++ b/config/protected-tests.json
@@ -13,7 +13,7 @@
     },
     {
       "path": "tests/tooling/verification/protected-tests.test.js",
-      "sha256": "2544482b9617ac42745c9d8eec82532ffb5d871cea14f9cc73be31a4ed224b46",
+      "sha256": "53dd9673dfcf9c9349d982e9221e5c24776c5d11c40fe34fe8e8defa9fcd2323",
       "reason": "Enforces the protected-test constitutional doctrine itself: no SHA laundering, no stale review, exact-path review coverage, and no inferred user override.",
       "scope": "governance",
       "protection_class": "constitutional_doctrine",

--- a/config/protected-tests.json
+++ b/config/protected-tests.json
@@ -13,8 +13,8 @@
     },
     {
       "path": "tests/tooling/verification/protected-tests.test.js",
-      "sha256": "fed3ccc972b84227434748324b0a4b2ef0363aa670634cbd8ad819c0eecf5a4b",
-      "reason": "Enforces the protected-test constitutional doctrine itself: no SHA laundering, no stale review including base-retarget freshness, exact-path control-plane coverage, viable single-author review semantics, and no inferred user override.",
+      "sha256": "d79c530711315791893c5d93fa9f5c318d0ac3ac2201b1a3d37228b27c76f249",
+      "reason": "Enforces the protected-test constitutional doctrine itself: no SHA laundering, no stale review including base-retarget freshness, complete protected control-plane coverage, fail-closed GitHub PR enumeration limits, viable single-author review semantics, and no inferred user override.",
       "scope": "governance",
       "protection_class": "constitutional_doctrine",
       "expected_change_frequency": "rare-to-never",

--- a/config/protected-tests.json
+++ b/config/protected-tests.json
@@ -1,0 +1,35 @@
+{
+  "schema": "canto-span-protected-tests-v1",
+  "tests": [
+    {
+      "path": "tests/tooling/runtime/regression-ratchet-verifier.test.js",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "reason": "Enforces the repository-wide monotonic regression-debt doctrine: stable failure identities may not expand or be hidden by changing the executable test contract.",
+      "scope": "runtime",
+      "protection_class": "constitutional_doctrine",
+      "expected_change_frequency": "rare-to-never",
+      "normal_growth_requires_edit": false,
+      "review_required_on_change": true
+    },
+    {
+      "path": "tests/tooling/verification/protected-tests.test.js",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "reason": "Enforces the protected-test constitutional doctrine itself: no SHA laundering, no stale review, exact-path review coverage, and no inferred user override.",
+      "scope": "governance",
+      "protection_class": "constitutional_doctrine",
+      "expected_change_frequency": "rare-to-never",
+      "normal_growth_requires_edit": false,
+      "review_required_on_change": true
+    },
+    {
+      "path": "tests/tooling/verification/verification-profiles.test.js",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "reason": "Enforces fail-closed canonical verification orchestration so registered profiles cannot be silently omitted, duplicated, renamed, or partially executed.",
+      "scope": "governance",
+      "protection_class": "constitutional_doctrine",
+      "expected_change_frequency": "rare-to-never",
+      "normal_growth_requires_edit": false,
+      "review_required_on_change": true
+    }
+  ]
+}

--- a/config/protected-tests.json
+++ b/config/protected-tests.json
@@ -13,8 +13,8 @@
     },
     {
       "path": "tests/tooling/verification/protected-tests.test.js",
-      "sha256": "53dd9673dfcf9c9349d982e9221e5c24776c5d11c40fe34fe8e8defa9fcd2323",
-      "reason": "Enforces the protected-test constitutional doctrine itself: no SHA laundering, no stale review, exact-path review coverage, and no inferred user override.",
+      "sha256": "ece52a4203af5984c90a9cd9c01d10c54ea0f65ba206ef6f545daa423eaef310",
+      "reason": "Enforces the protected-test constitutional doctrine itself: no SHA laundering, no stale review, exact-path control-plane coverage, viable single-author review semantics, and no inferred user override.",
       "scope": "governance",
       "protection_class": "constitutional_doctrine",
       "expected_change_frequency": "rare-to-never",

--- a/config/verification-profiles.json
+++ b/config/verification-profiles.json
@@ -53,12 +53,6 @@
         "run_when": "Current documentation, authority settings, or canonical state change."
       },
       {
-        "id": "protected-test-governance",
-        "command": ["node", "--test", "tests/tooling/verification/protected-tests.test.js"],
-        "reason": "Enforce the stable constitutional rules for protected-test admission, anti-laundering, review freshness, exact path coverage, and explicit user override.",
-        "run_when": "Protected-test registry, verifier, review gate, or doctrine test changes."
-      },
-      {
         "id": "protected-test-sha",
         "command": ["node", "tools/verify-protected-tests.js"],
         "reason": "Fail closed when a registered constitutional doctrine test drifts from its explicitly reviewed SHA-256.",

--- a/config/verification-profiles.json
+++ b/config/verification-profiles.json
@@ -53,6 +53,12 @@
         "run_when": "Current documentation, authority settings, or canonical state change."
       },
       {
+        "id": "protected-test-governance",
+        "command": ["node", "--test", "tests/tooling/verification/protected-tests.test.js"],
+        "reason": "Enforce the stable constitutional rules for protected-test admission, anti-laundering, review freshness, exact path coverage, and explicit user override.",
+        "run_when": "Protected-test registry, verifier, review gate, or doctrine test changes."
+      },
+      {
         "id": "protected-test-sha",
         "command": ["node", "tools/verify-protected-tests.js"],
         "reason": "Fail closed when a registered constitutional doctrine test drifts from its explicitly reviewed SHA-256.",

--- a/config/verification-profiles.json
+++ b/config/verification-profiles.json
@@ -50,7 +50,13 @@
         "id": "documentation",
         "command": ["node", "tools/verify-documentation-consistency.js"],
         "reason": "Prevent broken current-document links and competing current authority.",
-        "run_when": "Current documentation, authority settings, or canonical state changes."
+        "run_when": "Current documentation, authority settings, or canonical state change."
+      },
+      {
+        "id": "protected-test-sha",
+        "command": ["node", "tools/verify-protected-tests.js"],
+        "reason": "Fail closed when a registered constitutional doctrine test drifts from its explicitly reviewed SHA-256.",
+        "run_when": "A protected doctrine test or the protected-test registry changes; core verification also confirms the reviewed hashes remain intact."
       }
     ],
     "research": [

--- a/docs/current/PROTECTED-TEST-GOVERNANCE.md
+++ b/docs/current/PROTECTED-TEST-GOVERNANCE.md
@@ -1,0 +1,99 @@
+---
+title: Canto Span — Protected Test Governance
+status: current
+tags: [canto-span/testing, canto-span/governance]
+related: "[[TESTING]]"
+---
+
+# Protected test governance
+
+Protected-test SHA governance is a narrow constitutional safeguard. It does **not** make every important test immutable.
+
+## Admission rule
+
+A test may enter `config/protected-tests.json` only when all of these are true:
+
+1. it directly enforces a top-level repository doctrine or safety invariant;
+2. that doctrine is expected to change rarely to never;
+3. normal feature, corpus, lexical, construction, survey, or source expansion does not require editing the test;
+4. changing the test content itself deserves explicit review because it could weaken repository-wide safety or methodology.
+
+High value alone is insufficient. Expected low churn is mandatory.
+
+Do **not** SHA-protect scalable or routinely growing suites, including lexical runtime/authority coverage, lexical-ingestion source registries, construction/corpus/survey inventories, generated snapshots, source packets, migration-count checks, or other tests whose content should legitimately grow with coverage. Those remain governed by ordinary regression and test-validity review.
+
+Every protected registry entry declares:
+
+- `path`;
+- exact content `sha256`;
+- the doctrine-preserving `reason`;
+- `scope`;
+- `protection_class: constitutional_doctrine`;
+- `expected_change_frequency: rare-to-never`;
+- `normal_growth_requires_edit: false`;
+- `review_required_on_change: true`.
+
+## Initial constitutional set
+
+The bootstrap registry is deliberately small:
+
+- `tests/tooling/runtime/regression-ratchet-verifier.test.js` — protects monotonic regression-debt semantics and prevents stable failures from being hidden through test-contract drift;
+- `tests/tooling/verification/verification-profiles.test.js` — protects fail-closed canonical verification orchestration;
+- `tests/tooling/verification/protected-tests.test.js` — protects this governance mechanism's anti-laundering, review-freshness, exact-path, and explicit-user-override doctrine.
+
+Parser architecture, native-panel lifecycle, lexical coverage, construction inventories, generated-runtime behavior, and other important but evolving suites are intentionally **not** in the protected SHA registry.
+
+## Working-tree SHA verification
+
+`node tools/verify-protected-tests.js` validates the registry and compares every registered test's current bytes to its stored SHA-256.
+
+A mismatch, deletion, or missing protected path fails with `PROTECTED_TEST_REVIEW_REQUIRED`. The verifier reports the expected and actual hashes but never rewrites or blesses a hash.
+
+The check is part of the canonical core verification profile.
+
+## PR anti-laundering gate
+
+A stored hash alone is insufficient because a branch could change both a protected test and its registry hash. The trusted PR gate therefore evaluates base and head together.
+
+`.github/workflows/protected-test-review.yml` runs from trusted base code. It does not execute review-gate code supplied by the PR head. It:
+
+1. reads and validates both base and head registries;
+2. verifies every head registry SHA against the head file bytes;
+3. uses the union of base/head protected paths so removing or renaming protection cannot hide a change;
+4. treats registry entry addition/removal/change as a protected change;
+5. requires review for changes to the protected-test control plane itself (registry, schema, verifier, review logic, doctrine test, or trusted workflow);
+6. finds the latest PR commit touching the affected protected/control-plane paths;
+7. requires a structured review attached to a commit at or after that latest protected change;
+8. invalidates an earlier review when a later protected change occurs.
+
+A later unrelated commit does not invalidate a review that already contains the latest protected change.
+
+## Structured review
+
+Ordinary doctrine changes require a PR review containing an exact fenced record:
+
+```protected-test-review
+{"schema":"canto-span-protected-test-review-v1","decision":"approve","basis":"doctrine_review","paths":["config/protected-tests.json","tests/path/to/doctrine.test.js"],"registry_changed":true,"reason":"Independent reason the doctrine expectation itself must change."}
+```
+
+The path set must exactly match the gate's affected path set. A generic approval, ordinary review prose, or a request to "make the tests pass" is not a protected-test review.
+
+After an approved doctrine change, update the registry SHA to the reviewed final content. The gate never performs that update automatically.
+
+## Explicit user override
+
+A protected doctrine test can still change when the user explicitly requests changing that protected expectation. The authorization must be exact and auditable; it is never inferred from agent convenience or generic acceptance language.
+
+The authorizing issue must contain:
+
+```protected-test-override
+{"schema":"canto-span-protected-test-override-v1","authorized_by":"user","paths":["tests/path/to/doctrine.test.js"],"reason":"Why the protected expectation itself must change."}
+```
+
+The subsequent structured PR review uses `basis: user_override` and names that issue in `authorization_issue`. The override paths must exactly match the affected protected-test paths.
+
+A user override is a basis for the required review. It is not a bypass: final head SHA consistency and normal PR/merge review still apply.
+
+## Bootstrap limitation
+
+The first PR introducing this gate cannot be protected by a workflow that does not yet exist on its base branch. Bootstrap therefore requires direct review of the implementation and final hashes. Once merged to `main`, the trusted base-owned gate protects subsequent changes.

--- a/docs/current/PROTECTED-TEST-GOVERNANCE.md
+++ b/docs/current/PROTECTED-TEST-GOVERNANCE.md
@@ -64,7 +64,8 @@ A stored hash alone is insufficient because a branch could change both a protect
 5. requires review for changes to the protected-test control plane itself, including the registry, schema, SHA verifier, review analyzer, doctrine test, trusted review workflow, core verification-profile registration, and full-diagnostic enforcement workflow;
 6. finds the latest PR commit touching the affected protected/control-plane paths;
 7. requires a structured review attached to a commit at or after that latest protected change;
-8. invalidates an earlier review when a later protected change occurs.
+8. invalidates an earlier review when a later protected change occurs;
+9. reruns when the pull request is edited so a base-branch retarget cannot leave a stale trusted-base decision in place.
 
 A later unrelated commit does not invalidate a review that already contains the latest protected change.
 
@@ -86,7 +87,7 @@ Ordinary doctrine changes require a PR review containing an exact fenced record:
 
 The path set must exactly match the gate's affected path set, and the review must be attached to a commit containing the latest protected change. A generic approval, ordinary review prose, or a request to "make the tests pass" is not a protected-test review.
 
-After a reviewed doctrine change, update the registry SHA to the reviewed final content. The gate never performs that update automatically.
+Finalize the protected test content first, update `config/protected-tests.json` to the exact SHA-256 of that final content, and only then submit the structured review against the resulting commit. Because the registry is itself protected control-plane state, any later protected-test or registry edit invalidates that review and requires a new structured review. The gate never performs or blesses the SHA update automatically.
 
 ## Explicit user override
 

--- a/docs/current/PROTECTED-TEST-GOVERNANCE.md
+++ b/docs/current/PROTECTED-TEST-GOVERNANCE.md
@@ -39,7 +39,7 @@ The bootstrap registry is deliberately small:
 
 - `tests/tooling/runtime/regression-ratchet-verifier.test.js` — protects monotonic regression-debt semantics and prevents stable failures from being hidden through test-contract drift;
 - `tests/tooling/verification/verification-profiles.test.js` — protects fail-closed canonical verification orchestration;
-- `tests/tooling/verification/protected-tests.test.js` — protects this governance mechanism's anti-laundering, review-freshness, exact-path, and explicit-user-override doctrine.
+- `tests/tooling/verification/protected-tests.test.js` — protects this governance mechanism's anti-laundering, review-freshness, exact-path, API-completeness, and explicit-user-override doctrine.
 
 Parser architecture, native-panel lifecycle, lexical coverage, construction inventories, generated-runtime behavior, and other important but evolving suites are intentionally **not** in the protected SHA registry.
 
@@ -61,13 +61,16 @@ A stored hash alone is insufficient because a branch could change both a protect
 2. verifies every head registry SHA against the head file bytes;
 3. uses the union of base/head protected paths so removing or renaming protection cannot hide a change;
 4. treats registry entry addition/removal/change as a protected change;
-5. requires review for changes to the protected-test control plane itself, including the registry, schema, SHA verifier, review analyzer, doctrine test, trusted review workflow, core verification-profile registration, and full-diagnostic enforcement workflow;
+5. requires review for every path in the canonical `CONTROL_PLANE_PATHS` set, including the registry, schema, SHA verifier, review analyzer, doctrine test, trusted review workflow, core verification-profile registration, and full-diagnostic enforcement workflow;
 6. finds the latest PR commit touching the affected protected/control-plane paths;
 7. requires a structured review attached to a commit at or after that latest protected change;
 8. invalidates an earlier review when a later protected change occurs;
-9. reruns when the pull request is edited so a base-branch retarget cannot leave a stale trusted-base decision in place.
+9. reruns when the pull request is edited so a base-branch retarget cannot leave a stale trusted-base decision in place;
+10. fails closed before PR enumeration when GitHub reports more than 250 commits or more than 3,000 changed files, or when those counts are unavailable or invalid, because the REST endpoints used by this gate cannot prove complete enumeration beyond those limits.
 
 A later unrelated commit does not invalidate a review that already contains the latest protected change.
+
+The enumeration limits are safety boundaries, not project-size targets. A PR that exceeds either limit must be reduced/split or the gate must first move to a mechanism that can prove complete protected-path and commit enumeration. The gate must never treat a truncated API response as complete.
 
 ## Single-author/shared-account review model
 

--- a/docs/current/PROTECTED-TEST-GOVERNANCE.md
+++ b/docs/current/PROTECTED-TEST-GOVERNANCE.md
@@ -61,12 +61,20 @@ A stored hash alone is insufficient because a branch could change both a protect
 2. verifies every head registry SHA against the head file bytes;
 3. uses the union of base/head protected paths so removing or renaming protection cannot hide a change;
 4. treats registry entry addition/removal/change as a protected change;
-5. requires review for changes to the protected-test control plane itself (registry, schema, verifier, review logic, doctrine test, or trusted workflow);
+5. requires review for changes to the protected-test control plane itself, including the registry, schema, SHA verifier, review analyzer, doctrine test, trusted review workflow, core verification-profile registration, and full-diagnostic enforcement workflow;
 6. finds the latest PR commit touching the affected protected/control-plane paths;
 7. requires a structured review attached to a commit at or after that latest protected change;
 8. invalidates an earlier review when a later protected change occurs.
 
 A later unrelated commit does not invalidate a review that already contains the latest protected change.
+
+## Single-author/shared-account review model
+
+Canto Span currently has one GitHub author account. The user, ChatGPT, and Codex all make repository changes through that same account, so GitHub actor identity cannot distinguish the human owner from an assisting agent. GitHub also does not permit a pull-request author to submit an `APPROVED` review on their own PR.
+
+Therefore protected-test governance does **not** use reviewer identity or a separate-reviewer requirement as an authorization boundary. A structured `COMMENTED` review is intentionally valid in this repository when it satisfies the exact-path and freshness rules below. `APPROVED` is also accepted if a genuinely separate reviewer exists in the future. `PENDING`, `DISMISSED`, and `CHANGES_REQUESTED` reviews cannot satisfy the gate.
+
+This mechanism is designed to prevent silent, accidental, stale, inferred, or convenience-driven doctrine drift by repository agents following the project contract. It is not a cryptographic defense against a malicious actor already controlling the repository owner's GitHub credentials. Any future requirement for cryptographically distinct human authorization would need an external trust mechanism rather than GitHub account identity alone.
 
 ## Structured review
 
@@ -76,9 +84,9 @@ Ordinary doctrine changes require a PR review containing an exact fenced record:
 {"schema":"canto-span-protected-test-review-v1","decision":"approve","basis":"doctrine_review","paths":["config/protected-tests.json","tests/path/to/doctrine.test.js"],"registry_changed":true,"reason":"Independent reason the doctrine expectation itself must change."}
 ```
 
-The path set must exactly match the gate's affected path set. A generic approval, ordinary review prose, or a request to "make the tests pass" is not a protected-test review.
+The path set must exactly match the gate's affected path set, and the review must be attached to a commit containing the latest protected change. A generic approval, ordinary review prose, or a request to "make the tests pass" is not a protected-test review.
 
-After an approved doctrine change, update the registry SHA to the reviewed final content. The gate never performs that update automatically.
+After a reviewed doctrine change, update the registry SHA to the reviewed final content. The gate never performs that update automatically.
 
 ## Explicit user override
 
@@ -91,6 +99,8 @@ The authorizing issue must contain:
 ```
 
 The subsequent structured PR review uses `basis: user_override` and names that issue in `authorization_issue`. The override paths must exactly match the affected protected-test paths.
+
+Because all repository writes currently share one GitHub account, the automated gate can validate that this record is explicit, exact, and auditable but cannot cryptographically prove which same-account actor typed it. Repository agents are therefore forbidden by project doctrine from fabricating or inferring a user override that was not actually requested.
 
 A user override is a basis for the required review. It is not a bypass: final head SHA consistency and normal PR/merge review still apply.
 

--- a/schemas/protected-test-registry.schema.json
+++ b/schemas/protected-test-registry.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://canto-span.local/schemas/protected-test-registry.schema.json",
+  "title": "Canto Span protected doctrine-test registry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "tests"],
+  "properties": {
+    "schema": {
+      "const": "canto-span-protected-tests-v1"
+    },
+    "tests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "path",
+          "sha256",
+          "reason",
+          "scope",
+          "protection_class",
+          "expected_change_frequency",
+          "normal_growth_requires_edit",
+          "review_required_on_change"
+        ],
+        "properties": {
+          "path": {
+            "type": "string",
+            "pattern": "^tests/.+\\.test\\.(js|py)$"
+          },
+          "sha256": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          },
+          "scope": {
+            "enum": ["runtime", "research", "governance", "release"]
+          },
+          "protection_class": {
+            "const": "constitutional_doctrine"
+          },
+          "expected_change_frequency": {
+            "const": "rare-to-never"
+          },
+          "normal_growth_requires_edit": {
+            "const": false
+          },
+          "review_required_on_change": {
+            "const": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/tooling/verification/protected-tests.test.js
+++ b/tests/tooling/verification/protected-tests.test.js
@@ -62,15 +62,22 @@ function reviewBody({ paths, registryChanged = true, basis = "doctrine_review", 
   return `\`\`\`protected-test-review\n${JSON.stringify(record)}\n\`\`\``;
 }
 
-test("working-tree verifier accepts only the registered content hash", () => {
+test("working-tree verifier rejects changed or deleted protected content", () => {
   const item = fixture();
   try {
     assert.equal(verifyProtectedTests(item.root, item.registry).status, "PASS");
+
     fs.writeFileSync(path.join(item.root, item.path), "weakened\n");
-    const report = verifyProtectedTests(item.root, item.registry);
-    assert.equal(report.status, "FAIL");
-    assert.equal(report.failures[0].code, "PROTECTED_TEST_REVIEW_REQUIRED");
-    assert.equal(report.failures[0].path, item.path);
+    const changed = verifyProtectedTests(item.root, item.registry);
+    assert.equal(changed.status, "FAIL");
+    assert.equal(changed.failures[0].code, "PROTECTED_TEST_REVIEW_REQUIRED");
+    assert.equal(changed.failures[0].path, item.path);
+
+    fs.rmSync(path.join(item.root, item.path));
+    const deleted = verifyProtectedTests(item.root, item.registry);
+    assert.equal(deleted.status, "FAIL");
+    assert.equal(deleted.failures[0].code, "protected_test_missing");
+    assert.equal(deleted.failures[0].path, item.path);
   } finally {
     fs.rmSync(item.root, { recursive: true, force: true });
   }
@@ -113,14 +120,46 @@ test("removing a registry entry still requires review of the removed protection"
   assert.deepEqual(analysis.required_paths, [REGISTRY_PATH, "tests/doctrine.test.js"]);
 });
 
+test("renaming a protected path requires review of both old and new identities", () => {
+  const base = registry([{ path: "tests/old-doctrine.test.js", sha256: "a".repeat(64) }]);
+  const head = registry([{ path: "tests/new-doctrine.test.js", sha256: "b".repeat(64) }]);
+  const analysis = analyzeProtectedChanges({
+    baseRegistry: base,
+    headRegistry: head,
+    files: [
+      {
+        filename: "tests/new-doctrine.test.js",
+        previous_filename: "tests/old-doctrine.test.js",
+        status: "renamed",
+      },
+      { filename: REGISTRY_PATH, status: "modified" },
+    ],
+  });
+  assert.equal(analysis.status, "PASS");
+  assert.deepEqual(analysis.affected_protected_paths, [
+    "tests/new-doctrine.test.js",
+    "tests/old-doctrine.test.js",
+  ]);
+  assert.deepEqual(analysis.required_paths, [
+    REGISTRY_PATH,
+    "tests/new-doctrine.test.js",
+    "tests/old-doctrine.test.js",
+  ]);
+});
+
 test("protected control-plane edits require review even when no doctrine-test hash changes", () => {
   const unchanged = registry([]);
-  const analysis = analyzeProtectedChanges({
-    baseRegistry: unchanged,
-    headRegistry: unchanged,
-    files: [{ filename: ".github/workflows/protected-test-review.yml", status: "modified" }],
-  });
-  assert.deepEqual(analysis.required_paths, [".github/workflows/protected-test-review.yml"]);
+  for (const protectedControlPath of [
+    ".github/workflows/protected-test-review.yml",
+    "config/verification-profiles.json",
+  ]) {
+    const analysis = analyzeProtectedChanges({
+      baseRegistry: unchanged,
+      headRegistry: unchanged,
+      files: [{ filename: protectedControlPath, status: "modified" }],
+    });
+    assert.deepEqual(analysis.required_paths, [protectedControlPath]);
+  }
 });
 
 test("a review made before the latest protected change is stale", () => {

--- a/tests/tooling/verification/protected-tests.test.js
+++ b/tests/tooling/verification/protected-tests.test.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  sha256,
+  validateRegistry,
+  verifyProtectedTests,
+} = require("../../../tools/verify-protected-tests");
+const {
+  REGISTRY_PATH,
+  REVIEW_SCHEMA,
+  OVERRIDE_SCHEMA,
+  analyzeProtectedChanges,
+  evaluateReviewGate,
+  evaluateUserOverride,
+} = require("../../../tools/verify-protected-test-review");
+
+function registry(entries) {
+  return {
+    schema: "canto-span-protected-tests-v1",
+    tests: entries.map((entry) => ({
+      path: entry.path,
+      sha256: entry.sha256,
+      reason: entry.reason || "Protect a repository-wide doctrine whose expectation should not drift during ordinary feature work.",
+      scope: entry.scope || "governance",
+      protection_class: "constitutional_doctrine",
+      expected_change_frequency: "rare-to-never",
+      normal_growth_requires_edit: false,
+      review_required_on_change: true,
+    })),
+  };
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "canto-span-protected-tests-"));
+  const relative = "tests/doctrine.test.js";
+  const absolute = path.join(root, relative);
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  fs.writeFileSync(absolute, "doctrine\n");
+  return {
+    root,
+    path: relative,
+    registry: registry([{ path: relative, sha256: sha256(Buffer.from("doctrine\n")) }]),
+  };
+}
+
+function reviewBody({ paths, registryChanged = true, basis = "doctrine_review", authorizationIssue = null }) {
+  const record = {
+    schema: REVIEW_SCHEMA,
+    decision: "approve",
+    basis,
+    paths,
+    registry_changed: registryChanged,
+    reason: "The doctrine itself was explicitly reviewed rather than changed to make a test pass.",
+  };
+  if (authorizationIssue) record.authorization_issue = authorizationIssue;
+  return `\`\`\`protected-test-review\n${JSON.stringify(record)}\n\`\`\``;
+}
+
+test("working-tree verifier accepts only the registered content hash", () => {
+  const item = fixture();
+  try {
+    assert.equal(verifyProtectedTests(item.root, item.registry).status, "PASS");
+    fs.writeFileSync(path.join(item.root, item.path), "weakened\n");
+    const report = verifyProtectedTests(item.root, item.registry);
+    assert.equal(report.status, "FAIL");
+    assert.equal(report.failures[0].code, "PROTECTED_TEST_REVIEW_REQUIRED");
+    assert.equal(report.failures[0].path, item.path);
+  } finally {
+    fs.rmSync(item.root, { recursive: true, force: true });
+  }
+});
+
+test("registry rejects scalable tests as SHA-protection candidates", () => {
+  const item = fixture();
+  const bad = structuredClone(item.registry);
+  bad.tests[0].normal_growth_requires_edit = true;
+  assert.ok(validateRegistry(bad).some((failure) => failure.code === "scalable_test_not_eligible"));
+  fs.rmSync(item.root, { recursive: true, force: true });
+});
+
+test("base/head union prevents laundering a protected change by rewriting its registry entry", () => {
+  const oldEntry = registry([{ path: "tests/doctrine.test.js", sha256: "a".repeat(64) }]);
+  const newEntry = registry([{ path: "tests/doctrine.test.js", sha256: "b".repeat(64) }]);
+  const analysis = analyzeProtectedChanges({
+    baseRegistry: oldEntry,
+    headRegistry: newEntry,
+    files: [
+      { filename: "tests/doctrine.test.js", status: "modified" },
+      { filename: REGISTRY_PATH, status: "modified" },
+    ],
+  });
+  assert.equal(analysis.status, "PASS");
+  assert.deepEqual(analysis.affected_protected_paths, ["tests/doctrine.test.js"]);
+  assert.deepEqual(analysis.required_paths, [REGISTRY_PATH, "tests/doctrine.test.js"]);
+  assert.equal(analysis.registry_changed, true);
+});
+
+test("removing a registry entry still requires review of the removed protection", () => {
+  const base = registry([{ path: "tests/doctrine.test.js", sha256: "a".repeat(64) }]);
+  const head = registry([]);
+  const analysis = analyzeProtectedChanges({
+    baseRegistry: base,
+    headRegistry: head,
+    files: [{ filename: REGISTRY_PATH, status: "modified" }],
+  });
+  assert.deepEqual(analysis.affected_protected_paths, ["tests/doctrine.test.js"]);
+  assert.deepEqual(analysis.required_paths, [REGISTRY_PATH, "tests/doctrine.test.js"]);
+});
+
+test("protected control-plane edits require review even when no doctrine-test hash changes", () => {
+  const unchanged = registry([]);
+  const analysis = analyzeProtectedChanges({
+    baseRegistry: unchanged,
+    headRegistry: unchanged,
+    files: [{ filename: ".github/workflows/protected-test-review.yml", status: "modified" }],
+  });
+  assert.deepEqual(analysis.required_paths, [".github/workflows/protected-test-review.yml"]);
+});
+
+test("a review made before the latest protected change is stale", () => {
+  const required = [REGISTRY_PATH, "tests/doctrine.test.js"];
+  const commits = [
+    { sha: "c1", files: [{ filename: "tests/doctrine.test.js" }] },
+    { sha: "c2", files: [{ filename: REGISTRY_PATH }] },
+  ];
+  const reviews = [{ id: 1, state: "COMMENTED", commit_id: "c1", body: reviewBody({ paths: required }) }];
+  const result = evaluateReviewGate({ requiredPaths: required, registryChanged: true, commits, reviews });
+  assert.equal(result.status, "FAIL");
+  assert.equal(result.code, "PROTECTED_TEST_REVIEW_REQUIRED");
+});
+
+test("a fresh structured review must cover the exact protected change set", () => {
+  const required = [REGISTRY_PATH, "tests/doctrine.test.js"];
+  const commits = [
+    { sha: "c1", files: [{ filename: "tests/doctrine.test.js" }] },
+    { sha: "c2", files: [{ filename: REGISTRY_PATH }] },
+  ];
+  const partial = [{ id: 1, state: "COMMENTED", commit_id: "c2", body: reviewBody({ paths: ["tests/doctrine.test.js"] }) }];
+  assert.equal(evaluateReviewGate({ requiredPaths: required, registryChanged: true, commits, reviews: partial }).status, "FAIL");
+
+  const complete = [{ id: 2, state: "COMMENTED", commit_id: "c2", body: reviewBody({ paths: required }) }];
+  const result = evaluateReviewGate({ requiredPaths: required, registryChanged: true, commits, reviews: complete });
+  assert.equal(result.status, "PASS");
+  assert.equal(result.review.commit_id, "c2");
+  assert.equal(result.review.basis, "doctrine_review");
+});
+
+test("ordinary prose or a generic request to make tests pass is never authorization", () => {
+  const required = [REGISTRY_PATH, "tests/doctrine.test.js"];
+  const result = evaluateReviewGate({
+    requiredPaths: required,
+    registryChanged: true,
+    commits: [{ sha: "c1", files: [{ filename: REGISTRY_PATH }, { filename: "tests/doctrine.test.js" }] }],
+    reviews: [{ id: 1, state: "COMMENTED", commit_id: "c1", body: "Please make the tests pass." }],
+  });
+  assert.equal(result.status, "FAIL");
+});
+
+test("user override requires an explicit exact-path authorization record", () => {
+  const paths = ["tests/doctrine.test.js"];
+  const good = `\`\`\`protected-test-override\n${JSON.stringify({
+    schema: OVERRIDE_SCHEMA,
+    authorized_by: "user",
+    paths,
+    reason: "The user explicitly requested changing this protected doctrine expectation.",
+  })}\n\`\`\``;
+  assert.equal(evaluateUserOverride(good, paths).status, "PASS");
+
+  const overbroad = good.replace("tests/doctrine.test.js", "tests/other.test.js");
+  assert.equal(evaluateUserOverride(overbroad, paths).status, "FAIL");
+  assert.equal(evaluateUserOverride("make it green", paths).status, "FAIL");
+});

--- a/tests/tooling/verification/protected-tests.test.js
+++ b/tests/tooling/verification/protected-tests.test.js
@@ -147,10 +147,11 @@ test("renaming a protected path requires review of both old and new identities",
   ]);
 });
 
-test("protected control-plane edits require review even when no doctrine-test hash changes", () => {
+test("all protected control-plane enforcement files require review", () => {
   const unchanged = registry([]);
   for (const protectedControlPath of [
     ".github/workflows/protected-test-review.yml",
+    ".github/workflows/full-diagnostic-verification.yml",
     "config/verification-profiles.json",
   ]) {
     const analysis = analyzeProtectedChanges({
@@ -174,7 +175,7 @@ test("a review made before the latest protected change is stale", () => {
   assert.equal(result.code, "PROTECTED_TEST_REVIEW_REQUIRED");
 });
 
-test("a fresh structured review must cover the exact protected change set", () => {
+test("a fresh structured COMMENTED attestation can pass in the single-author repository", () => {
   const required = [REGISTRY_PATH, "tests/doctrine.test.js"];
   const commits = [
     { sha: "c1", files: [{ filename: "tests/doctrine.test.js" }] },
@@ -187,7 +188,35 @@ test("a fresh structured review must cover the exact protected change set", () =
   const result = evaluateReviewGate({ requiredPaths: required, registryChanged: true, commits, reviews: complete });
   assert.equal(result.status, "PASS");
   assert.equal(result.review.commit_id, "c2");
+  assert.equal(result.review.state, "COMMENTED");
   assert.equal(result.review.basis, "doctrine_review");
+});
+
+test("pending, dismissed, and changes-requested reviews cannot satisfy the gate", () => {
+  const required = [REGISTRY_PATH];
+  const commits = [{ sha: "c1", files: [{ filename: REGISTRY_PATH }] }];
+  for (const state of ["PENDING", "DISMISSED", "CHANGES_REQUESTED"]) {
+    const result = evaluateReviewGate({
+      requiredPaths: required,
+      registryChanged: true,
+      commits,
+      reviews: [{ id: 1, state, commit_id: "c1", body: reviewBody({ paths: required }) }],
+    });
+    assert.equal(result.status, "FAIL");
+    assert.equal(result.code, "PROTECTED_TEST_REVIEW_REQUIRED");
+  }
+});
+
+test("an APPROVED structured review remains valid when a separate reviewer exists", () => {
+  const required = [REGISTRY_PATH];
+  const result = evaluateReviewGate({
+    requiredPaths: required,
+    registryChanged: true,
+    commits: [{ sha: "c1", files: [{ filename: REGISTRY_PATH }] }],
+    reviews: [{ id: 1, state: "APPROVED", commit_id: "c1", body: reviewBody({ paths: required }) }],
+  });
+  assert.equal(result.status, "PASS");
+  assert.equal(result.review.state, "APPROVED");
 });
 
 test("ordinary prose or a generic request to make tests pass is never authorization", () => {

--- a/tests/tooling/verification/protected-tests.test.js
+++ b/tests/tooling/verification/protected-tests.test.js
@@ -163,6 +163,15 @@ test("all protected control-plane enforcement files require review", () => {
   }
 });
 
+test("trusted review workflow reruns when pull request metadata can change the base", () => {
+  const workflowPath = path.resolve(__dirname, "../../../.github/workflows/protected-test-review.yml");
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+  const match = workflow.match(/pull_request_target:\s*\n\s+types:\s*\[([^\]]+)\]/u);
+  assert.ok(match, "protected review workflow must declare pull_request_target activity types");
+  const activityTypes = match[1].split(",").map((item) => item.trim());
+  assert.ok(activityTypes.includes("edited"), "protected review must rerun when PR metadata/base changes");
+});
+
 test("a review made before the latest protected change is stale", () => {
   const required = [REGISTRY_PATH, "tests/doctrine.test.js"];
   const commits = [

--- a/tests/tooling/verification/protected-tests.test.js
+++ b/tests/tooling/verification/protected-tests.test.js
@@ -12,12 +12,16 @@ const {
   verifyProtectedTests,
 } = require("../../../tools/verify-protected-tests");
 const {
+  CONTROL_PLANE_PATHS,
   REGISTRY_PATH,
   REVIEW_SCHEMA,
   OVERRIDE_SCHEMA,
+  PR_COMMIT_API_LIMIT,
+  PR_FILE_API_LIMIT,
   analyzeProtectedChanges,
   evaluateReviewGate,
   evaluateUserOverride,
+  validateReviewApiCompleteness,
 } = require("../../../tools/verify-protected-test-review");
 
 function registry(entries) {
@@ -149,11 +153,7 @@ test("renaming a protected path requires review of both old and new identities",
 
 test("all protected control-plane enforcement files require review", () => {
   const unchanged = registry([]);
-  for (const protectedControlPath of [
-    ".github/workflows/protected-test-review.yml",
-    ".github/workflows/full-diagnostic-verification.yml",
-    "config/verification-profiles.json",
-  ]) {
+  for (const protectedControlPath of CONTROL_PLANE_PATHS) {
     const analysis = analyzeProtectedChanges({
       baseRegistry: unchanged,
       headRegistry: unchanged,
@@ -163,13 +163,44 @@ test("all protected control-plane enforcement files require review", () => {
   }
 });
 
-test("trusted review workflow reruns when pull request metadata can change the base", () => {
+test("trusted review API enumeration fails closed beyond GitHub limits", () => {
+  assert.deepEqual(
+    validateReviewApiCompleteness({
+      commitCount: PR_COMMIT_API_LIMIT,
+      changedFileCount: PR_FILE_API_LIMIT,
+    }),
+    []
+  );
+
+  const tooManyCommits = validateReviewApiCompleteness({
+    commitCount: PR_COMMIT_API_LIMIT + 1,
+    changedFileCount: 1,
+  });
+  assert.equal(tooManyCommits[0].code, "pr_commit_api_limit_exceeded");
+
+  const tooManyFiles = validateReviewApiCompleteness({
+    commitCount: 1,
+    changedFileCount: PR_FILE_API_LIMIT + 1,
+  });
+  assert.equal(tooManyFiles[0].code, "pr_file_api_limit_exceeded");
+
+  const missingCounts = validateReviewApiCompleteness({});
+  assert.deepEqual(
+    missingCounts.map((failure) => failure.code),
+    ["pr_commit_count_invalid", "pr_changed_file_count_invalid"]
+  );
+});
+
+test("trusted review workflow reruns on base edits and enforces API completeness", () => {
   const workflowPath = path.resolve(__dirname, "../../../.github/workflows/protected-test-review.yml");
   const workflow = fs.readFileSync(workflowPath, "utf8");
   const match = workflow.match(/pull_request_target:\s*\n\s+types:\s*\[([^\]]+)\]/u);
   assert.ok(match, "protected review workflow must declare pull_request_target activity types");
   const activityTypes = match[1].split(",").map((item) => item.trim());
   assert.ok(activityTypes.includes("edited"), "protected review must rerun when PR metadata/base changes");
+  assert.ok(workflow.includes("validateReviewApiCompleteness"), "trusted workflow must enforce PR enumeration completeness");
+  assert.ok(workflow.includes("prDetails.data.commits"), "trusted workflow must validate authoritative PR commit count");
+  assert.ok(workflow.includes("prDetails.data.changed_files"), "trusted workflow must validate authoritative changed-file count");
 });
 
 test("a review made before the latest protected change is stale", () => {

--- a/tools/verify-protected-test-review.js
+++ b/tools/verify-protected-test-review.js
@@ -6,6 +6,8 @@ const { validateRegistry } = require("./verify-protected-tests");
 const REGISTRY_PATH = "config/protected-tests.json";
 const REVIEW_SCHEMA = "canto-span-protected-test-review-v1";
 const OVERRIDE_SCHEMA = "canto-span-protected-test-override-v1";
+const PR_COMMIT_API_LIMIT = 250;
+const PR_FILE_API_LIMIT = 3000;
 const CONTROL_PLANE_PATHS = Object.freeze([
   REGISTRY_PATH,
   "config/verification-profiles.json",
@@ -54,6 +56,29 @@ function changedCandidates(files, candidates) {
     }
   }
   return changed;
+}
+
+function validateReviewApiCompleteness({ commitCount, changedFileCount }) {
+  const failures = [];
+  if (!Number.isInteger(commitCount) || commitCount < 0) {
+    failures.push({ code: "pr_commit_count_invalid", actual: commitCount ?? null });
+  } else if (commitCount > PR_COMMIT_API_LIMIT) {
+    failures.push({
+      code: "pr_commit_api_limit_exceeded",
+      actual: commitCount,
+      limit: PR_COMMIT_API_LIMIT,
+    });
+  }
+  if (!Number.isInteger(changedFileCount) || changedFileCount < 0) {
+    failures.push({ code: "pr_changed_file_count_invalid", actual: changedFileCount ?? null });
+  } else if (changedFileCount > PR_FILE_API_LIMIT) {
+    failures.push({
+      code: "pr_file_api_limit_exceeded",
+      actual: changedFileCount,
+      limit: PR_FILE_API_LIMIT,
+    });
+  }
+  return failures;
 }
 
 function analyzeProtectedChanges({ baseRegistry, headRegistry, files }) {
@@ -202,6 +227,8 @@ function evaluateUserOverride(issueBody, affectedProtectedPaths) {
 module.exports = {
   CONTROL_PLANE_PATHS,
   OVERRIDE_SCHEMA,
+  PR_COMMIT_API_LIMIT,
+  PR_FILE_API_LIMIT,
   REGISTRY_PATH,
   REVIEW_SCHEMA,
   analyzeProtectedChanges,
@@ -215,5 +242,6 @@ module.exports = {
   registryEntryDeltaPaths,
   setEquals,
   validateOverrideRecord,
+  validateReviewApiCompleteness,
   validateReviewRecord,
 };

--- a/tools/verify-protected-test-review.js
+++ b/tools/verify-protected-test-review.js
@@ -14,6 +14,7 @@ const CONTROL_PLANE_PATHS = Object.freeze([
   "tools/verify-protected-test-review.js",
   "tests/tooling/verification/protected-tests.test.js",
   ".github/workflows/protected-test-review.yml",
+  ".github/workflows/full-diagnostic-verification.yml",
 ]);
 
 function stableEntry(entry) {
@@ -147,7 +148,8 @@ function evaluateReviewGate({ requiredPaths, registryChanged, commits, reviews }
 
   const candidates = [];
   for (const review of reviews || []) {
-    if (["DISMISSED", "CHANGES_REQUESTED"].includes(String(review.state || "").toUpperCase())) continue;
+    const reviewState = String(review.state || "").toUpperCase();
+    if (!["COMMENTED", "APPROVED"].includes(reviewState)) continue;
     const reviewIndex = commitShas.indexOf(review.commit_id);
     if (reviewIndex < latest) continue;
     for (const record of extractFencedJson(review.body, "protected-test-review")) {
@@ -155,7 +157,7 @@ function evaluateReviewGate({ requiredPaths, registryChanged, commits, reviews }
       if (failures.length) continue;
       if (!setEquals(record.paths, requiredPaths)) continue;
       if (record.registry_changed !== registryChanged) continue;
-      candidates.push({ review, record, review_index: reviewIndex });
+      candidates.push({ review, record, review_index: reviewIndex, review_state: reviewState });
     }
   }
   if (!candidates.length) {
@@ -170,6 +172,7 @@ function evaluateReviewGate({ requiredPaths, registryChanged, commits, reviews }
     review: {
       id: selected.review.id,
       commit_id: selected.review.commit_id,
+      state: selected.review_state,
       basis: selected.record.basis,
       authorization_issue: selected.record.authorization_issue || null,
       paths: [...selected.record.paths].sort(),

--- a/tools/verify-protected-test-review.js
+++ b/tools/verify-protected-test-review.js
@@ -8,6 +8,7 @@ const REVIEW_SCHEMA = "canto-span-protected-test-review-v1";
 const OVERRIDE_SCHEMA = "canto-span-protected-test-override-v1";
 const CONTROL_PLANE_PATHS = Object.freeze([
   REGISTRY_PATH,
+  "config/verification-profiles.json",
   "schemas/protected-test-registry.schema.json",
   "tools/verify-protected-tests.js",
   "tools/verify-protected-test-review.js",

--- a/tools/verify-protected-test-review.js
+++ b/tools/verify-protected-test-review.js
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+"use strict";
+
+const { validateRegistry } = require("./verify-protected-tests");
+
+const REGISTRY_PATH = "config/protected-tests.json";
+const REVIEW_SCHEMA = "canto-span-protected-test-review-v1";
+const OVERRIDE_SCHEMA = "canto-span-protected-test-override-v1";
+const CONTROL_PLANE_PATHS = Object.freeze([
+  REGISTRY_PATH,
+  "schemas/protected-test-registry.schema.json",
+  "tools/verify-protected-tests.js",
+  "tools/verify-protected-test-review.js",
+  "tests/tooling/verification/protected-tests.test.js",
+  ".github/workflows/protected-test-review.yml",
+]);
+
+function stableEntry(entry) {
+  return JSON.stringify(entry, Object.keys(entry || {}).sort());
+}
+
+function entryMap(registry) {
+  return new Map((registry.tests || []).map((entry) => [entry.path, entry]));
+}
+
+function protectedPathUnion(baseRegistry, headRegistry) {
+  return new Set([
+    ...entryMap(baseRegistry).keys(),
+    ...entryMap(headRegistry).keys(),
+  ]);
+}
+
+function registryEntryDeltaPaths(baseRegistry, headRegistry) {
+  const base = entryMap(baseRegistry);
+  const head = entryMap(headRegistry);
+  const changed = new Set();
+  for (const path of new Set([...base.keys(), ...head.keys()])) {
+    if (!base.has(path) || !head.has(path) || stableEntry(base.get(path)) !== stableEntry(head.get(path))) changed.add(path);
+  }
+  return changed;
+}
+
+function namesForFile(file) {
+  return [file && file.filename, file && file.previous_filename].filter(Boolean);
+}
+
+function changedCandidates(files, candidates) {
+  const changed = new Set();
+  for (const file of files || []) {
+    for (const name of namesForFile(file)) {
+      if (candidates.has(name)) changed.add(name);
+    }
+  }
+  return changed;
+}
+
+function analyzeProtectedChanges({ baseRegistry, headRegistry, files }) {
+  const baseFailures = validateRegistry(baseRegistry);
+  const headFailures = validateRegistry(headRegistry);
+  if (baseFailures.length || headFailures.length) {
+    return {
+      status: "FAIL",
+      failures: [
+        ...baseFailures.map((failure) => ({ side: "base", ...failure })),
+        ...headFailures.map((failure) => ({ side: "head", ...failure })),
+      ],
+      required_paths: [],
+      affected_protected_paths: [],
+      registry_changed: false,
+    };
+  }
+
+  const fileList = files || [];
+  const protectedUnion = protectedPathUnion(baseRegistry, headRegistry);
+  const changedProtected = changedCandidates(fileList, protectedUnion);
+  const entryDeltas = registryEntryDeltaPaths(baseRegistry, headRegistry);
+  const affectedProtected = new Set([...changedProtected, ...entryDeltas]);
+  const changedControlPlane = changedCandidates(fileList, new Set(CONTROL_PLANE_PATHS));
+  const registryChanged = fileList.some((file) => namesForFile(file).includes(REGISTRY_PATH));
+  const required = new Set([...affectedProtected, ...changedControlPlane]);
+  if (registryChanged) required.add(REGISTRY_PATH);
+
+  return {
+    status: "PASS",
+    failures: [],
+    required_paths: [...required].sort(),
+    affected_protected_paths: [...affectedProtected].sort(),
+    registry_changed: registryChanged,
+  };
+}
+
+function latestRelevantCommitIndex(commits, requiredPaths) {
+  const required = new Set(requiredPaths || []);
+  let latest = -1;
+  for (let index = 0; index < (commits || []).length; index += 1) {
+    const files = commits[index].files || [];
+    if (files.some((file) => namesForFile(file).some((name) => required.has(name)))) latest = index;
+  }
+  return latest;
+}
+
+function extractFencedJson(body, fenceName) {
+  const text = String(body || "");
+  const escaped = fenceName.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const regex = new RegExp("```" + escaped + "\\s*([\\s\\S]*?)```", "gu");
+  const records = [];
+  for (const match of text.matchAll(regex)) {
+    try {
+      records.push(JSON.parse(match[1].trim()));
+    } catch (error) {
+      records.push({ __parse_error: error.message });
+    }
+  }
+  return records;
+}
+
+function validateReviewRecord(record) {
+  const failures = [];
+  if (!record || typeof record !== "object" || Array.isArray(record) || record.__parse_error) return ["review_record_invalid_json"];
+  if (record.schema !== REVIEW_SCHEMA) failures.push("review_schema_invalid");
+  if (record.decision !== "approve") failures.push("review_decision_not_approve");
+  if (!["doctrine_review", "user_override"].includes(record.basis)) failures.push("review_basis_invalid");
+  if (!Array.isArray(record.paths) || !record.paths.length || record.paths.some((item) => typeof item !== "string" || !item)) failures.push("review_paths_invalid");
+  if (Array.isArray(record.paths) && new Set(record.paths).size !== record.paths.length) failures.push("review_paths_duplicate");
+  if (typeof record.registry_changed !== "boolean") failures.push("review_registry_flag_invalid");
+  if (typeof record.reason !== "string" || !record.reason.trim()) failures.push("review_reason_missing");
+  if (record.basis === "user_override" && (!Number.isInteger(record.authorization_issue) || record.authorization_issue <= 0)) failures.push("user_override_issue_missing");
+  return failures;
+}
+
+function setEquals(left, right) {
+  const a = new Set(left || []);
+  const b = new Set(right || []);
+  return a.size === b.size && [...a].every((item) => b.has(item));
+}
+
+function evaluateReviewGate({ requiredPaths, registryChanged, commits, reviews }) {
+  if (!(requiredPaths || []).length) {
+    return { status: "PASS", code: "NO_PROTECTED_CHANGE", latest_change_index: -1, review: null };
+  }
+  const commitShas = (commits || []).map((commit) => commit.sha);
+  const latest = latestRelevantCommitIndex(commits, requiredPaths);
+  if (latest < 0) {
+    return { status: "FAIL", code: "PROTECTED_CHANGE_COMMIT_NOT_FOUND", latest_change_index: -1, review: null };
+  }
+
+  const candidates = [];
+  for (const review of reviews || []) {
+    if (["DISMISSED", "CHANGES_REQUESTED"].includes(String(review.state || "").toUpperCase())) continue;
+    const reviewIndex = commitShas.indexOf(review.commit_id);
+    if (reviewIndex < latest) continue;
+    for (const record of extractFencedJson(review.body, "protected-test-review")) {
+      const failures = validateReviewRecord(record);
+      if (failures.length) continue;
+      if (!setEquals(record.paths, requiredPaths)) continue;
+      if (record.registry_changed !== registryChanged) continue;
+      candidates.push({ review, record, review_index: reviewIndex });
+    }
+  }
+  if (!candidates.length) {
+    return { status: "FAIL", code: "PROTECTED_TEST_REVIEW_REQUIRED", latest_change_index: latest, review: null };
+  }
+  candidates.sort((a, b) => b.review_index - a.review_index);
+  const selected = candidates[0];
+  return {
+    status: "PASS",
+    code: "PROTECTED_TEST_REVIEW_ACCEPTED",
+    latest_change_index: latest,
+    review: {
+      id: selected.review.id,
+      commit_id: selected.review.commit_id,
+      basis: selected.record.basis,
+      authorization_issue: selected.record.authorization_issue || null,
+      paths: [...selected.record.paths].sort(),
+      reason: selected.record.reason,
+    },
+  };
+}
+
+function validateOverrideRecord(record, affectedProtectedPaths) {
+  const failures = [];
+  if (!record || typeof record !== "object" || Array.isArray(record) || record.__parse_error) return ["override_record_invalid_json"];
+  if (record.schema !== OVERRIDE_SCHEMA) failures.push("override_schema_invalid");
+  if (record.authorized_by !== "user") failures.push("override_authorizer_invalid");
+  if (!Array.isArray(record.paths) || !record.paths.length || !setEquals(record.paths, affectedProtectedPaths)) failures.push("override_paths_not_exact");
+  if (typeof record.reason !== "string" || !record.reason.trim()) failures.push("override_reason_missing");
+  return failures;
+}
+
+function evaluateUserOverride(issueBody, affectedProtectedPaths) {
+  const records = extractFencedJson(issueBody, "protected-test-override");
+  for (const record of records) {
+    if (!validateOverrideRecord(record, affectedProtectedPaths).length) return { status: "PASS", record };
+  }
+  return { status: "FAIL", code: "USER_OVERRIDE_NOT_EXPLICIT_OR_EXACT" };
+}
+
+module.exports = {
+  CONTROL_PLANE_PATHS,
+  OVERRIDE_SCHEMA,
+  REGISTRY_PATH,
+  REVIEW_SCHEMA,
+  analyzeProtectedChanges,
+  changedCandidates,
+  entryMap,
+  evaluateReviewGate,
+  evaluateUserOverride,
+  extractFencedJson,
+  latestRelevantCommitIndex,
+  protectedPathUnion,
+  registryEntryDeltaPaths,
+  setEquals,
+  validateOverrideRecord,
+  validateReviewRecord,
+};

--- a/tools/verify-protected-tests.js
+++ b/tools/verify-protected-tests.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REGISTRY_SCHEMA = "canto-span-protected-tests-v1";
+const DEFAULT_REGISTRY_PATH = "config/protected-tests.json";
+const ALLOWED_SCOPES = new Set(["runtime", "research", "governance", "release"]);
+
+function sha256(content) {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+function isSafeTestPath(filePath) {
+  if (typeof filePath !== "string" || !filePath) return false;
+  if (path.posix.isAbsolute(filePath) || filePath.includes("\\")) return false;
+  const normalized = path.posix.normalize(filePath);
+  return normalized === filePath
+    && !normalized.startsWith("../")
+    && /^tests\/.+\.test\.(?:js|py)$/u.test(normalized);
+}
+
+function validateRegistry(registry) {
+  const failures = [];
+  if (!registry || typeof registry !== "object" || Array.isArray(registry)) {
+    return [{ code: "registry_not_object", path: DEFAULT_REGISTRY_PATH }];
+  }
+  if (registry.schema !== REGISTRY_SCHEMA) {
+    failures.push({ code: "registry_schema_invalid", actual: registry.schema || null });
+  }
+  if (!Array.isArray(registry.tests)) {
+    failures.push({ code: "registry_tests_not_array" });
+    return failures;
+  }
+
+  const seen = new Set();
+  for (let index = 0; index < registry.tests.length; index += 1) {
+    const entry = registry.tests[index];
+    const prefix = `tests[${index}]`;
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      failures.push({ code: "registry_entry_not_object", entry: prefix });
+      continue;
+    }
+    const allowedKeys = new Set([
+      "path",
+      "sha256",
+      "reason",
+      "scope",
+      "protection_class",
+      "expected_change_frequency",
+      "normal_growth_requires_edit",
+      "review_required_on_change",
+    ]);
+    for (const key of Object.keys(entry)) {
+      if (!allowedKeys.has(key)) failures.push({ code: "registry_entry_unknown_field", entry: prefix, field: key });
+    }
+    if (!isSafeTestPath(entry.path)) failures.push({ code: "protected_path_invalid", entry: prefix, path: entry.path || null });
+    if (seen.has(entry.path)) failures.push({ code: "protected_path_duplicate", path: entry.path });
+    seen.add(entry.path);
+    if (!/^[0-9a-f]{64}$/u.test(String(entry.sha256 || ""))) failures.push({ code: "sha256_invalid", path: entry.path || null });
+    if (typeof entry.reason !== "string" || !entry.reason.trim()) failures.push({ code: "reason_missing", path: entry.path || null });
+    if (!ALLOWED_SCOPES.has(entry.scope)) failures.push({ code: "scope_invalid", path: entry.path || null, scope: entry.scope || null });
+    if (entry.protection_class !== "constitutional_doctrine") failures.push({ code: "protection_class_invalid", path: entry.path || null });
+    if (entry.expected_change_frequency !== "rare-to-never") failures.push({ code: "expected_change_frequency_invalid", path: entry.path || null });
+    if (entry.normal_growth_requires_edit !== false) failures.push({ code: "scalable_test_not_eligible", path: entry.path || null });
+    if (entry.review_required_on_change !== true) failures.push({ code: "review_requirement_invalid", path: entry.path || null });
+  }
+  return failures;
+}
+
+function loadRegistry(root, registryPath = DEFAULT_REGISTRY_PATH) {
+  const absolute = path.resolve(root, registryPath);
+  return JSON.parse(fs.readFileSync(absolute, "utf8"));
+}
+
+function verifyProtectedTests(root, registry = loadRegistry(root)) {
+  const failures = validateRegistry(registry);
+  const checks = [];
+  if (failures.length) {
+    return { schema: REGISTRY_SCHEMA, status: "FAIL", protected_count: Array.isArray(registry.tests) ? registry.tests.length : 0, checks, failures };
+  }
+
+  for (const entry of registry.tests) {
+    const absolute = path.resolve(root, entry.path);
+    const relative = path.relative(root, absolute);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      failures.push({ code: "protected_path_escapes_root", path: entry.path });
+      continue;
+    }
+    if (!fs.existsSync(absolute) || !fs.statSync(absolute).isFile()) {
+      failures.push({ code: "protected_test_missing", path: entry.path });
+      checks.push({ path: entry.path, expected_sha256: entry.sha256, actual_sha256: null, status: "MISSING" });
+      continue;
+    }
+    const actual = sha256(fs.readFileSync(absolute));
+    const status = actual === entry.sha256 ? "PASS" : "MISMATCH";
+    checks.push({ path: entry.path, expected_sha256: entry.sha256, actual_sha256: actual, status });
+    if (status !== "PASS") {
+      failures.push({ code: "PROTECTED_TEST_REVIEW_REQUIRED", path: entry.path, expected_sha256: entry.sha256, actual_sha256: actual });
+    }
+  }
+
+  return {
+    schema: REGISTRY_SCHEMA,
+    status: failures.length ? "FAIL" : "PASS",
+    protected_count: registry.tests.length,
+    checks,
+    failures,
+  };
+}
+
+function main() {
+  const root = path.resolve(__dirname, "..");
+  let report;
+  try {
+    report = verifyProtectedTests(root);
+  } catch (error) {
+    report = { schema: REGISTRY_SCHEMA, status: "FAIL", protected_count: 0, checks: [], failures: [{ code: "registry_load_failed", message: error.message }] };
+  }
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  if (report.status !== "PASS") process.exitCode = 1;
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  ALLOWED_SCOPES,
+  DEFAULT_REGISTRY_PATH,
+  REGISTRY_SCHEMA,
+  isSafeTestPath,
+  loadRegistry,
+  sha256,
+  validateRegistry,
+  verifyProtectedTests,
+};


### PR DESCRIPTION
<!-- coordination-claim: #908 -->

Work claim: #908
Parent intake: #907
Stacked dependency: #905 / #904

## Outcome

Adds a narrow protected-test SHA governance layer for **constitutional doctrine tests only**. Scalable or routinely growing suites remain intentionally outside SHA protection.

The initial registry contains exactly three rare-to-never doctrine tests:

- repository-wide regression-debt ratchet semantics;
- fail-closed verification-orchestrator semantics;
- protected-test governance itself (anti-laundering, review freshness including base-retarget freshness, deletion/rename, complete canonical control-plane coverage, viable single-author review semantics, explicit user override, and fail-closed GitHub API enumeration completeness).

Lexical coverage, lexical ingestion/source registries, growing construction/corpus/survey inventories, parser coverage, generated snapshots, source packets, migration counts, and other normally expanding tests remain mutable under ordinary regression and test-validity review.

## Architecture

- `config/protected-tests.json` is the single canonical registry.
- `schemas/protected-test-registry.schema.json` constrains entries to constitutional, rare-to-never, non-scaling tests.
- `tools/verify-protected-tests.js` validates exact SHA-256 values and never auto-blesses hashes.
- The SHA verifier is part of the existing core verification profile.
- Governance unit tests remain task-scoped rather than becoming another always-run core tax.
- `.github/workflows/full-diagnostic-verification.yml` runs the governance unit suite whenever this control plane changes and is itself protected control-plane state.

## Trusted PR gate

`.github/workflows/protected-test-review.yml` uses trusted base-owned code (`pull_request_target`) rather than executing review logic supplied by the PR head.

It compares base and head using the union of protected paths, so changing a doctrine test and its registry hash together cannot launder the change. Registry changes, deletion/rename, removal of the core SHA-verifier registration, schema/verifier/review-logic changes, trusted review-workflow changes, and full-diagnostic enforcement changes all require protected review.

The trusted workflow runs for `opened`, `synchronize`, `reopened`, `ready_for_review`, and **`edited`** PR activity. Changing/retargeting the PR base therefore reruns the trusted-base decision.

Before calling GitHub's capped PR enumeration endpoints, the workflow fetches authoritative PR metadata and fails closed when:

- commit count exceeds **250**;
- changed-file count exceeds **3,000**;
- either count is missing or invalid.

This prevents a truncated file or commit list from being treated as complete. Per-commit file enumeration retains its existing fail-closed pagination ceiling.

`CONTROL_PLANE_PATHS` is the canonical protected enforcement set. The constitutional governance test now iterates that exported set directly, so newly admitted control-plane paths cannot be omitted from the test through a stale hand-maintained duplicate list.

A valid structured review must be attached to a commit containing the latest protected change, contain the fenced `protected-test-review` record, exactly cover the affected path set, and distinguish ordinary doctrine review from an explicit exact-path user override.

## Single-author/shared-account model

Canto Span currently has one GitHub author account. The user, ChatGPT, and Codex all make repository writes through that same account, so GitHub identity cannot distinguish the human owner from assisting agents. GitHub also prevents a PR author from approving their own PR.

Therefore reviewer identity is **not** an authorization boundary here. A structured `COMMENTED` review is intentionally valid when it satisfies exact-path and latest-protected-commit requirements. `APPROVED` is also accepted if a separate reviewer exists later. `PENDING`, `DISMISSED`, and `CHANGES_REQUESTED` cannot satisfy the gate.

## Review/SHA order

The final sequence is:

1. finalize protected test content;
2. compute and record the exact final SHA in `config/protected-tests.json`;
3. submit review against that resulting commit.

Any later protected-test or registry edit invalidates that review and requires a new one. The gate never performs or blesses the SHA update automatically.

## Validation — current PR head

Head: `b74a6657843b1544c2f55c20018e37186a8c86d1`

PR-triggered checks on this exact head:

- Research provenance #2051: **PASS**
- Runtime source-first validation #1529: **PASS**
- Full diagnostic verification #484: **PASS**
- verification + protected-test governance unit tests: **26/26 PASS**
- protected-test SHA verifier: **PASS** with governance hash `d79c530711315791893c5d93fa9f5c318d0ac3ac2201b1a3d37228b27c76f249`
- all non-release core/research/runtime profiles: **PASS**
- release-only `JauDakMouDakAvailabilityPredicate` debt remains inherited from the stacked base and is not modified here.

The deliberate intermediate fail-closed run rejected only the stale prior governance SHA and exposed the new exact test hash before it was frozen; no unrelated non-release failure appeared.

## Review repair status

Resolved findings:

- independent/non-author reviewer requirement withdrawn because it is impossible and invalid under the repository's shared-account model;
- full-diagnostic workflow added to protected control-plane detection;
- PR `edited` activity reruns the trusted gate, closing base-retarget freshness;
- documentation requires SHA freeze **before** review rather than after it;
- PR commit/file enumeration truncation now fails closed using authoritative count guards;
- constitutional control-plane coverage now derives directly from `CONTROL_PLANE_PATHS`.

## Scope

Net diff against #905 remains exactly nine governance/verification files. No runtime source, lexical data, construction behavior, survey state, corpus state, or release/deployment state changes.

## Merge order

This PR is intentionally stacked on draft PR #905. **Do not merge it before #905 is resolved.** After #905 lands, rebase/retarget #909 to resulting `main`, rerun applicable verification, and perform a fresh review of that final head before any merge.
