### PR TITLE
Add shared transactional artifact mutation framework

### DIFF
--- a/tests/tooling/artifact-mutation/artifact-mutation.test.js
+++ b/tests/tooling/artifact-mutation/artifact-mutation.test.js
@@ -343,12 +343,23 @@ test("primitive identity types remain distinct in current state and mutations", 
     { id: "1", value: "string-one" },
     { id: true, value: "boolean-true" },
     { id: "true", value: "string-true" },
+    { id: "number:1", value: "tag-looking-string" },
   ]);
   const adapter = createJsonCollectionAdapter({ file, keyField: "id", requiredFields: ["value"] });
 
   const audit = runMutation(adapter, []);
   assert.equal(audit.status, "PASS");
   assert.equal(audit.validation_results[0].status, "PASS");
+
+  const numericConflict = runMutation(adapter, [
+    { operation: "add", record: { id: 1, value: "conflicting-number" } },
+  ]);
+  const taggedStringConflict = runMutation(adapter, [
+    { operation: "add", record: { id: "number:1", value: "conflicting-string" } },
+  ]);
+  assert.equal(numericConflict.status, "FAIL");
+  assert.equal(taggedStringConflict.status, "FAIL");
+  assert.notEqual(numericConflict.conflicts[0].identity, taggedStringConflict.conflicts[0].identity);
 
   const committed = runMutation(adapter, [
     { operation: "replace", record: { id: 1, value: "updated-number" } },

--- a/tests/tooling/artifact-mutation/artifact-mutation.test.js
+++ b/tests/tooling/artifact-mutation/artifact-mutation.test.js
@@ -207,6 +207,32 @@ test("invalid explicit lifecycle statuses fail normalization before write", () =
   assert.deepEqual(readJson(file), []);
 });
 
+test("declared lifecycle statuses are validated independent of target and in current state", () => {
+  const file = path.join(tempDir(), "records.json");
+  const config = {
+    file,
+    keyField: "id",
+    lifecycleDimensions: [
+      { name: "evidence", field: "evidence", statusField: "evidence_status", targets: ["runtime"] },
+    ],
+  };
+
+  writeJson(file, []);
+  const adapter = createJsonCollectionAdapter(config);
+  const wrongTarget = runMutation(adapter, [
+    { operation: "add", record: { id: "a", evidence_status: "bogus" } },
+  ], { target: "survey", write: true });
+  assert.equal(wrongTarget.status, "FAIL");
+  assert.match(wrongTarget.errors[0], /evidence_status has invalid lifecycle status bogus/);
+  assert.deepEqual(readJson(file), []);
+
+  writeJson(file, [{ id: "existing", evidence_status: "bogus" }]);
+  const invalidCurrent = runMutation(createJsonCollectionAdapter(config), [], { target: "survey", write: true });
+  assert.equal(invalidCurrent.status, "FAIL");
+  assert.equal(invalidCurrent.validation_results[0].status, "FAIL");
+  assert.match(invalidCurrent.validation_results[0].errors[0], /evidence_status has invalid lifecycle status bogus/);
+});
+
 test("large batches load and stage each affected artifact once", () => {
   const file = path.join(tempDir(), "records.json");
   writeJson(file, []);

--- a/tests/tooling/artifact-mutation/artifact-mutation.test.js
+++ b/tests/tooling/artifact-mutation/artifact-mutation.test.js
@@ -1,0 +1,209 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const test = require("node:test");
+
+const { commitWrites, runMutation } = require("../../../tools/artifact-mutation/core");
+const { createJsonCollectionAdapter } = require("../../../tools/artifact-mutation/json-collection-adapter");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "canto-span-artifact-mutation-"));
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+test("dry-run is deterministic and write mode commits one staged artifact", () => {
+  const file = path.join(tempDir(), "records.json");
+  writeJson(file, [{ id: "a", value: 1 }]);
+  const adapter = createJsonCollectionAdapter({ file, keyField: "id", requiredFields: ["value"] });
+  const candidates = [
+    { operation: "add", record: { id: "b", value: 2 } },
+    { operation: "replace", record: { id: "a", value: 3 } },
+  ];
+
+  const first = runMutation(adapter, candidates);
+  assert.deepEqual(runMutation(adapter, candidates), first);
+  assert.equal(first.status, "PASS");
+  assert.deepEqual(first.counts, { added: 1, updated: 1, already_present: 0, skipped: 0 });
+  assert.equal(first.writes_occurred, false);
+  assert.deepEqual(readJson(file), [{ id: "a", value: 1 }]);
+
+  const committed = runMutation(adapter, candidates, { write: true });
+  assert.equal(committed.status, "PASS");
+  assert.deepEqual(committed.counts, first.counts);
+  assert.deepEqual(committed.gaps, first.gaps);
+  assert.deepEqual(committed.affected_artifacts, first.affected_artifacts);
+  assert.equal(committed.write_count, 1);
+  assert.deepEqual(readJson(file), [{ id: "a", value: 3 }, { id: "b", value: 2 }]);
+});
+
+test("existing-state and within-batch conflicts prevent canonical writes", () => {
+  const file = path.join(tempDir(), "records.json");
+  const original = [{ id: "a", value: 1 }];
+  writeJson(file, original);
+  const adapter = createJsonCollectionAdapter({ file, keyField: "id", requiredFields: ["value"] });
+
+  const existing = runMutation(adapter, [
+    { operation: "add", record: { id: "a", value: 9 } },
+  ], { write: true });
+  assert.equal(existing.status, "FAIL");
+  assert.equal(existing.conflicts[0].code, "existing_record_differs");
+  assert.equal(existing.writes_occurred, false);
+  assert.deepEqual(readJson(file), original);
+
+  const batch = runMutation(adapter, [
+    { operation: "add", record: { id: "b", value: 2 } },
+    { operation: "add", record: { id: "b", value: 2 } },
+  ], { write: true });
+  assert.equal(batch.status, "FAIL");
+  assert.equal(batch.conflicts[0].code, "duplicate_in_batch");
+  assert.equal(batch.writes_occurred, false);
+  assert.deepEqual(readJson(file), original);
+});
+
+test("required input and staged-result validation fail before write", () => {
+  const file = path.join(tempDir(), "records.json");
+  writeJson(file, []);
+  const adapter = createJsonCollectionAdapter({ file, keyField: "id", requiredFields: ["value"] });
+  const missing = runMutation(adapter, [
+    { operation: "add", record: { id: "a" } },
+  ], { write: true });
+  assert.equal(missing.status, "FAIL");
+  assert.match(missing.errors[0], /missing required field value/);
+  assert.deepEqual(readJson(file), []);
+
+  let serialized = false;
+  const validatingAdapter = {
+    id: "validation-test",
+    load: () => ({ records: [] }),
+    normalize: (candidate) => candidate,
+    plan: ({ candidates }) => ({
+      nextState: { records: candidates },
+      operations: candidates.map((item) => ({ identity: item.id, action: "added" })),
+      conflicts: [],
+    }),
+    validateResult: () => ["staged state rejected"],
+    serialize: () => {
+      serialized = true;
+      return [{ path: file, content: "[]\n" }];
+    },
+  };
+  const rejected = runMutation(validatingAdapter, [{ id: "a" }], { write: true });
+  assert.equal(rejected.status, "FAIL");
+  assert.equal(rejected.validation_results.at(-1).status, "FAIL");
+  assert.equal(serialized, false);
+  assert.deepEqual(readJson(file), []);
+});
+
+test("lifecycle omissions remain explicit and target gap policy can block writes", () => {
+  const file = path.join(tempDir(), "records.json");
+  writeJson(file, []);
+  const adapter = createJsonCollectionAdapter({
+    file,
+    keyField: "id",
+    lifecycleDimensions: [
+      { name: "evidence", field: "evidence", statusField: "evidence_status", targets: ["runtime"] },
+    ],
+  });
+  const candidates = [
+    { operation: "add", record: { id: "a", evidence: "present" } },
+    { operation: "add", record: { id: "b", evidence_status: "intentional_hold" } },
+    { operation: "add", record: { id: "c" } },
+    { operation: "add", record: { id: "d" } },
+  ];
+
+  const audit = runMutation(adapter, candidates, { target: "runtime", omissionThreshold: 0.5 });
+  assert.equal(audit.status, "PASS");
+  assert.deepEqual(audit.gaps.by_dimension.evidence, {
+    complete: 1,
+    unresolved: 2,
+    intentional_hold: 1,
+    not_applicable: 0,
+  });
+  assert.deepEqual(audit.gaps.systematic_omissions, [{
+    dimension: "evidence",
+    omitted_count: 2,
+    input_count: 4,
+    ratio: 0.5,
+  }]);
+
+  const blocked = runMutation(adapter, candidates, {
+    target: "runtime",
+    omissionThreshold: 0.5,
+    failOnGap: true,
+    write: true,
+  });
+  assert.equal(blocked.status, "FAIL");
+  assert.match(blocked.errors.at(-1), /unresolved completeness gaps: 2/);
+  assert.equal(blocked.writes_occurred, false);
+  assert.deepEqual(readJson(file), []);
+});
+
+test("large batches load and stage each affected artifact once", () => {
+  const file = path.join(tempDir(), "records.json");
+  writeJson(file, []);
+  let readCount = 0;
+  let stagedWriteCount = 0;
+  const countedFs = Object.create(fs);
+  countedFs.readFileSync = (...args) => {
+    readCount += 1;
+    return fs.readFileSync(...args);
+  };
+  countedFs.writeFileSync = (...args) => {
+    stagedWriteCount += 1;
+    return fs.writeFileSync(...args);
+  };
+  const adapter = createJsonCollectionAdapter({ file, keyField: "id", fsImpl: countedFs });
+  const candidates = Array.from({ length: 1000 }, (_, index) => ({
+    operation: "add",
+    record: { id: `r${index}`, value: index },
+  }));
+
+  const result = runMutation(adapter, candidates, { write: true, fsImpl: countedFs });
+  assert.equal(result.status, "PASS");
+  assert.equal(result.counts.added, 1000);
+  assert.equal(readCount, 1);
+  assert.equal(stagedWriteCount, 1);
+  assert.equal(result.write_count, 1);
+  assert.equal(readJson(file).length, 1000);
+});
+
+test("multi-file commit rolls back earlier replacements after a later rename failure", () => {
+  const dir = tempDir();
+  const first = path.join(dir, "first.txt");
+  const second = path.join(dir, "second.txt");
+  fs.writeFileSync(first, "old-first\n");
+  fs.writeFileSync(second, "old-second\n");
+
+  let renameCount = 0;
+  let injected = false;
+  const failingFs = Object.create(fs);
+  failingFs.renameSync = (...args) => {
+    renameCount += 1;
+    if (!injected && renameCount === 4) {
+      injected = true;
+      throw new Error("injected rename failure");
+    }
+    return fs.renameSync(...args);
+  };
+
+  assert.throws(
+    () => commitWrites([
+      { path: first, content: "new-first\n" },
+      { path: second, content: "new-second\n" },
+    ], { fsImpl: failingFs }),
+    /artifact mutation commit failed: injected rename failure/
+  );
+  assert.equal(fs.readFileSync(first, "utf8"), "old-first\n");
+  assert.equal(fs.readFileSync(second, "utf8"), "old-second\n");
+  assert.deepEqual(fs.readdirSync(dir).sort(), ["first.txt", "second.txt"]);
+});

--- a/tests/tooling/artifact-mutation/artifact-mutation.test.js
+++ b/tests/tooling/artifact-mutation/artifact-mutation.test.js
@@ -104,6 +104,45 @@ test("required input and staged-result validation fail before write", () => {
   assert.deepEqual(readJson(file), []);
 });
 
+test("throwing validators become machine-readable FAIL reports", () => {
+  const file = path.join(tempDir(), "records.json");
+  writeJson(file, []);
+
+  const baseAdapter = {
+    id: "throwing-validator-test",
+    load: () => ({ records: [] }),
+    normalize: (candidate) => candidate,
+    plan: ({ candidates }) => ({
+      nextState: { records: candidates },
+      operations: candidates.map((item) => ({ identity: item.id, action: "added" })),
+      conflicts: [],
+    }),
+    serialize: () => [{ path: file, content: "[]\n" }],
+  };
+
+  const currentFailure = runMutation({
+    ...baseAdapter,
+    validateCurrent: () => { throw new Error("current exploded"); },
+  }, [{ id: "a" }], { write: true });
+  assert.equal(currentFailure.status, "FAIL");
+  assert.deepEqual(currentFailure.validation_results, [{
+    phase: "current",
+    status: "FAIL",
+    errors: ["current validator threw: current exploded"],
+  }]);
+  assert.equal(currentFailure.writes_occurred, false);
+
+  const resultFailure = runMutation({
+    ...baseAdapter,
+    validateResult: () => { throw new Error("result exploded"); },
+  }, [{ id: "a" }], { write: true });
+  assert.equal(resultFailure.status, "FAIL");
+  assert.equal(resultFailure.validation_results.at(-1).status, "FAIL");
+  assert.deepEqual(resultFailure.validation_results.at(-1).errors, ["result validator threw: result exploded"]);
+  assert.equal(resultFailure.writes_occurred, false);
+  assert.deepEqual(readJson(file), []);
+});
+
 test("lifecycle omissions remain explicit and target gap policy can block writes", () => {
   const file = path.join(tempDir(), "records.json");
   writeJson(file, []);
@@ -145,6 +184,26 @@ test("lifecycle omissions remain explicit and target gap policy can block writes
   assert.equal(blocked.status, "FAIL");
   assert.match(blocked.errors.at(-1), /unresolved completeness gaps: 2/);
   assert.equal(blocked.writes_occurred, false);
+  assert.deepEqual(readJson(file), []);
+});
+
+test("invalid explicit lifecycle statuses fail normalization before write", () => {
+  const file = path.join(tempDir(), "records.json");
+  writeJson(file, []);
+  const adapter = createJsonCollectionAdapter({
+    file,
+    keyField: "id",
+    lifecycleDimensions: [
+      { name: "evidence", field: "evidence", statusField: "evidence_status", targets: ["runtime"] },
+    ],
+  });
+
+  const invalid = runMutation(adapter, [
+    { operation: "add", record: { id: "a", evidence_status: "bogus" } },
+  ], { target: "runtime", write: true });
+  assert.equal(invalid.status, "FAIL");
+  assert.match(invalid.errors[0], /evidence_status has invalid lifecycle status bogus/);
+  assert.equal(invalid.writes_occurred, false);
   assert.deepEqual(readJson(file), []);
 });
 
@@ -206,4 +265,47 @@ test("multi-file commit rolls back earlier replacements after a later rename fai
   assert.equal(fs.readFileSync(first, "utf8"), "old-first\n");
   assert.equal(fs.readFileSync(second, "utf8"), "old-second\n");
   assert.deepEqual(fs.readdirSync(dir).sort(), ["first.txt", "second.txt"]);
+});
+
+test("rollback preserves a backup when restoring that backup fails", () => {
+  const dir = tempDir();
+  const first = path.join(dir, "first.txt");
+  const second = path.join(dir, "second.txt");
+  fs.writeFileSync(first, "old-first\n");
+  fs.writeFileSync(second, "old-second\n");
+
+  let commitFailureInjected = false;
+  let restoreFailureInjected = false;
+  const failingFs = Object.create(fs);
+  failingFs.renameSync = (source, destination) => {
+    if (!commitFailureInjected && source.includes(".tmp") && destination === second) {
+      commitFailureInjected = true;
+      throw new Error("injected commit failure");
+    }
+    if (!restoreFailureInjected && source.includes(".bak") && destination === first) {
+      restoreFailureInjected = true;
+      throw new Error("injected restore failure");
+    }
+    return fs.renameSync(source, destination);
+  };
+
+  let failure;
+  try {
+    commitWrites([
+      { path: first, content: "new-first\n" },
+      { path: second, content: "new-second\n" },
+    ], { fsImpl: failingFs });
+    assert.fail("expected commitWrites to throw");
+  } catch (error) {
+    failure = error;
+  }
+
+  assert.match(failure.message, /artifact mutation commit failed: injected commit failure/);
+  assert.ok(failure.rollbackErrors.some((item) => item.includes("restore") && item.includes("injected restore failure")));
+  assert.equal(fs.readFileSync(second, "utf8"), "old-second\n");
+  assert.equal(fs.existsSync(first), false);
+
+  const backup = fs.readdirSync(dir).find((name) => name.startsWith("first.txt.artifact-mutation-") && name.endsWith(".bak"));
+  assert.ok(backup, "failed restore must preserve the original backup");
+  assert.equal(fs.readFileSync(path.join(dir, backup), "utf8"), "old-first\n");
 });

--- a/tests/tooling/artifact-mutation/artifact-mutation.test.js
+++ b/tests/tooling/artifact-mutation/artifact-mutation.test.js
@@ -335,3 +335,126 @@ test("rollback preserves a backup when restoring that backup fails", () => {
   assert.ok(backup, "failed restore must preserve the original backup");
   assert.equal(fs.readFileSync(path.join(dir, backup), "utf8"), "old-first\n");
 });
+
+test("primitive identity types remain distinct in current state and mutations", () => {
+  const file = path.join(tempDir(), "records.json");
+  writeJson(file, [
+    { id: 1, value: "number-one" },
+    { id: "1", value: "string-one" },
+    { id: true, value: "boolean-true" },
+    { id: "true", value: "string-true" },
+  ]);
+  const adapter = createJsonCollectionAdapter({ file, keyField: "id", requiredFields: ["value"] });
+
+  const audit = runMutation(adapter, []);
+  assert.equal(audit.status, "PASS");
+  assert.equal(audit.validation_results[0].status, "PASS");
+
+  const committed = runMutation(adapter, [
+    { operation: "replace", record: { id: 1, value: "updated-number" } },
+    { operation: "replace", record: { id: "1", value: "updated-string" } },
+  ], { write: true });
+  assert.equal(committed.status, "PASS");
+  assert.deepEqual(committed.counts, { added: 0, updated: 2, already_present: 0, skipped: 0 });
+  assert.deepEqual(readJson(file).slice(0, 2), [
+    { id: 1, value: "updated-number" },
+    { id: "1", value: "updated-string" },
+  ]);
+});
+
+test("malformed plan operations and conflicts fail closed", () => {
+  const file = path.join(tempDir(), "records.json");
+  writeJson(file, []);
+  const baseAdapter = {
+    id: "plan-contract-test",
+    load: () => ({ records: [] }),
+    normalize: (candidate) => candidate,
+    serialize: () => [{ path: file, content: "[]\n" }],
+  };
+
+  const missingOperations = runMutation({
+    ...baseAdapter,
+    plan: () => ({ nextState: { records: [] }, conflicts: [] }),
+  }, [{ id: "a" }], { write: true });
+  assert.equal(missingOperations.status, "FAIL");
+  assert.match(missingOperations.errors[0], /must return an operations array/);
+
+  const malformedOperations = runMutation({
+    ...baseAdapter,
+    plan: () => ({ nextState: { records: [] }, operations: "added", conflicts: [] }),
+  }, [{ id: "a" }], { write: true });
+  assert.equal(malformedOperations.status, "FAIL");
+  assert.ok(malformedOperations.errors.some((item) => /must return an operations array/.test(item)));
+
+  const missingOperationEntry = runMutation({
+    ...baseAdapter,
+    plan: () => ({ nextState: { records: [{ id: "a" }] }, operations: [], conflicts: [] }),
+  }, [{ id: "a" }], { write: true });
+  assert.equal(missingOperationEntry.status, "FAIL");
+  assert.ok(missingOperationEntry.errors.some((item) => /operations length 0 does not match input count 1/.test(item)));
+
+  const malformedConflicts = runMutation({
+    ...baseAdapter,
+    plan: () => ({ nextState: { records: [] }, operations: [], conflicts: "none" }),
+  }, [], { write: true });
+  assert.equal(malformedConflicts.status, "FAIL");
+  assert.ok(malformedConflicts.errors.some((item) => /conflicts must be an array/.test(item)));
+});
+
+test("changed plans must serialize at least one write", () => {
+  const adapter = {
+    id: "missing-write-test",
+    load: () => ({ records: [] }),
+    normalize: (candidate) => candidate,
+    plan: ({ candidates }) => ({
+      nextState: { records: candidates },
+      operations: candidates.map((item) => ({ identity: item.id, action: "added" })),
+      conflicts: [],
+    }),
+    serialize: () => [],
+  };
+
+  const dryRun = runMutation(adapter, [{ id: "a" }]);
+  assert.equal(dryRun.status, "FAIL");
+  assert.match(dryRun.errors.at(-1), /changed plan must serialize at least one write/);
+
+  const write = runMutation(adapter, [{ id: "a" }], { write: true });
+  assert.equal(write.status, "FAIL");
+  assert.equal(write.writes_occurred, false);
+  assert.match(write.errors.at(-1), /changed plan must serialize at least one write/);
+});
+
+test("present non-function optional validators fail the adapter contract", () => {
+  const file = path.join(tempDir(), "records.json");
+  writeJson(file, []);
+  const baseAdapter = {
+    id: "optional-validator-contract-test",
+    load: () => ({ records: [] }),
+    normalize: (candidate) => candidate,
+    plan: () => ({ nextState: { records: [] }, operations: [], conflicts: [] }),
+    serialize: () => [{ path: file, content: "[]\n" }],
+  };
+
+  const badCurrent = runMutation({ ...baseAdapter, validateCurrent: "nope" }, []);
+  assert.equal(badCurrent.status, "FAIL");
+  assert.ok(badCurrent.errors.includes("adapter.validateCurrent must be a function when provided"));
+
+  const badResult = runMutation({ ...baseAdapter, validateResult: null }, []);
+  assert.equal(badResult.status, "FAIL");
+  assert.ok(badResult.errors.includes("adapter.validateResult must be a function when provided"));
+});
+
+test("non-array lifecycle target configuration fails closed", () => {
+  const file = path.join(tempDir(), "records.json");
+  writeJson(file, []);
+  assert.throws(
+    () => createJsonCollectionAdapter({
+      file,
+      keyField: "id",
+      lifecycleDimensions: [
+        { name: "evidence", targets: "runtime" },
+      ],
+    }),
+    /lifecycle dimension evidence targets must be an array when provided/
+  );
+});

--- a/tools/artifact-mutation/core.js
+++ b/tools/artifact-mutation/core.js
@@ -1,0 +1,359 @@
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+const COMPLETENESS_STATUSES = new Set([
+  "complete",
+  "unresolved",
+  "intentional_hold",
+  "not_applicable",
+]);
+const OPERATION_ACTIONS = new Set(["added", "updated", "already_present", "skipped"]);
+
+function asErrors(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.map(String);
+  if (Array.isArray(value.errors)) return value.errors.map(String);
+  return [String(value)];
+}
+
+function stableCompare(left, right) {
+  return JSON.stringify(left).localeCompare(JSON.stringify(right));
+}
+
+function sortedCopy(items) {
+  return [...items].sort(stableCompare);
+}
+
+function validationEntry(phase, errors) {
+  return { phase, status: errors.length ? "FAIL" : "PASS", errors: [...errors].sort() };
+}
+
+function emptyGaps() {
+  return { records: [], by_dimension: {}, systematic_omissions: [] };
+}
+
+function baseReport(adapterId, options, inputCount) {
+  return {
+    schema: "canto-span-artifact-mutation-report-v1",
+    status: "FAIL",
+    mode: options.write ? "write" : "dry-run",
+    adapter: adapterId || null,
+    target: options.target || null,
+    input_count: inputCount,
+    counts: { added: 0, updated: 0, already_present: 0, skipped: 0 },
+    conflicts: [],
+    gaps: emptyGaps(),
+    affected_artifacts: [],
+    planned_write_count: 0,
+    writes_occurred: false,
+    write_count: 0,
+    validation_results: [],
+    warnings: [],
+    errors: [],
+  };
+}
+
+function adapterContractErrors(adapter) {
+  if (!adapter || typeof adapter !== "object") return ["adapter must be an object"];
+  const errors = [];
+  if (!adapter.id || typeof adapter.id !== "string") errors.push("adapter.id must be a non-empty string");
+  for (const name of ["load", "normalize", "plan", "serialize"]) {
+    if (typeof adapter[name] !== "function") errors.push(`adapter.${name} must be a function`);
+  }
+  if (adapter.completenessDimensions && typeof adapter.completenessDimensions !== "function") {
+    errors.push("adapter.completenessDimensions must be a function when provided");
+  }
+  if (adapter.assessCompleteness && typeof adapter.assessCompleteness !== "function") {
+    errors.push("adapter.assessCompleteness must be a function when provided");
+  }
+  return errors;
+}
+
+function normalizeDimensions(adapter, target) {
+  if (!adapter.completenessDimensions) return [];
+  const values = adapter.completenessDimensions({ target }) || [];
+  if (!Array.isArray(values)) throw new Error("adapter.completenessDimensions must return an array");
+  const dimensions = values.map((item) => typeof item === "string" ? item : item && item.name);
+  if (dimensions.some((item) => !item || typeof item !== "string")) {
+    throw new Error("completeness dimensions must be strings or objects with a string name");
+  }
+  if (new Set(dimensions).size !== dimensions.length) throw new Error("duplicate completeness dimension");
+  return dimensions.sort();
+}
+
+function assessGaps(adapter, rawCandidates, normalizedCandidates, target, omissionThreshold) {
+  const dimensions = normalizeDimensions(adapter, target);
+  if (!dimensions.length) return emptyGaps();
+  if (typeof adapter.assessCompleteness !== "function") {
+    throw new Error("adapter declares completeness dimensions but has no assessCompleteness function");
+  }
+
+  const records = [];
+  const byDimension = {};
+  const omitted = {};
+  for (const dimension of dimensions) {
+    byDimension[dimension] = { complete: 0, unresolved: 0, intentional_hold: 0, not_applicable: 0 };
+    omitted[dimension] = 0;
+  }
+
+  for (let index = 0; index < rawCandidates.length; index += 1) {
+    const values = adapter.assessCompleteness({
+      rawCandidate: rawCandidates[index],
+      normalizedCandidate: normalizedCandidates[index],
+      index,
+      target,
+    });
+    if (!Array.isArray(values)) throw new Error(`assessCompleteness must return an array for input ${index}`);
+    const assessments = new Map();
+    for (const value of values) {
+      if (!value || typeof value.dimension !== "string") throw new Error(`invalid completeness assessment at input ${index}`);
+      if (assessments.has(value.dimension)) throw new Error(`duplicate completeness assessment ${value.dimension} at input ${index}`);
+      assessments.set(value.dimension, value);
+    }
+    for (const dimension of dimensions) {
+      const value = assessments.get(dimension);
+      if (!value) throw new Error(`missing completeness assessment ${dimension} for input ${index}`);
+      if (!COMPLETENESS_STATUSES.has(value.status)) {
+        throw new Error(`invalid completeness status ${value.status} for ${dimension} at input ${index}`);
+      }
+      byDimension[dimension][value.status] += 1;
+      if (value.provided === false) omitted[dimension] += 1;
+      if (value.status !== "complete") {
+        records.push({
+          index,
+          identity: value.identity == null ? null : String(value.identity),
+          dimension,
+          status: value.status,
+          provided: value.provided === true ? true : value.provided === false ? false : null,
+          detail: value.detail || null,
+        });
+      }
+    }
+  }
+
+  const systematic = [];
+  if (rawCandidates.length) {
+    for (const dimension of dimensions) {
+      const ratio = omitted[dimension] / rawCandidates.length;
+      if (ratio >= omissionThreshold) {
+        systematic.push({
+          dimension,
+          omitted_count: omitted[dimension],
+          input_count: rawCandidates.length,
+          ratio,
+        });
+      }
+    }
+  }
+  return {
+    records: sortedCopy(records),
+    by_dimension: byDimension,
+    systematic_omissions: sortedCopy(systematic),
+  };
+}
+
+function normalizeWrites(writes) {
+  if (!Array.isArray(writes)) throw new Error("adapter.serialize must return an array of writes");
+  const seen = new Set();
+  const normalized = writes.map((write, index) => {
+    if (!write || typeof write.path !== "string" || !write.path) throw new Error(`write ${index} requires a path`);
+    if (typeof write.content !== "string" && !Buffer.isBuffer(write.content)) {
+      throw new Error(`write ${index} content must be a string or Buffer`);
+    }
+    const absolute = path.resolve(write.path);
+    if (seen.has(absolute)) throw new Error(`duplicate write target: ${absolute}`);
+    seen.add(absolute);
+    return { path: absolute, content: write.content };
+  });
+  return normalized.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function safeUnlink(fsImpl, file, errors) {
+  try {
+    if (fsImpl.existsSync(file)) fsImpl.unlinkSync(file);
+  } catch (error) {
+    errors.push(`cleanup ${file}: ${error.message}`);
+  }
+}
+
+function commitWrites(writes, options = {}) {
+  const fsImpl = options.fsImpl || fs;
+  const normalized = normalizeWrites(writes);
+  if (!normalized.length) return { writeCount: 0, warnings: [] };
+
+  const nonce = crypto.randomUUID();
+  const entries = normalized.map((write, index) => ({
+    ...write,
+    temp: `${write.path}.artifact-mutation-${nonce}-${index}.tmp`,
+    backup: `${write.path}.artifact-mutation-${nonce}-${index}.bak`,
+    hadOriginal: false,
+    committed: false,
+  }));
+
+  try {
+    for (const entry of entries) {
+      fsImpl.mkdirSync(path.dirname(entry.path), { recursive: true });
+      fsImpl.writeFileSync(entry.temp, entry.content);
+    }
+    for (const entry of entries) {
+      if (fsImpl.existsSync(entry.path)) {
+        fsImpl.renameSync(entry.path, entry.backup);
+        entry.hadOriginal = true;
+      }
+      fsImpl.renameSync(entry.temp, entry.path);
+      entry.committed = true;
+    }
+  } catch (error) {
+    const rollbackErrors = [];
+    for (const entry of [...entries].reverse()) {
+      if (entry.committed) safeUnlink(fsImpl, entry.path, rollbackErrors);
+      if (entry.hadOriginal) {
+        try {
+          if (fsImpl.existsSync(entry.backup)) fsImpl.renameSync(entry.backup, entry.path);
+        } catch (rollbackError) {
+          rollbackErrors.push(`restore ${entry.path}: ${rollbackError.message}`);
+        }
+      }
+      safeUnlink(fsImpl, entry.temp, rollbackErrors);
+      safeUnlink(fsImpl, entry.backup, rollbackErrors);
+    }
+    const wrapped = new Error(`artifact mutation commit failed: ${error.message}`);
+    wrapped.code = "ARTIFACT_MUTATION_COMMIT_FAILED";
+    wrapped.rollbackErrors = rollbackErrors;
+    throw wrapped;
+  }
+
+  const warnings = [];
+  for (const entry of entries) safeUnlink(fsImpl, entry.backup, warnings);
+  return { writeCount: entries.length, warnings };
+}
+
+function deriveCounts(operations) {
+  const counts = { added: 0, updated: 0, already_present: 0, skipped: 0 };
+  for (const operation of operations) {
+    if (!operation || !OPERATION_ACTIONS.has(operation.action)) {
+      throw new Error(`invalid planned action: ${operation && operation.action}`);
+    }
+    counts[operation.action] += 1;
+  }
+  return counts;
+}
+
+function runMutation(adapter, candidates, options = {}) {
+  const effective = {
+    write: options.write === true,
+    target: options.target || null,
+    failOnGap: options.failOnGap === true,
+    omissionThreshold: options.omissionThreshold == null ? 0.9 : Number(options.omissionThreshold),
+    fsImpl: options.fsImpl || fs,
+  };
+  const input = Array.isArray(candidates) ? candidates : [];
+  const report = baseReport(adapter && adapter.id, effective, input.length);
+
+  if (!Array.isArray(candidates)) {
+    report.errors.push("candidates must be an array");
+    return report;
+  }
+  if (!(effective.omissionThreshold > 0 && effective.omissionThreshold <= 1)) {
+    report.errors.push("omissionThreshold must be greater than 0 and at most 1");
+    return report;
+  }
+  const contractErrors = adapterContractErrors(adapter);
+  if (contractErrors.length) {
+    report.errors.push(...contractErrors.sort());
+    return report;
+  }
+
+  let current;
+  try {
+    current = adapter.load();
+  } catch (error) {
+    report.errors.push(`load failed: ${error.message}`);
+    return report;
+  }
+  const currentErrors = typeof adapter.validateCurrent === "function" ? asErrors(adapter.validateCurrent(current)) : [];
+  report.validation_results.push(validationEntry("current", currentErrors));
+  if (currentErrors.length) return report;
+
+  const normalized = [];
+  for (let index = 0; index < input.length; index += 1) {
+    try {
+      normalized.push(adapter.normalize(input[index], { index, target: effective.target }));
+    } catch (error) {
+      report.errors.push(`input ${index}: ${error.message}`);
+    }
+  }
+  if (report.errors.length) return report;
+
+  try {
+    report.gaps = assessGaps(adapter, input, normalized, effective.target, effective.omissionThreshold);
+  } catch (error) {
+    report.errors.push(`completeness assessment failed: ${error.message}`);
+    return report;
+  }
+
+  let plan;
+  try {
+    plan = adapter.plan({ current, candidates: normalized, rawCandidates: input, target: effective.target }) || {};
+  } catch (error) {
+    report.errors.push(`planning failed: ${error.message}`);
+    return report;
+  }
+  report.errors.push(...asErrors(plan.errors).sort());
+  report.conflicts = sortedCopy(Array.isArray(plan.conflicts) ? plan.conflicts : []);
+  try {
+    report.counts = deriveCounts(Array.isArray(plan.operations) ? plan.operations : []);
+  } catch (error) {
+    report.errors.push(`planning failed: ${error.message}`);
+  }
+  if (report.errors.length || report.conflicts.length) return report;
+  if (!("nextState" in plan)) {
+    report.errors.push("adapter.plan must return nextState");
+    return report;
+  }
+
+  const resultErrors = typeof adapter.validateResult === "function" ? asErrors(adapter.validateResult(plan.nextState, plan)) : [];
+  report.validation_results.push(validationEntry("result", resultErrors));
+  if (resultErrors.length) return report;
+
+  let writes;
+  try {
+    writes = normalizeWrites(adapter.serialize(plan.nextState, plan));
+  } catch (error) {
+    report.errors.push(`serialization failed: ${error.message}`);
+    return report;
+  }
+  report.affected_artifacts = writes.map((write) => write.path);
+  report.planned_write_count = writes.length;
+
+  const unresolved = report.gaps.records.filter((gap) => gap.status === "unresolved");
+  if (effective.failOnGap && unresolved.length) {
+    report.errors.push(`unresolved completeness gaps: ${unresolved.length}`);
+    return report;
+  }
+
+  const changed = report.counts.added + report.counts.updated > 0;
+  if (!effective.write || !changed || !writes.length) {
+    report.status = "PASS";
+    return report;
+  }
+
+  try {
+    const committed = commitWrites(writes, { fsImpl: effective.fsImpl });
+    report.writes_occurred = committed.writeCount > 0;
+    report.write_count = committed.writeCount;
+    report.warnings.push(...committed.warnings.sort());
+    report.status = "PASS";
+  } catch (error) {
+    report.errors.push(error.message);
+    if (Array.isArray(error.rollbackErrors)) {
+      report.errors.push(...error.rollbackErrors.map((item) => `rollback: ${item}`).sort());
+    }
+  }
+  return report;
+}
+
+module.exports = { COMPLETENESS_STATUSES, commitWrites, runMutation };

--- a/tools/artifact-mutation/core.js
+++ b/tools/artifact-mutation/core.js
@@ -72,11 +72,10 @@ function adapterContractErrors(adapter) {
   for (const name of ["load", "normalize", "plan", "serialize"]) {
     if (typeof adapter[name] !== "function") errors.push(`adapter.${name} must be a function`);
   }
-  if (adapter.completenessDimensions && typeof adapter.completenessDimensions !== "function") {
-    errors.push("adapter.completenessDimensions must be a function when provided");
-  }
-  if (adapter.assessCompleteness && typeof adapter.assessCompleteness !== "function") {
-    errors.push("adapter.assessCompleteness must be a function when provided");
+  for (const name of ["validateCurrent", "validateResult", "completenessDimensions", "assessCompleteness"]) {
+    if (adapter[name] !== undefined && typeof adapter[name] !== "function") {
+      errors.push(`adapter.${name} must be a function when provided`);
+    }
   }
   return errors;
 }
@@ -316,9 +315,19 @@ function runMutation(adapter, candidates, options = {}) {
     return report;
   }
   report.errors.push(...asErrors(plan.errors).sort());
-  report.conflicts = sortedCopy(Array.isArray(plan.conflicts) ? plan.conflicts : []);
+  if (!Array.isArray(plan.operations)) {
+    report.errors.push("adapter.plan must return an operations array");
+  } else if (plan.operations.length !== normalized.length) {
+    report.errors.push(`adapter.plan operations length ${plan.operations.length} does not match input count ${normalized.length}`);
+  }
+  if (plan.conflicts !== undefined && !Array.isArray(plan.conflicts)) {
+    report.errors.push("adapter.plan conflicts must be an array when provided");
+  }
+  if (report.errors.length) return report;
+
+  report.conflicts = sortedCopy(plan.conflicts || []);
   try {
-    report.counts = deriveCounts(Array.isArray(plan.operations) ? plan.operations : []);
+    report.counts = deriveCounts(plan.operations);
   } catch (error) {
     report.errors.push(`planning failed: ${error.message}`);
   }
@@ -342,14 +351,19 @@ function runMutation(adapter, candidates, options = {}) {
   report.affected_artifacts = writes.map((write) => write.path);
   report.planned_write_count = writes.length;
 
+  const changed = report.counts.added + report.counts.updated > 0;
+  if (changed && !writes.length) {
+    report.errors.push("changed plan must serialize at least one write");
+    return report;
+  }
+
   const unresolved = report.gaps.records.filter((gap) => gap.status === "unresolved");
   if (effective.failOnGap && unresolved.length) {
     report.errors.push(`unresolved completeness gaps: ${unresolved.length}`);
     return report;
   }
 
-  const changed = report.counts.added + report.counts.updated > 0;
-  if (!effective.write || !changed || !writes.length) {
+  if (!effective.write || !changed) {
     report.status = "PASS";
     return report;
   }

--- a/tools/artifact-mutation/core.js
+++ b/tools/artifact-mutation/core.js
@@ -31,6 +31,15 @@ function validationEntry(phase, errors) {
   return { phase, status: errors.length ? "FAIL" : "PASS", errors: [...errors].sort() };
 }
 
+function runValidator(phase, validator, ...args) {
+  if (typeof validator !== "function") return [];
+  try {
+    return asErrors(validator(...args));
+  } catch (error) {
+    return [`${phase} validator threw: ${error.message}`];
+  }
+}
+
 function emptyGaps() {
   return { records: [], by_dimension: {}, systematic_omissions: [] };
 }
@@ -212,13 +221,17 @@ function commitWrites(writes, options = {}) {
       if (entry.committed) safeUnlink(fsImpl, entry.path, rollbackErrors);
       if (entry.hadOriginal) {
         try {
-          if (fsImpl.existsSync(entry.backup)) fsImpl.renameSync(entry.backup, entry.path);
+          if (!fsImpl.existsSync(entry.backup)) {
+            rollbackErrors.push(`restore ${entry.path}: backup missing at ${entry.backup}`);
+          } else {
+            fsImpl.renameSync(entry.backup, entry.path);
+          }
         } catch (rollbackError) {
           rollbackErrors.push(`restore ${entry.path}: ${rollbackError.message}`);
         }
       }
       safeUnlink(fsImpl, entry.temp, rollbackErrors);
-      safeUnlink(fsImpl, entry.backup, rollbackErrors);
+      if (!entry.hadOriginal) safeUnlink(fsImpl, entry.backup, rollbackErrors);
     }
     const wrapped = new Error(`artifact mutation commit failed: ${error.message}`);
     wrapped.code = "ARTIFACT_MUTATION_COMMIT_FAILED";
@@ -274,7 +287,7 @@ function runMutation(adapter, candidates, options = {}) {
     report.errors.push(`load failed: ${error.message}`);
     return report;
   }
-  const currentErrors = typeof adapter.validateCurrent === "function" ? asErrors(adapter.validateCurrent(current)) : [];
+  const currentErrors = runValidator("current", adapter.validateCurrent, current);
   report.validation_results.push(validationEntry("current", currentErrors));
   if (currentErrors.length) return report;
 
@@ -315,7 +328,7 @@ function runMutation(adapter, candidates, options = {}) {
     return report;
   }
 
-  const resultErrors = typeof adapter.validateResult === "function" ? asErrors(adapter.validateResult(plan.nextState, plan)) : [];
+  const resultErrors = runValidator("result", adapter.validateResult, plan.nextState, plan);
   report.validation_results.push(validationEntry("result", resultErrors));
   if (resultErrors.length) return report;
 

--- a/tools/artifact-mutation/json-collection-adapter.js
+++ b/tools/artifact-mutation/json-collection-adapter.js
@@ -18,27 +18,59 @@ function primitiveIdentity(value) {
   return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
 }
 
+function requireString(value, label) {
+  if (typeof value !== "string" || !value) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
 function createJsonCollectionAdapter(config = {}) {
-  if (!config.file) throw new Error("json collection adapter requires file");
-  if (!config.keyField) throw new Error("json collection adapter requires keyField");
+  requireString(config.file, "json collection adapter file");
+  requireString(config.keyField, "json collection adapter keyField");
+  if (config.collectionKey !== undefined && config.collectionKey !== null) {
+    requireString(config.collectionKey, "json collection adapter collectionKey");
+  }
+  if (config.requiredFields !== undefined && !Array.isArray(config.requiredFields)) {
+    throw new Error("json collection adapter requiredFields must be an array when provided");
+  }
+  for (const field of config.requiredFields || []) {
+    requireString(field, "json collection adapter required field");
+  }
+  if (config.lifecycleDimensions !== undefined && !Array.isArray(config.lifecycleDimensions)) {
+    throw new Error("json collection adapter lifecycleDimensions must be an array when provided");
+  }
+
+  const rawDimensions = config.lifecycleDimensions || [];
+  for (let index = 0; index < rawDimensions.length; index += 1) {
+    const dimension = rawDimensions[index];
+    if (!dimension || typeof dimension !== "object" || Array.isArray(dimension)) {
+      throw new Error(`lifecycle dimension ${index} must be an object`);
+    }
+    requireString(dimension.name, `lifecycle dimension ${index} name`);
+    if (dimension.field !== undefined) requireString(dimension.field, `lifecycle dimension ${dimension.name} field`);
+    if (dimension.statusField !== undefined && dimension.statusField !== null) {
+      requireString(dimension.statusField, `lifecycle dimension ${dimension.name} statusField`);
+    }
+    if (hasOwn(dimension, "targets")) {
+      if (!Array.isArray(dimension.targets)) {
+        throw new Error(`lifecycle dimension ${dimension.name} targets must be an array when provided`);
+      }
+      for (const target of dimension.targets) {
+        requireString(target, `lifecycle dimension ${dimension.name} target`);
+      }
+    }
+  }
 
   const file = path.resolve(config.file);
   const keyField = config.keyField;
   const collectionKey = config.collectionKey || null;
   const requiredFields = [...new Set([keyField, ...(config.requiredFields || [])])];
-  const lifecycleDimensions = (config.lifecycleDimensions || []).map((dimension) => ({
+  const lifecycleDimensions = rawDimensions.map((dimension) => ({
     name: dimension.name,
     field: dimension.field || dimension.name,
     statusField: dimension.statusField || null,
-    targets: Array.isArray(dimension.targets) ? [...dimension.targets] : null,
+    targets: hasOwn(dimension, "targets") ? [...dimension.targets] : null,
   }));
   const fsImpl = config.fsImpl || fs;
-
-  for (const dimension of lifecycleDimensions) {
-    if (!dimension.name || typeof dimension.name !== "string") {
-      throw new Error("lifecycle dimension requires a string name");
-    }
-  }
 
   function recordsFromDocument(document) {
     const records = collectionKey ? document && document[collectionKey] : document;
@@ -48,9 +80,24 @@ function createJsonCollectionAdapter(config = {}) {
     return records;
   }
 
-  function identity(record) {
+  function identityValue(record) {
     const value = record && record[keyField];
-    return primitiveIdentity(value) ? String(value) : null;
+    return primitiveIdentity(value) ? value : null;
+  }
+
+  function identityKey(record) {
+    const value = identityValue(record);
+    return value === null ? null : `${typeof value}:${JSON.stringify(value)}`;
+  }
+
+  function reportIdentity(record) {
+    const value = identityValue(record);
+    if (value === null || typeof value === "string") return value;
+    return `${typeof value}:${JSON.stringify(value)}`;
+  }
+
+  function identityLabel(value) {
+    return `${typeof value}:${JSON.stringify(value)}`;
   }
 
   function validateRecord(record, context) {
@@ -100,9 +147,10 @@ function createJsonCollectionAdapter(config = {}) {
         const record = current.records[index];
         errors.push(...validateRecord(record, `current record ${index}`));
         errors.push(...validateExplicitStatuses(record, `current record ${index}`));
-        const key = identity(record);
+        const key = identityKey(record);
+        const value = identityValue(record);
         if (key !== null) {
-          if (seen.has(key)) errors.push(`current collection has duplicate ${keyField}: ${key}`);
+          if (seen.has(key)) errors.push(`current collection has duplicate ${keyField}: ${identityLabel(value)}`);
           seen.add(key);
         }
       }
@@ -137,7 +185,7 @@ function createJsonCollectionAdapter(config = {}) {
       const rawRecord = rawCandidate && rawCandidate.record && typeof rawCandidate.record === "object"
         ? rawCandidate.record
         : {};
-      const key = identity(normalizedCandidate.record);
+      const key = reportIdentity(normalizedCandidate.record);
       return applicableDimensions(target).map((dimension) => {
         const fieldProvided = hasOwn(rawRecord, dimension.field) && usableValue(rawRecord[dimension.field]);
         if (fieldProvided) {
@@ -157,21 +205,22 @@ function createJsonCollectionAdapter(config = {}) {
       const nextRecords = current.records.map((record) => JSON.parse(JSON.stringify(record)));
       const currentIndex = new Map();
       for (let index = 0; index < nextRecords.length; index += 1) {
-        currentIndex.set(identity(nextRecords[index]), index);
+        currentIndex.set(identityKey(nextRecords[index]), index);
       }
 
       const seenBatch = new Map();
       for (let index = 0; index < candidates.length; index += 1) {
         const candidate = candidates[index];
-        const key = identity(candidate.record);
+        const key = identityKey(candidate.record);
+        const reportedIdentity = reportIdentity(candidate.record);
         if (seenBatch.has(key)) {
           conflicts.push({
             code: "duplicate_in_batch",
-            identity: key,
+            identity: reportedIdentity,
             first_index: seenBatch.get(key),
             second_index: index,
           });
-          operations.push({ identity: key, action: "skipped" });
+          operations.push({ identity: reportedIdentity, action: "skipped" });
           continue;
         }
         seenBatch.set(key, index);
@@ -182,24 +231,24 @@ function createJsonCollectionAdapter(config = {}) {
           if (existing === null) {
             nextRecords.push(candidate.record);
             currentIndex.set(key, nextRecords.length - 1);
-            operations.push({ identity: key, action: "added" });
+            operations.push({ identity: reportedIdentity, action: "added" });
           } else if (isDeepStrictEqual(existing, candidate.record)) {
-            operations.push({ identity: key, action: "already_present" });
+            operations.push({ identity: reportedIdentity, action: "already_present" });
           } else {
-            conflicts.push({ code: "existing_record_differs", identity: key, index });
-            operations.push({ identity: key, action: "skipped" });
+            conflicts.push({ code: "existing_record_differs", identity: reportedIdentity, index });
+            operations.push({ identity: reportedIdentity, action: "skipped" });
           }
           continue;
         }
 
         if (existing === null) {
-          conflicts.push({ code: "replace_target_missing", identity: key, index });
-          operations.push({ identity: key, action: "skipped" });
+          conflicts.push({ code: "replace_target_missing", identity: reportedIdentity, index });
+          operations.push({ identity: reportedIdentity, action: "skipped" });
         } else if (isDeepStrictEqual(existing, candidate.record)) {
-          operations.push({ identity: key, action: "already_present" });
+          operations.push({ identity: reportedIdentity, action: "already_present" });
         } else {
           nextRecords[existingIndex] = candidate.record;
-          operations.push({ identity: key, action: "updated" });
+          operations.push({ identity: reportedIdentity, action: "updated" });
         }
       }
 

--- a/tools/artifact-mutation/json-collection-adapter.js
+++ b/tools/artifact-mutation/json-collection-adapter.js
@@ -1,0 +1,224 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { isDeepStrictEqual } = require("util");
+
+const EXPLICIT_GAP_STATUSES = new Set(["unresolved", "intentional_hold", "not_applicable"]);
+
+function hasOwn(object, key) {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function usableValue(value) {
+  return value !== null && value !== undefined && value !== "";
+}
+
+function primitiveIdentity(value) {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+function createJsonCollectionAdapter(config = {}) {
+  if (!config.file) throw new Error("json collection adapter requires file");
+  if (!config.keyField) throw new Error("json collection adapter requires keyField");
+
+  const file = path.resolve(config.file);
+  const keyField = config.keyField;
+  const collectionKey = config.collectionKey || null;
+  const requiredFields = [...new Set([keyField, ...(config.requiredFields || [])])];
+  const lifecycleDimensions = (config.lifecycleDimensions || []).map((dimension) => ({
+    name: dimension.name,
+    field: dimension.field || dimension.name,
+    statusField: dimension.statusField || null,
+    targets: Array.isArray(dimension.targets) ? [...dimension.targets] : null,
+  }));
+  const fsImpl = config.fsImpl || fs;
+
+  for (const dimension of lifecycleDimensions) {
+    if (!dimension.name || typeof dimension.name !== "string") {
+      throw new Error("lifecycle dimension requires a string name");
+    }
+  }
+
+  function recordsFromDocument(document) {
+    const records = collectionKey ? document && document[collectionKey] : document;
+    if (!Array.isArray(records)) {
+      throw new Error(collectionKey ? `expected array at ${collectionKey}` : "expected root JSON array");
+    }
+    return records;
+  }
+
+  function identity(record) {
+    const value = record && record[keyField];
+    return primitiveIdentity(value) ? String(value) : null;
+  }
+
+  function validateRecord(record, context) {
+    const errors = [];
+    if (!record || typeof record !== "object" || Array.isArray(record)) {
+      return [`${context} must be an object`];
+    }
+    for (const field of requiredFields) {
+      if (!hasOwn(record, field) || !usableValue(record[field])) {
+        errors.push(`${context} missing required field ${field}`);
+      }
+    }
+    if (hasOwn(record, keyField) && !primitiveIdentity(record[keyField])) {
+      errors.push(`${context} field ${keyField} must be a string, number, or boolean`);
+    }
+    return errors;
+  }
+
+  const adapter = {
+    id: config.id || "json-collection",
+
+    load() {
+      const document = JSON.parse(fsImpl.readFileSync(file, "utf8"));
+      return { document, records: recordsFromDocument(document) };
+    },
+
+    validateCurrent(current) {
+      const errors = [];
+      const seen = new Set();
+      for (let index = 0; index < current.records.length; index += 1) {
+        const record = current.records[index];
+        errors.push(...validateRecord(record, `current record ${index}`));
+        const key = identity(record);
+        if (key !== null) {
+          if (seen.has(key)) errors.push(`current collection has duplicate ${keyField}: ${key}`);
+          seen.add(key);
+        }
+      }
+      return errors;
+    },
+
+    normalize(candidate, context = {}) {
+      if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+        throw new Error("candidate must be an object");
+      }
+      if (!hasOwn(candidate, "operation") || !["add", "replace"].includes(candidate.operation)) {
+        throw new Error("candidate.operation must be add or replace");
+      }
+      if (!candidate.record || typeof candidate.record !== "object" || Array.isArray(candidate.record)) {
+        throw new Error("candidate.record must be an object");
+      }
+      const record = JSON.parse(JSON.stringify(candidate.record));
+      const errors = validateRecord(record, `input ${context.index == null ? "?" : context.index} record`);
+      if (errors.length) throw new Error(errors.join("; "));
+      return { operation: candidate.operation, record };
+    },
+
+    completenessDimensions({ target } = {}) {
+      return lifecycleDimensions
+        .filter((dimension) => !dimension.targets || !target || dimension.targets.includes(target))
+        .map((dimension) => dimension.name);
+    },
+
+    assessCompleteness({ rawCandidate, normalizedCandidate, target }) {
+      const rawRecord = rawCandidate && rawCandidate.record && typeof rawCandidate.record === "object"
+        ? rawCandidate.record
+        : {};
+      const key = identity(normalizedCandidate.record);
+      return lifecycleDimensions
+        .filter((dimension) => !dimension.targets || !target || dimension.targets.includes(target))
+        .map((dimension) => {
+          const fieldProvided = hasOwn(rawRecord, dimension.field) && usableValue(rawRecord[dimension.field]);
+          if (fieldProvided) {
+            return { identity: key, dimension: dimension.name, status: "complete", provided: true };
+          }
+          if (dimension.statusField && hasOwn(rawRecord, dimension.statusField)) {
+            const explicitStatus = rawRecord[dimension.statusField];
+            if (!EXPLICIT_GAP_STATUSES.has(explicitStatus)) {
+              return {
+                identity: key,
+                dimension: dimension.name,
+                status: "unresolved",
+                provided: true,
+                detail: `invalid explicit status ${String(explicitStatus)}`,
+              };
+            }
+            return { identity: key, dimension: dimension.name, status: explicitStatus, provided: true };
+          }
+          return { identity: key, dimension: dimension.name, status: "unresolved", provided: false };
+        });
+    },
+
+    plan({ current, candidates }) {
+      const operations = [];
+      const conflicts = [];
+      const nextRecords = current.records.map((record) => JSON.parse(JSON.stringify(record)));
+      const currentIndex = new Map();
+      for (let index = 0; index < nextRecords.length; index += 1) {
+        currentIndex.set(identity(nextRecords[index]), index);
+      }
+
+      const seenBatch = new Map();
+      for (let index = 0; index < candidates.length; index += 1) {
+        const candidate = candidates[index];
+        const key = identity(candidate.record);
+        if (seenBatch.has(key)) {
+          conflicts.push({
+            code: "duplicate_in_batch",
+            identity: key,
+            first_index: seenBatch.get(key),
+            second_index: index,
+          });
+          operations.push({ identity: key, action: "skipped" });
+          continue;
+        }
+        seenBatch.set(key, index);
+
+        const existingIndex = currentIndex.has(key) ? currentIndex.get(key) : null;
+        const existing = existingIndex === null ? null : nextRecords[existingIndex];
+        if (candidate.operation === "add") {
+          if (existing === null) {
+            nextRecords.push(candidate.record);
+            currentIndex.set(key, nextRecords.length - 1);
+            operations.push({ identity: key, action: "added" });
+          } else if (isDeepStrictEqual(existing, candidate.record)) {
+            operations.push({ identity: key, action: "already_present" });
+          } else {
+            conflicts.push({ code: "existing_record_differs", identity: key, index });
+            operations.push({ identity: key, action: "skipped" });
+          }
+          continue;
+        }
+
+        if (existing === null) {
+          conflicts.push({ code: "replace_target_missing", identity: key, index });
+          operations.push({ identity: key, action: "skipped" });
+        } else if (isDeepStrictEqual(existing, candidate.record)) {
+          operations.push({ identity: key, action: "already_present" });
+        } else {
+          nextRecords[existingIndex] = candidate.record;
+          operations.push({ identity: key, action: "updated" });
+        }
+      }
+
+      let nextDocument;
+      if (collectionKey) {
+        nextDocument = JSON.parse(JSON.stringify(current.document));
+        nextDocument[collectionKey] = nextRecords;
+      } else {
+        nextDocument = nextRecords;
+      }
+      return {
+        nextState: { document: nextDocument, records: nextRecords },
+        operations,
+        conflicts,
+      };
+    },
+
+    validateResult(nextState) {
+      return adapter.validateCurrent(nextState);
+    },
+
+    serialize(nextState) {
+      return [{ path: file, content: `${JSON.stringify(nextState.document, null, 2)}\n` }];
+    },
+  };
+
+  return adapter;
+}
+
+module.exports = { createJsonCollectionAdapter };

--- a/tools/artifact-mutation/json-collection-adapter.js
+++ b/tools/artifact-mutation/json-collection-adapter.js
@@ -92,8 +92,7 @@ function createJsonCollectionAdapter(config = {}) {
 
   function reportIdentity(record) {
     const value = identityValue(record);
-    if (value === null || typeof value === "string") return value;
-    return `${typeof value}:${JSON.stringify(value)}`;
+    return value === null ? null : `${typeof value}:${JSON.stringify(value)}`;
   }
 
   function identityLabel(value) {

--- a/tools/artifact-mutation/json-collection-adapter.js
+++ b/tools/artifact-mutation/json-collection-adapter.js
@@ -73,9 +73,9 @@ function createJsonCollectionAdapter(config = {}) {
     return lifecycleDimensions.filter((dimension) => !dimension.targets || !target || dimension.targets.includes(target));
   }
 
-  function validateExplicitStatuses(record, context, target) {
+  function validateExplicitStatuses(record, context) {
     const errors = [];
-    for (const dimension of applicableDimensions(target)) {
+    for (const dimension of lifecycleDimensions) {
       if (!dimension.statusField || !hasOwn(record, dimension.statusField)) continue;
       const explicitStatus = record[dimension.statusField];
       if (!EXPLICIT_GAP_STATUSES.has(explicitStatus)) {
@@ -99,6 +99,7 @@ function createJsonCollectionAdapter(config = {}) {
       for (let index = 0; index < current.records.length; index += 1) {
         const record = current.records[index];
         errors.push(...validateRecord(record, `current record ${index}`));
+        errors.push(...validateExplicitStatuses(record, `current record ${index}`));
         const key = identity(record);
         if (key !== null) {
           if (seen.has(key)) errors.push(`current collection has duplicate ${keyField}: ${key}`);
@@ -122,7 +123,7 @@ function createJsonCollectionAdapter(config = {}) {
       const label = `input ${context.index == null ? "?" : context.index} record`;
       const errors = [
         ...validateRecord(record, label),
-        ...validateExplicitStatuses(record, label, context.target),
+        ...validateExplicitStatuses(record, label),
       ];
       if (errors.length) throw new Error(errors.join("; "));
       return { operation: candidate.operation, record };

--- a/tools/artifact-mutation/json-collection-adapter.js
+++ b/tools/artifact-mutation/json-collection-adapter.js
@@ -69,6 +69,22 @@ function createJsonCollectionAdapter(config = {}) {
     return errors;
   }
 
+  function applicableDimensions(target) {
+    return lifecycleDimensions.filter((dimension) => !dimension.targets || !target || dimension.targets.includes(target));
+  }
+
+  function validateExplicitStatuses(record, context, target) {
+    const errors = [];
+    for (const dimension of applicableDimensions(target)) {
+      if (!dimension.statusField || !hasOwn(record, dimension.statusField)) continue;
+      const explicitStatus = record[dimension.statusField];
+      if (!EXPLICIT_GAP_STATUSES.has(explicitStatus)) {
+        errors.push(`${context} field ${dimension.statusField} has invalid lifecycle status ${String(explicitStatus)}`);
+      }
+    }
+    return errors;
+  }
+
   const adapter = {
     id: config.id || "json-collection",
 
@@ -103,15 +119,17 @@ function createJsonCollectionAdapter(config = {}) {
         throw new Error("candidate.record must be an object");
       }
       const record = JSON.parse(JSON.stringify(candidate.record));
-      const errors = validateRecord(record, `input ${context.index == null ? "?" : context.index} record`);
+      const label = `input ${context.index == null ? "?" : context.index} record`;
+      const errors = [
+        ...validateRecord(record, label),
+        ...validateExplicitStatuses(record, label, context.target),
+      ];
       if (errors.length) throw new Error(errors.join("; "));
       return { operation: candidate.operation, record };
     },
 
     completenessDimensions({ target } = {}) {
-      return lifecycleDimensions
-        .filter((dimension) => !dimension.targets || !target || dimension.targets.includes(target))
-        .map((dimension) => dimension.name);
+      return applicableDimensions(target).map((dimension) => dimension.name);
     },
 
     assessCompleteness({ rawCandidate, normalizedCandidate, target }) {
@@ -119,28 +137,17 @@ function createJsonCollectionAdapter(config = {}) {
         ? rawCandidate.record
         : {};
       const key = identity(normalizedCandidate.record);
-      return lifecycleDimensions
-        .filter((dimension) => !dimension.targets || !target || dimension.targets.includes(target))
-        .map((dimension) => {
-          const fieldProvided = hasOwn(rawRecord, dimension.field) && usableValue(rawRecord[dimension.field]);
-          if (fieldProvided) {
-            return { identity: key, dimension: dimension.name, status: "complete", provided: true };
-          }
-          if (dimension.statusField && hasOwn(rawRecord, dimension.statusField)) {
-            const explicitStatus = rawRecord[dimension.statusField];
-            if (!EXPLICIT_GAP_STATUSES.has(explicitStatus)) {
-              return {
-                identity: key,
-                dimension: dimension.name,
-                status: "unresolved",
-                provided: true,
-                detail: `invalid explicit status ${String(explicitStatus)}`,
-              };
-            }
-            return { identity: key, dimension: dimension.name, status: explicitStatus, provided: true };
-          }
-          return { identity: key, dimension: dimension.name, status: "unresolved", provided: false };
-        });
+      return applicableDimensions(target).map((dimension) => {
+        const fieldProvided = hasOwn(rawRecord, dimension.field) && usableValue(rawRecord[dimension.field]);
+        if (fieldProvided) {
+          return { identity: key, dimension: dimension.name, status: "complete", provided: true };
+        }
+        if (dimension.statusField && hasOwn(rawRecord, dimension.statusField)) {
+          const explicitStatus = rawRecord[dimension.statusField];
+          return { identity: key, dimension: dimension.name, status: explicitStatus, provided: true };
+        }
+        return { identity: key, dimension: dimension.name, status: "unresolved", provided: false };
+      });
     },
 
     plan({ current, candidates }) {


### PR DESCRIPTION
<!-- coordination-claim: #918 -->
Work claim: #918
Closes #918

Implements the reviewed first unit of #911.

## Outcome and scope

Adds a source-neutral mutation core plus a concrete JSON-collection reference adapter and focused recurring tests. The shared layer stages the full batch before writes, keeps lifecycle omissions explicit, reports conflicts/gaps deterministically, bounds writes by affected artifact, and provides rollback mechanics for multi-file replacement failures.

Changed files:
- `tools/artifact-mutation/core.js`
- `tools/artifact-mutation/json-collection-adapter.js`
- `tests/tooling/artifact-mutation/artifact-mutation.test.js`

## Review blockers resolved

The full review sequence is preserved in the PR conversation. The final exact-head state resolves all identified blockers:

- rollback preserves a recoverable backup when restoration itself fails;
- thrown current/result validators become deterministic machine-readable `FAIL` validation entries;
- declared lifecycle status values are validated before write and in current state, independent of completeness target;
- JSON primitive identities use type-preserving internal keys, and machine-readable identities also remain unambiguous for values such as numeric `1`, string `"1"`, and literal tag-looking strings such as `"number:1"`;
- `plan.operations` must be an array with exactly one result per normalized input, supplied conflicts must be arrays, and changed plans must serialize at least one write;
- optional validator/completeness hooks must be functions when present rather than being silently bypassed;
- lifecycle configuration fails closed: malformed `targets` and other declared config shapes are rejected instead of broadening applicability.

Final exact-head review found no remaining blocker in the claimed transaction/reporting surface.

## Protected / unchanged

No changes to runtime behavior, lexical authority, construction identities or statuses, corpus classifications, surveys/native-panel state, research evidence, coordination changeset semantics, schemas, workflows, `package.json`, verification profiles, generated runtime, or `main`.

Domain semantics and production adapters remain deferred to #912–#917. Mixed-artifact dispatch is deliberately deferred.

## Validation

Focused command:

`node --test tests/tooling/artifact-mutation/artifact-mutation.test.js`

Result: **15/15 tests passed** locally on the exact final files. An additional local adversarial contract probe also passed for mixed primitive identities and malformed hook/target declarations; it remains a local diagnostic rather than a permanent repository check.

The exact locally executed files were verified byte-for-byte against final-head Git blobs:
- `core.js`: `0951d5107c866a40ac735311def4dc4fcea77c6d`
- `json-collection-adapter.js`: `2c3c55ac75471d6505844d5a942728650cc43454`
- `artifact-mutation.test.js`: `232c59f3871e5c7eed612baa102fd4194e5f40a9`

Final reviewed head: `76aacdd9aec3746fe1353412b390e59b608a135d`.
Base / current `main`: `2af0a9b440bb5ca93e4463ed774fc6ecd6ff1754`.

GitHub `Runtime source-first validation` run #1542 completed successfully on that exact head. The workflow does not directly run the focused Node file, so the independent 15/15 result above is retained as the task-specific validation record.

There are no inline review threads. `needs-review-fix` is cleared and PR #919 is **ready for review**. Integration remains separate from this worker claim.